### PR TITLE
HOCS-1730 - UKVI Change success page

### DIFF
--- a/server/services/action.js
+++ b/server/services/action.js
@@ -89,7 +89,7 @@ const actions = {
                     case actionTypes.CREATE_CASE: {
                         const { data: documentTags } = await getDocumentTags(context);
                         response = await createCase('/case', { caseType: context, form }, documentTags[0], headers);
-                        clientResponse = { summary: 'Created a new case ', link: `${response.data.reference}` };
+                        clientResponse = { summary: 'Case Created ', link: `${response.data.reference}` };
                         return handleActionSuccess(clientResponse, workflow, form);
                     }
                     case actionTypes.CREATE_AND_ALLOCATE_CASE: {

--- a/src/shared/common/forms/__tests__/__snapshots__/panel.spec.js.snap
+++ b/src/shared/common/forms/__tests__/__snapshots__/panel.spec.js.snap
@@ -1,33 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Panel component should render with content when passed 1`] = `
-<div
-  class="govuk-panel govuk-panel--confirmation"
->
-  <h1
-    class="govuk-panel__title"
-  />
+<div>
   <div
-    class="govuk-panel__body"
+    class="govuk-panel govuk-panel--confirmation"
   >
-    <form
-      action="/search/reference?_csrf=__token__"
-      enctype="multipart/form-data"
-      method="POST"
-    >
-      <input
-        class="govuk-input"
-        id="case-reference"
-        name="case-reference"
-        type="hidden"
-      />
-      <input
-        class="govuk-button-panel--link"
-        id="submit"
-        type="submit"
-      />
-    </form>
+    <div
+      class="govuk-panel__body"
+    />
   </div>
+  <form
+    action="/search/reference?_csrf=__token__"
+    enctype="multipart/form-data"
+    method="POST"
+  >
+    <input
+      class="govuk-input"
+      id="case-reference"
+      name="case-reference"
+      type="hidden"
+    />
+    <input
+      class="govuk-button-panel--link"
+      id="submit"
+      type="submit"
+    />
+  </form>
 </div>
 `;
 
@@ -45,34 +43,35 @@ exports[`Panel component should render with default props 1`] = `
 `;
 
 exports[`Panel component should render with title when passed 1`] = `
-<div
-  class="govuk-panel govuk-panel--confirmation"
->
-  <h1
-    class="govuk-panel__title"
-  >
-    Testing
-  </h1>
+<div>
   <div
-    class="govuk-panel__body"
+    class="govuk-panel govuk-panel--confirmation"
   >
-    <form
-      action="/search/reference?_csrf=__token__"
-      enctype="multipart/form-data"
-      method="POST"
+    <h1
+      class="govuk-panel__title"
     >
-      <input
-        class="govuk-input"
-        id="case-reference"
-        name="case-reference"
-        type="hidden"
-      />
-      <input
-        class="govuk-button-panel--link"
-        id="submit"
-        type="submit"
-      />
-    </form>
+      Testing
+    </h1>
+    <div
+      class="govuk-panel__body"
+    />
   </div>
+  <form
+    action="/search/reference?_csrf=__token__"
+    enctype="multipart/form-data"
+    method="POST"
+  >
+    <input
+      class="govuk-input"
+      id="case-reference"
+      name="case-reference"
+      type="hidden"
+    />
+    <input
+      class="govuk-button-panel--link"
+      id="submit"
+      type="submit"
+    />
+  </form>
 </div>
 `;

--- a/src/shared/common/forms/panel.jsx
+++ b/src/shared/common/forms/panel.jsx
@@ -7,23 +7,25 @@ class Panel extends Component {
      * A visible container used on confirmation or results pages to highlight important content
      */
     render() {
-        const { title, children , csrf } = this.props;
+        const { title, children, csrf } = this.props;
 
         return (
-            <div className="govuk-panel govuk-panel--confirmation">
-                <h1 className="govuk-panel__title">{title}</h1>
-                <div className="govuk-panel__body">{children.summary}
-                    {/* todo: why is the body not passed to the csrf parsing? */}
-                    { children.link &&
-                        <form action={`/search/reference?_csrf=${csrf}`} method='POST'
-                            encType='multipart/form-data'>
-                            <input className="govuk-input" id="case-reference" type="hidden" name="case-reference"
-                                value={children.link}/>
-                            <input className="govuk-button-panel--link" id="submit" type="submit"
-                                value={children.link}/>
-                        </form>
-                    }
+            <div>
+                <div className="govuk-panel govuk-panel--confirmation">
+                    {title && <h1 className="govuk-panel__title">{title}</h1>}
+                    <div className="govuk-panel__body">{children.summary}
+                    </div>
                 </div>
+                {/* todo: why is the body not passed to the csrf parsing? */}
+                {children.link &&
+                    <form action={`/search/reference?_csrf=${csrf}`} method='POST'
+                        encType='multipart/form-data'>
+                        <input className="govuk-input" id="case-reference" type="hidden" name="case-reference"
+                            value={children.link} />
+                        <input className="govuk-button-panel--link" id="submit" type="submit"
+                            value={children.link} />
+                    </form>
+                }
             </div>
         );
     }

--- a/src/shared/pages/form-enabled.jsx
+++ b/src/shared/pages/form-enabled.jsx
@@ -168,7 +168,7 @@ function withForm(Page) {
         renderConfirmation() {
             return (
                 <Fragment>
-                    <Panel title='Success'>
+                    <Panel >
                         {this.state.confirmation}
                     </Panel >
                     <BackLink />

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -646,13 +646,27 @@ $border-colour: govuk-colour("grey-2");
 }
 
 .govuk-button-panel--link {
-  color: govuk-colour("white");
-  text-decoration: none;
+  color: $link-colour;
+  text-decoration: underline;
   font-size: 2.25rem;
   cursor: pointer;
   background: none;
   border: none;
-  margin: 0; 
+  margin: 20, 0, 20, 0; 
+
+  &:hover {
+    color: $link-hover-colour;
+  }
+}
+
+.govuk-panel--confirmation {
+  max-width: 600px;
+}
+
+.govuk-panel--confirmation2 {
+  color: #ffffff;
+  background: #28a197;
+  max-width: 600px;
 }
 
 .govuk-fieldset{


### PR DESCRIPTION
- changed 'Created a new case' massage to 'Case Created'
- separated case link from success banner to make it more apparent it's a clickable link
- styled case ref button to make it look like an actual hyperlink
- removed 'Success' massage to match new design