### PR TITLE
Deploy to dev environments in parallel

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -54,6 +54,7 @@ pipeline:
         event: [push, deployment, tag]
   
     deploy-to-cs-dev-from-build-number:
+      group: deploy-to-dev
       image: quay.io/ukhomeofficedigital/kd:v1.16.0
       environment:
         - DOMAIN=cs
@@ -71,6 +72,7 @@ pipeline:
         event: [push, tag]
 
     deploy-to-wcs-dev-from-build-number:
+      group: deploy-to-dev
       image: quay.io/ukhomeofficedigital/kd:v1.16.0
       environment:
         - DOMAIN=wcs


### PR DESCRIPTION
Prior to this commit, Drone deployments would deploy to cs-dev, and,
once completed successfully, would deploy to wcs-dev.

This commit changes that behaviour so that cs-dev and wcs-dev are
deployed to simultaneously, in parallel.

This utilises the parallel execution step in Drone CI:
https://0-8-0.docs.drone.io/pipelines/#parallel-execution

This will save two minutes or so on each merge to master.