### PR TITLE
 Avoid Y2K in year validation

### DIFF
--- a/src/shared/common/forms/__tests__/date.spec.js
+++ b/src/shared/common/forms/__tests__/date.spec.js
@@ -1,41 +1,41 @@
 import React from 'react';
-import Date from '../date.jsx';
+import DateInput from '../date.jsx';
 
 describe('Form date component', () => {
     it('should render with default props', () => {
         expect(
-            render(<Date name="date-field" />)
+            render(<DateInput name="date-field" />)
         ).toMatchSnapshot();
     });
     it('should render with value when passed', () => {
         expect(
-            render(<Date name="date-field" value="2018-01-19" />)
+            render(<DateInput name="date-field" value="2018-01-19" />)
         ).toMatchSnapshot();
     });
     it('should render with label when passed', () => {
         expect(
-            render(<Date name="date-field" label="My text field" />)
+            render(<DateInput name="date-field" label="My text field" />)
         ).toMatchSnapshot();
     });
     it('should render with hint when passed', () => {
         expect(
-            render(<Date name="date-field" hint="Put some text in the box below" />)
+            render(<DateInput name="date-field" hint="Put some text in the box below" />)
         ).toMatchSnapshot();
     });
     it('should render with error when passed', () => {
         expect(
-            render(<Date name="date-field" error="Some error message" />)
+            render(<DateInput name="date-field" error="Some error message" />)
         ).toMatchSnapshot();
     });
     it('should render disabled when passed', () => {
         expect(
-            render(<Date name="date-field" disabled={true} />)
+            render(<DateInput name="date-field" disabled={true} />)
         ).toMatchSnapshot();
     });
     it('should execute callback on initialization', () => {
         const mockCallback = jest.fn();
         shallow(
-            <Date name="date" updateState={mockCallback} />
+            <DateInput name="date" updateState={mockCallback} />
         );
         expect(mockCallback).toHaveBeenCalledTimes(1);
         expect(mockCallback).toHaveBeenCalledWith({ 'date-day': '', 'date-month': '', 'date-year': '' });
@@ -43,7 +43,7 @@ describe('Form date component', () => {
     it('should execute callback on change', () => {
         const mockCallback = jest.fn();
         const wrapper = shallow(
-            <Date name="date" updateState={mockCallback} />
+            <DateInput name="date" updateState={mockCallback} />
         );
 
         let event = { target: { value: '19' } };

--- a/src/shared/common/forms/date.jsx
+++ b/src/shared/common/forms/date.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-class Date extends Component {
+class DateInput extends Component {
 
     constructor(props) {
         super(props);
@@ -36,7 +36,9 @@ class Date extends Component {
             disabled,
             error,
             hint,
-            label
+            label,
+            minYear,
+            maxYear
         } = this.props;
         return <div className={`govuk-form-group${error ? ' govuk-form-group--error' : ''}`}>
             <fieldset disabled={disabled} className="govuk-fieldset" role="group">
@@ -85,8 +87,8 @@ class Date extends Component {
                                 name={this.datePart('year')}
                                 type="number"
                                 pattern="[0-9]*"
-                                min="1900"
-                                max="2100"
+                                min={minYear}
+                                max={maxYear}
                                 value={this.state[this.datePart('year')]}
                                 onChange={e => this.handleChange(this.datePart('year'), e.target.value)}
                             />
@@ -98,19 +100,24 @@ class Date extends Component {
     }
 }
 
-Date.propTypes = {
+DateInput.propTypes = {
     disabled: PropTypes.bool,
     error: PropTypes.string,
     hint: PropTypes.string,
     label: PropTypes.string,
     name: PropTypes.string.isRequired,
     updateState: PropTypes.func.isRequired,
-    value: PropTypes.string
+    value: PropTypes.string,
+    maxYear: PropTypes.number,
+    minYear: PropTypes.number
 };
 
-Date.defaultProps = {
+DateInput.defaultProps = {
     disabled: false,
-    value: ''
+    value: '',
+    minYear: 1900,
+    maxYear: (new Date().getFullYear() + 100),
+    hint: 'For example, 31 03 1980'
 };
 
-export default Date;
+export default DateInput;

--- a/src/shared/common/forms/form.jsx
+++ b/src/shared/common/forms/form.jsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 import ErrorSummary from './error-summary.jsx';
 import Text from './text.jsx';
 import Radio from './radio-group.jsx';
-import Date from './date.jsx';
+import DateInput from './date.jsx';
 import Checkbox from './checkbox-group.jsx';
 import Submit from './submit.jsx';
 import TextArea from './text-area.jsx';
@@ -79,7 +79,7 @@ class Form extends Component {
                 value={this.props.data && this.props.data[field.props.name]}
                 updateState={data => this.updateFormState(data)} />;
         case 'date':
-            return <Date key={i}
+            return <DateInput key={i}
                 {...field.props}
                 error={this.props.errors && this.props.errors[field.props.name]}
                 value={this.props.data && this.props.data[field.props.name]}


### PR DESCRIPTION
This PR changes the client-side year validation from a fixed `2100` to `currentYear + 100`, on the off chance that our service is still being used in several decades.

We rename the `Date` component to `DateInput` because `Date` is already used for a somewhat important purpose that we would prefer not to clash with.