### PR TITLE
HOCS-1838: Prevent entity-list.jsx table from overflowing.

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -760,3 +760,20 @@ $border-colour: govuk-colour("grey-2");
         top: unset;
     }
 }
+
+.govuk-form-group {
+  .govuk-fieldset {
+    .govuk-table {
+      table-layout: fixed;
+    }
+  }
+}
+
+.govuk-table__cell {
+  .govuk-radios__item {
+    .govuk-label {
+      display: inherit;
+      overflow-wrap: break-word;
+    }
+  }
+}


### PR DESCRIPTION
Added css to prevent overflow as described in HOCS-1838. This css only targets the entity-list.jsx component.