### PR TITLE
Add backlink; add concept of secondary action

### DIFF
--- a/server/forms/bulk-create.json
+++ b/server/forms/bulk-create.json
@@ -1,0 +1,48 @@
+{
+  "form": {
+    "schema": {
+      "action": "bulk_upload",
+      "callback": {
+        "action": "case",
+        "value": "documents"
+      },
+      "title": "Create cases in bulk",
+      "defaultActionLabel": "Create multiple cases",
+      "fields": [
+        {
+          "component": "radio",
+          "validation": [
+            "required"
+          ],
+          "props": {
+            "name": "case-type",
+            "label": "Case type",
+            "choices": "CASE_TYPE"
+          }
+        },
+        {
+          "component": "paragraph",
+          "props": {
+            "content": "Description to go here"
+          }
+        },
+        {
+          "component": "addDocument",
+          "validation": [
+            "required",
+            "hasWhitelistedExtension"
+          ],
+          "props": {
+            "name": "add_document",
+            "action": "ADD_DOCUMENT",
+            "documentType": "ORIGINAL",
+            "className": "button-secondary-action",
+            "label": "Documents",
+            "allowMultiple": true,
+            "whitelist": "DOCUMENT_EXTENSION_WHITELIST"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/server/forms/bulk-create.json
+++ b/server/forms/bulk-create.json
@@ -42,6 +42,14 @@
             "whitelist": "DOCUMENT_EXTENSION_WHITELIST"
           }
         }
+      ],
+      "secondaryActions": [
+        {
+            "component": "backlink",
+            "props": {
+                "label": "Cancel"
+            }
+        }
       ]
     }
   }

--- a/server/forms/document-add.json
+++ b/server/forms/document-add.json
@@ -31,7 +31,9 @@
             "allowMultiple": true,
             "whitelist": "DOCUMENT_EXTENSION_WHITELIST"
           }
-        },
+        }
+      ],
+      "secondaryActions": [
         {
           "component": "button",
           "props": {

--- a/server/services/form.js
+++ b/server/services/form.js
@@ -8,6 +8,8 @@ const actions = {
         switch (action) {
         case 'create':
             return getCreateForm(user);
+        case 'bulk':
+            return getBulkCreateForm(user);
         }
     },
     workflow: ({ caseId }) => {
@@ -85,12 +87,22 @@ module.exports = {
 
 function getCreateForm(user) {
     const { form: { schema, data } } = formRepository.getForm('caseCreate');
-    schema.fields = schema.fields.map(field => {
+    schema.fields = populateFields(schema.fields, user);
+    return { schema, data };
+}
+
+function getBulkCreateForm(user) {
+    const { form: { schema, data } } = formRepository.getForm('bulkCreate');
+    schema.fields = populateFields(schema.fields, user);
+    return { schema, data };
+}
+
+function populateFields(fields, user) {
+    return fields.map(field => {
         const choices = field.props.choices;
         if (choices && typeof choices === 'string') {
             field.props.choices = listService.getList(choices, { user });
         }
         return field;
     });
-    return { schema, data };
 }

--- a/src/shared/common/forms/form.jsx
+++ b/src/shared/common/forms/form.jsx
@@ -10,6 +10,7 @@ import Submit from './submit.jsx';
 import TextArea from './text-area.jsx';
 import AddDocument from './composite/document-add.jsx';
 import Button from './button.jsx';
+import BackLink from './backlink.jsx';
 import { ApplicationConsumer } from '../../contexts/application.jsx';
 import { redirect, updateForm, updateFormData, updateFormErrors } from '../../contexts/actions/index.jsx';
 import Dropdown from './dropdown.jsx';
@@ -93,6 +94,9 @@ class Form extends Component {
         case 'button':
             return <Button key={i}
                 {...field.props} />;
+        case 'backlink':
+            return <BackLink key={i}
+                {...field.props} />;
         case 'addDocument':
             return <AddDocument key={i}
                 {...field.props}
@@ -100,6 +104,17 @@ class Form extends Component {
                 updateState={data => this.updateFormState(data)} />;
         case 'heading':
             return <h2 key={i} className="heading-medium">{field.props.label}</h2>;
+        }
+    }
+    
+    renderSecondaryAction(field, i) {
+        switch (field.component) {
+        // Whitelist of boring elements that are allowed to be below the "submit" button
+        case 'backlink':
+        case 'button':
+            return this.renderFormComponent(field, i);
+        default:
+            return null;
         }
     }
 
@@ -125,6 +140,9 @@ class Form extends Component {
                         return this.renderFormComponent(field, i);
                     })}
                     <Submit label={schema.defaultActionLabel} />
+                    {schema && schema.secondaryActions && schema.secondaryActions.map((field, i) => {
+                        return this.renderSecondaryAction(field, i);
+                    })}
                 </form>
             </Fragment>
         );
@@ -134,6 +152,7 @@ class Form extends Component {
 Form.propTypes = {
     action: PropTypes.string,
     children: PropTypes.node,
+    secondaryActions: PropTypes.node,
     data: PropTypes.object,
     dispatch: PropTypes.func.isRequired,
     errors: PropTypes.object,

--- a/src/shared/pages/main.jsx
+++ b/src/shared/pages/main.jsx
@@ -29,8 +29,17 @@ class MainPage extends Component {
                                     {title}
                                     {subTitle && <span className="heading-secondary">{subTitle}</span>}
                                 </h1>
-                                <ul>
-                                    <li><Link to={'/action/create'}>Create case</Link></li>
+                                <h2 className="heading-medium">
+                                  Primary actions
+                                </h2>
+                                <ul className="list list-bullet">
+                                    <li><Link to={'/action/create'}>Create single case</Link></li>
+                                    <li><Link to={'/action/bulk'}>Create cases in bulk</Link></li>
+                                </ul>
+                                <h2 className="heading-medium">
+                                  Secondary routes
+                                </h2>
+                                <ul className="list list-bullet">
                                     <li><Link to={'/some/random/url'}>Test 404</Link></li>
                                     <li><Link to={'/action/test'}>Test 403</Link></li>
                                     <li><Link to={'/error'}>Test 500</Link></li>


### PR DESCRIPTION
The submit button on the form is currently hardcoded to exist as the
very bottom form element. This is problematic as usually we want the
primary action button to be aligned to the left edge of the form, and in
the user's line of sight. At the moment, secondary actions come
beforehand which is confusing.

This commit adds the concept of secondaryActions separate to the main
form to allow for buttons and other elements after the main submit
button. We whitelist elements to fairly innocuous ones to ensure that
the primary button remains primary.

This commit also adds a back link component to go in this
secondaryActions thing because "cancel" shouldn't
be a similar precedence than "next step".