### PR TITLE
Set localstack image version so localstack services remain compatible.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     - ${PWD}/keycloak:/tmp
 
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:0.9.5
     ports:
       - 9000:8080
       - 4572:4572


### PR DESCRIPTION
The localstack image version has been set to `0.9.5`; this localstack services from this version are known to work with all the HOCS/WCS services, whereas a later localstack version broke the search functionality as the version of elasticsearch (from localstack) was not compatible with `hocs-search` service.