### PR TITLE
Only logstashify in production

### DIFF
--- a/server/libs/logger.js
+++ b/server/libs/logger.js
@@ -33,7 +33,7 @@ loggingTransports.push(
 exceptionTransports.push(
     new (winston.transports.Console)({
         json: isProduction,
-        logstash: true,
+        logstash: isProduction,
         timestamp: true,
         colorize: true,
         stringify: function stringify(obj) {


### PR DESCRIPTION
This hopefully reduces the amount of times one must decipher minified
JSON in order to figure out what a stack trace is trying to say whilst
developing.