### PR TITLE
HOCS-1808 - Wcs search result page is always blank

### DIFF
--- a/server/middleware/__tests__/searchHandler.spec.js
+++ b/server/middleware/__tests__/searchHandler.spec.js
@@ -51,8 +51,8 @@ describe('handleSearch', () => {
                     if (listId === 'S_SYSTEM_CONFIGURATION') {
                         return Promise.resolve({
                             workstackTypeColumns: [
-                                { workstackColumns: {} },
-                                { workstackColumns: {} }
+                                { workstackType: 'DEFAULT', workstackColumns: {} },
+                                { workstackType: 'TypeB', workstackColumns: {} }
                             ]
                         }
                         );

--- a/server/middleware/searchHandler.js
+++ b/server/middleware/searchHandler.js
@@ -43,12 +43,14 @@ async function handleSearch(req, res, next) {
             .map(bindDisplayElements(fromStaticList)));
         const { workstackTypeColumns } = await req.listService.fetch('S_SYSTEM_CONFIGURATION');
         // using DEFAULT columns for search
-        const workstackColumnsForSearch = workstackTypeColumns[0].workstackColumns;
+        const workstackTypeForSearch = workstackTypeColumns.find(
+            item => item.workstackType === 'DEFAULT'
+        );
 
         res.locals.workstack = {
             label: 'Search Results',
             items: workstackData,
-            columns: workstackColumnsForSearch
+            columns: workstackTypeForSearch.workstackColumns
         };
 
         next();


### PR DESCRIPTION
Updating the fetch logic for 'DEFAULT' workstack type, as it is not guaranteed to always be the first item in the list.