### PR TITLE
point allocate links to casework

### DIFF
--- a/server/middleware/stage.js
+++ b/server/middleware/stage.js
@@ -1,6 +1,6 @@
 const actionService = require('../services/action');
 const logger = require('../libs/logger');
-const { workflowServiceClient } = require('../libs/request');
+const { caseworkServiceClient } = require('../libs/request');
 
 async function stageResponseMiddleware(req, res, next) {
     const { caseId, stageId } = req.params;
@@ -53,7 +53,7 @@ async function allocateCase(req, res, next) {
         }
     };
     try {
-        await workflowServiceClient.post(`/case/${caseId}/stage/${stageId}/userUUID`, {
+        await caseworkServiceClient.post(`/case/${caseId}/stage/${stageId}/user`, {
             userUUID: user.uuid,
         }, headers);
     } catch (e) {

--- a/src/shared/common/forms/composite/__tests__/__snapshots__/entity-manager.spec.jsx.snap
+++ b/src/shared/common/forms/composite/__tests__/__snapshots__/entity-manager.spec.jsx.snap
@@ -58,7 +58,7 @@ exports[`Entity list component should render with created date when passed in pr
       <td
         class="govuk-table__cell"
       >
-        2020-1-1
+        1/1/2020
       </td>
     </tr>
     <tr
@@ -72,7 +72,7 @@ exports[`Entity list component should render with created date when passed in pr
       <td
         class="govuk-table__cell"
       >
-        2020-1-1
+        1/1/2020
       </td>
     </tr>
   </tbody>

--- a/src/shared/pages/__tests__/__snapshots__/dashboard.spec.jsx.snap
+++ b/src/shared/pages/__tests__/__snapshots__/dashboard.spec.jsx.snap
@@ -18,15 +18,39 @@ exports[`Dashboard page component should render with default props 1`] = `
       "results": Array [
         Object {
           "isThrow": false,
-          "value": Promise {},
+          "value": Promise {
+            "_a": undefined,
+            "_c": Array [],
+            "_d": true,
+            "_h": 0,
+            "_n": false,
+            "_s": 1,
+            "_v": undefined,
+          },
         },
         Object {
           "isThrow": false,
-          "value": Promise {},
+          "value": Promise {
+            "_a": undefined,
+            "_c": Array [],
+            "_d": true,
+            "_h": 0,
+            "_n": false,
+            "_s": 1,
+            "_v": undefined,
+          },
         },
         Object {
           "isThrow": false,
-          "value": Promise {},
+          "value": Promise {
+            "_a": undefined,
+            "_c": Array [],
+            "_d": true,
+            "_h": 0,
+            "_n": false,
+            "_s": 1,
+            "_v": undefined,
+          },
         },
       ],
     }
@@ -49,15 +73,39 @@ exports[`Dashboard page component should render with default props 1`] = `
         "results": Array [
           Object {
             "isThrow": false,
-            "value": Promise {},
+            "value": Promise {
+              "_a": undefined,
+              "_c": Array [],
+              "_d": true,
+              "_h": 0,
+              "_n": false,
+              "_s": 1,
+              "_v": undefined,
+            },
           },
           Object {
             "isThrow": false,
-            "value": Promise {},
+            "value": Promise {
+              "_a": undefined,
+              "_c": Array [],
+              "_d": true,
+              "_h": 0,
+              "_n": false,
+              "_s": 1,
+              "_v": undefined,
+            },
           },
           Object {
             "isThrow": false,
-            "value": Promise {},
+            "value": Promise {
+              "_a": undefined,
+              "_c": Array [],
+              "_d": true,
+              "_h": 0,
+              "_n": false,
+              "_s": 1,
+              "_v": undefined,
+            },
           },
         ],
       }

--- a/src/shared/pages/__tests__/__snapshots__/workstack.spec.jsx.snap
+++ b/src/shared/pages/__tests__/__snapshots__/workstack.spec.jsx.snap
@@ -18,15 +18,39 @@ exports[`Workstack page component should render with default props 1`] = `
       "results": Array [
         Object {
           "isThrow": false,
-          "value": Promise {},
+          "value": Promise {
+            "_a": undefined,
+            "_c": Array [],
+            "_d": true,
+            "_h": 0,
+            "_n": false,
+            "_s": 1,
+            "_v": undefined,
+          },
         },
         Object {
           "isThrow": false,
-          "value": Promise {},
+          "value": Promise {
+            "_a": undefined,
+            "_c": Array [],
+            "_d": true,
+            "_h": 0,
+            "_n": false,
+            "_s": 1,
+            "_v": undefined,
+          },
         },
         Object {
           "isThrow": false,
-          "value": Promise {},
+          "value": Promise {
+            "_a": undefined,
+            "_c": Array [],
+            "_d": true,
+            "_h": 0,
+            "_n": false,
+            "_s": 1,
+            "_v": undefined,
+          },
         },
       ],
     }
@@ -49,15 +73,39 @@ exports[`Workstack page component should render with default props 1`] = `
         "results": Array [
           Object {
             "isThrow": false,
-            "value": Promise {},
+            "value": Promise {
+              "_a": undefined,
+              "_c": Array [],
+              "_d": true,
+              "_h": 0,
+              "_n": false,
+              "_s": 1,
+              "_v": undefined,
+            },
           },
           Object {
             "isThrow": false,
-            "value": Promise {},
+            "value": Promise {
+              "_a": undefined,
+              "_c": Array [],
+              "_d": true,
+              "_h": 0,
+              "_n": false,
+              "_s": 1,
+              "_v": undefined,
+            },
           },
           Object {
             "isThrow": false,
-            "value": Promise {},
+            "value": Promise {
+              "_a": undefined,
+              "_c": Array [],
+              "_d": true,
+              "_h": 0,
+              "_n": false,
+              "_s": 1,
+              "_v": undefined,
+            },
           },
         ],
       }


### PR DESCRIPTION
We don't need to pass the allocate request through the workflow service now that we understand the allocation behaviour more,
The workflow service immediately calls casework so we might as well go direct.