### PR TITLE
HOCS-1825 - Primary Draft Tag in document list

### DIFF
--- a/server/lists/adapters/__tests__/__snapshots__/documents.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/documents.spec.js.snap
@@ -7,6 +7,7 @@ Array [
     Array [
       Object {
         "label": "Document A",
+        "labels": undefined,
         "status": undefined,
         "tags": Array [
           undefined,
@@ -17,6 +18,7 @@ Array [
       },
       Object {
         "label": "Document B",
+        "labels": undefined,
         "status": undefined,
         "tags": Array [
           undefined,
@@ -32,6 +34,7 @@ Array [
     Array [
       Object {
         "label": "Document C",
+        "labels": undefined,
         "status": undefined,
         "tags": Array [
           undefined,

--- a/server/lists/adapters/documents.js
+++ b/server/lists/adapters/documents.js
@@ -18,14 +18,24 @@ module.exports = async (data, { logger }) => {
     };
 
     return [...data.documents
-        .map(({ displayName, uuid, created, status, type }) => ({
-            label: displayName,
-            status,
-            tags: [status],
-            timeStamp: created,
-            type,
-            value: uuid,
-        }))
+        .map(({ displayName, uuid, created, status, type, labels }) => {
+            var tags = [];
+            if (status !== 'UPLOADED') {
+                tags.push(status);
+            }
+            if (labels) {
+                tags = tags.concat(labels);
+            }
+            return {
+                label: displayName,
+                status,
+                tags,
+                timeStamp: created,
+                type,
+                value: uuid,
+                labels
+            };
+        })
         .reduce(reduceDocumentsByType, new Map(data.documentTags.map(label => [label, []])))]
         .map(([name, documents]) => [name, documents.sort(sortByTimeStamp)]);
 };

--- a/src/shared/common/components/__tests__/__snapshots__/document-list.spec.jsx.snap
+++ b/src/shared/common/components/__tests__/__snapshots__/document-list.spec.jsx.snap
@@ -66,6 +66,11 @@ Array [
         class="govuk-table__row"
       >
         <td
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          TEST_DOCUMENT_1
+        </td>
+        <td
           class="govuk-table__cell govuk-!-width-one-quarter"
         >
           <strong
@@ -73,11 +78,6 @@ Array [
           >
             UPLOADED
           </strong>
-        </td>
-        <td
-          class="govuk-table__cell govuk-!-width-full"
-        >
-          TEST_DOCUMENT_1
         </td>
         <td
           class="govuk-table__cell"
@@ -106,6 +106,11 @@ Array [
         class="govuk-table__row"
       >
         <td
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          TEST_DOCUMENT_2
+        </td>
+        <td
           class="govuk-table__cell govuk-!-width-one-quarter"
         >
           <strong
@@ -113,11 +118,6 @@ Array [
           >
             UPLOADED
           </strong>
-        </td>
-        <td
-          class="govuk-table__cell govuk-!-width-full"
-        >
-          TEST_DOCUMENT_2
         </td>
         <td
           class="govuk-table__cell"
@@ -146,6 +146,11 @@ Array [
         class="govuk-table__row"
       >
         <td
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          TEST_DOCUMENT_3
+        </td>
+        <td
           class="govuk-table__cell govuk-!-width-one-quarter"
         >
           <strong
@@ -153,11 +158,6 @@ Array [
           >
             PENDING
           </strong>
-        </td>
-        <td
-          class="govuk-table__cell govuk-!-width-full"
-        >
-          TEST_DOCUMENT_3
         </td>
         <td
           class="govuk-table__cell"
@@ -183,6 +183,11 @@ Array [
         class="govuk-table__row"
       >
         <td
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          TEST_DOCUMENT_4
+        </td>
+        <td
           class="govuk-table__cell govuk-!-width-one-quarter"
         >
           <strong
@@ -190,11 +195,6 @@ Array [
           >
             UPLOADED
           </strong>
-        </td>
-        <td
-          class="govuk-table__cell govuk-!-width-full"
-        >
-          TEST_DOCUMENT_4
         </td>
         <td
           class="govuk-table__cell"
@@ -223,6 +223,11 @@ Array [
         class="govuk-table__row"
       >
         <td
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          TEST_DOCUMENT_5
+        </td>
+        <td
           class="govuk-table__cell govuk-!-width-one-quarter"
         >
           <strong
@@ -230,11 +235,6 @@ Array [
           >
             UPLOADED
           </strong>
-        </td>
-        <td
-          class="govuk-table__cell govuk-!-width-full"
-        >
-          TEST_DOCUMENT_5
         </td>
         <td
           class="govuk-table__cell"
@@ -263,6 +263,11 @@ Array [
         class="govuk-table__row"
       >
         <td
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          TEST_DOCUMENT_6
+        </td>
+        <td
           class="govuk-table__cell govuk-!-width-one-quarter"
         >
           <strong
@@ -270,11 +275,6 @@ Array [
           >
             UPLOADED
           </strong>
-        </td>
-        <td
-          class="govuk-table__cell govuk-!-width-full"
-        >
-          TEST_DOCUMENT_6
         </td>
         <td
           class="govuk-table__cell"
@@ -316,6 +316,11 @@ Array [
         class="govuk-table__row"
       >
         <td
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          TEST_DOCUMENT_7
+        </td>
+        <td
           class="govuk-table__cell govuk-!-width-one-quarter"
         >
           <strong
@@ -323,11 +328,6 @@ Array [
           >
             UPLOADED
           </strong>
-        </td>
-        <td
-          class="govuk-table__cell govuk-!-width-full"
-        >
-          TEST_DOCUMENT_7
         </td>
         <td
           class="govuk-table__cell"
@@ -356,6 +356,11 @@ Array [
         class="govuk-table__row"
       >
         <td
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          TEST_DOCUMENT_8
+        </td>
+        <td
           class="govuk-table__cell govuk-!-width-one-quarter"
         >
           <strong
@@ -363,11 +368,6 @@ Array [
           >
             PENDING
           </strong>
-        </td>
-        <td
-          class="govuk-table__cell govuk-!-width-full"
-        >
-          TEST_DOCUMENT_8
         </td>
         <td
           class="govuk-table__cell"
@@ -380,6 +380,11 @@ Array [
         class="govuk-table__row"
       >
         <td
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          TEST_DOCUMENT_9
+        </td>
+        <td
           class="govuk-table__cell govuk-!-width-one-quarter"
         >
           <strong
@@ -387,11 +392,6 @@ Array [
           >
             PENDING
           </strong>
-        </td>
-        <td
-          class="govuk-table__cell govuk-!-width-full"
-        >
-          TEST_DOCUMENT_9
         </td>
         <td
           class="govuk-table__cell"

--- a/src/shared/common/components/document-list.jsx
+++ b/src/shared/common/components/document-list.jsx
@@ -24,6 +24,9 @@ class DocumentList extends Component {
                                 {
                                     caseId && Array.isArray(groupedDocuments) && groupedDocuments.map(({ label, status, tags, value }, i) => (
                                         <tr key={i} className='govuk-table__row'>
+                                            <td className='govuk-table__cell govuk-!-width-full'>
+                                                {label}
+                                            </td>
                                             {Array.isArray(tags) && <td className='govuk-table__cell govuk-!-width-one-quarter'>
                                                 {tags.map(tag =>
                                                     <strong key={tag} className='govuk-tag margin-right--small'>
@@ -32,9 +35,6 @@ class DocumentList extends Component {
                                                 )}
                                             </td>
                                             }
-                                            <td className='govuk-table__cell govuk-!-width-full'>
-                                                {label}
-                                            </td>
                                             <td className='govuk-table__cell'>
                                                 {value && status === 'UPLOADED' && caseId && activeDocument !== value &&
                                                     <a

--- a/src/shared/common/components/document-pane.jsx
+++ b/src/shared/common/components/document-pane.jsx
@@ -89,6 +89,7 @@ class DocumentPanel extends Component {
             <Fragment>
                 <div className='govuk-grid-row'>
                     <div className='govuk-grid-column-full'>
+                        <Link className='govuk-body govuk-link' to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/document/manage`} >Manage Documents</Link>
                         {activeDocument && page.params.caseId && <Document caseId={page.params.caseId} activeDocument={activeDocument} />}
                         {documents && documents.length > 0 && <DocumentList
                             caseId={page.params.caseId}
@@ -97,7 +98,6 @@ class DocumentPanel extends Component {
                             activeDocument={activeDocument}
                             clickHandler={this.setActiveDocument.bind(this)}
                         />}
-                        <Link className='govuk-body govuk-link' to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/document/manage`} >Manage Documents</Link>
                     </div>
                 </div>
             </Fragment>

--- a/src/shared/common/forms/composite/__tests__/__snapshots__/entity-manager.spec.jsx.snap
+++ b/src/shared/common/forms/composite/__tests__/__snapshots__/entity-manager.spec.jsx.snap
@@ -226,7 +226,12 @@ Array [
         class="govuk-radios govuk-table__row"
       >
         <td
-          class="govuk-table__cell"
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          Choice A
+        </td>
+        <td
+          class="govuk-table__cell "
         >
           <strong
             class="govuk-tag margin-right--small"
@@ -234,28 +239,23 @@ Array [
             A
           </strong>
         </td>
-        <td
-          class="govuk-table__cell govuk-!-width-full"
-        >
-          Choice A
-        </td>
       </tr>
       <tr
         class="govuk-radios govuk-table__row"
       >
         <td
-          class="govuk-table__cell"
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          Choice B
+        </td>
+        <td
+          class="govuk-table__cell "
         >
           <strong
             class="govuk-tag margin-right--small"
           >
             B
           </strong>
-        </td>
-        <td
-          class="govuk-table__cell govuk-!-width-full"
-        >
-          Choice B
         </td>
       </tr>
     </tbody>
@@ -275,7 +275,12 @@ Array [
         class="govuk-radios govuk-table__row"
       >
         <td
-          class="govuk-table__cell"
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          Choice C
+        </td>
+        <td
+          class="govuk-table__cell "
         >
           <strong
             class="govuk-tag margin-right--small"
@@ -283,28 +288,23 @@ Array [
             C
           </strong>
         </td>
-        <td
-          class="govuk-table__cell govuk-!-width-full"
-        >
-          Choice C
-        </td>
       </tr>
       <tr
         class="govuk-radios govuk-table__row"
       >
         <td
-          class="govuk-table__cell"
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          Choice D
+        </td>
+        <td
+          class="govuk-table__cell "
         >
           <strong
             class="govuk-tag margin-right--small"
           >
             D
           </strong>
-        </td>
-        <td
-          class="govuk-table__cell govuk-!-width-full"
-        >
-          Choice D
         </td>
       </tr>
     </tbody>
@@ -399,7 +399,12 @@ exports[`Entity list component should render with tags when passed in props on c
       class="govuk-radios govuk-table__row"
     >
       <td
-        class="govuk-table__cell"
+        class="govuk-table__cell govuk-!-width-full"
+      >
+        Choice A
+      </td>
+      <td
+        class="govuk-table__cell "
       >
         <strong
           class="govuk-tag margin-right--small"
@@ -407,28 +412,23 @@ exports[`Entity list component should render with tags when passed in props on c
           A
         </strong>
       </td>
-      <td
-        class="govuk-table__cell govuk-!-width-full"
-      >
-        Choice A
-      </td>
     </tr>
     <tr
       class="govuk-radios govuk-table__row"
     >
       <td
-        class="govuk-table__cell"
+        class="govuk-table__cell govuk-!-width-full"
+      >
+        Choice B
+      </td>
+      <td
+        class="govuk-table__cell "
       >
         <strong
           class="govuk-tag margin-right--small"
         >
           B
         </strong>
-      </td>
-      <td
-        class="govuk-table__cell govuk-!-width-full"
-      >
-        Choice B
       </td>
     </tr>
   </tbody>

--- a/src/shared/common/forms/composite/entity-manager.jsx
+++ b/src/shared/common/forms/composite/entity-manager.jsx
@@ -25,14 +25,14 @@ class EntityManager extends Component {
                         {Array.isArray(choices) && choices.map((choice, i) => {
                             return (
                                 <tr className='govuk-radios govuk-table__row' key={i}>
-                                    {choice.tags && <td className='govuk-table__cell' >
-                                        {choice.tags.map((tag, i) => <strong key={i} className='govuk-tag margin-right--small'>{tag}</strong>)}
-                                    </td>}
                                     <td className='govuk-table__cell govuk-!-width-full'>
                                         {choice.label}
                                     </td>
                                     {choice.created && <td className='govuk-table__cell'>
                                         {new Date(choice.created).toLocaleDateString()}
+                                    </td>}
+                                    {choice.tags && <td className='govuk-table__cell ' >
+                                        {choice.tags.map((tag, i) => <strong key={i} className='govuk-tag margin-right--small'>{tag}</strong>)}
                                     </td>}
                                     {hasDownloadLink && <td className='govuk-table__cell'>
                                         <a href={`${baseUrl}/download/${entity}/${choice.value}`} className="govuk-link" download={choice.label}>Download</a>


### PR DESCRIPTION
- moved 'Manage Documents' link to top of the page (to match people's tab)
- stopped 'UPLOADED' document tag from showing (pending and failed status will still be visible)
- shifted label colum to be the first column
- added 'PRIMARY DRAFT' label on primary draft document