### PR TITLE
HOCS-1331 : display casework team name

### DIFF
--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -86,9 +86,9 @@ module.exports = {
             endpoint: '/stage',
             adapter: workstack.teamAdapter
         },
-        WCS_CASEWORK_UNIT: {
+        WCS_CASEWORK_TEAMS: {
             client: 'INFO',
-            endpoint: '/teams?unit=WCS_CASEWORK_UNIT',
+            endpoint: '/teams?unit=WCS_CASEWORK_TEAMS',
             adapter: teamsAdapter
         },
         WCS_COHORTS: {


### PR DESCRIPTION
Display Casework team name instead of UUID on Case Details view. Merge to WCS.