### PR TITLE
Bug/hocs 1049 edge csrf issue (#319)

### DIFF
--- a/server/middleware/csrf.js
+++ b/server/middleware/csrf.js
@@ -1,10 +1,11 @@
 const csurf = require('csurf');
+const { isProduction } = require('../config');
 
 const csrfMiddleware = csurf({
     cookie: {
         path: '/',
         httpOnly: true,
-        secure: true
+        secure: isProduction
     }
 });
 


### PR DESCRIPTION
* HOCS-1049-edge-csrf-issue change from httponly cookie

* HOCS-1049-edge-csrf-issue change csrf cookie path

* HOCS-1049-edge-csrf-issue increase cookie security

* HOCS-1049-edge-csrf-issue allow insecure cookie in dev