### PR TITLE
HOCS-1756

### DIFF
--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -181,6 +181,11 @@ module.exports = {
             type: listService.types.STATIC,
             adapter: entityListItemsAdapter
         },
+        MPAM_CAMPAIGNS: {
+            client: 'INFO',
+            endpoint: '/entity/list/MPAM_CAMPAIGNS',
+            adapter: entityListItemsAdapter
+        },
         CASE_TYPES: {
             client: 'INFO',
             endpoint: '/caseType?bulkOnly=false',

--- a/src/shared/common/forms/__tests__/__snapshots__/type-ahead.spec.js.snap
+++ b/src/shared/common/forms/__tests__/__snapshots__/type-ahead.spec.js.snap
@@ -152,6 +152,7 @@ exports[`Form type ahead component (select) should render disabled when passed 1
 <TypeAhead
   choices={Array []}
   clearable={true}
+  defaultOptions={false}
   disabled={true}
   name="type-ahead"
   updateState={[Function]}
@@ -1458,6 +1459,7 @@ exports[`Form type ahead component (select) should render with default props 1`]
 <TypeAhead
   choices={Array []}
   clearable={true}
+  defaultOptions={false}
   disabled={false}
   name="type-ahead"
   updateState={[Function]}
@@ -2764,6 +2766,7 @@ exports[`Form type ahead component (select) should render with error when passed
 <TypeAhead
   choices={Array []}
   clearable={true}
+  defaultOptions={false}
   disabled={false}
   error="Some error message"
   name="type-ahead"
@@ -4080,6 +4083,7 @@ exports[`Form type ahead component (select) should render with hint when passed 
 <TypeAhead
   choices={Array []}
   clearable={true}
+  defaultOptions={false}
   disabled={false}
   hint="Select an option"
   name="type-ahead"
@@ -5392,6 +5396,7 @@ exports[`Form type ahead component (select) should render with label when passed
 <TypeAhead
   choices={Array []}
   clearable={true}
+  defaultOptions={false}
   disabled={false}
   label="Type-ahead"
   name="type-ahead"

--- a/src/shared/common/forms/type-ahead.jsx
+++ b/src/shared/common/forms/type-ahead.jsx
@@ -168,7 +168,7 @@ TypeAhead.defaultProps = {
     clearable: true,
     disabled: false,
     choices: [],
-    defaultOptions: false,
+    defaultOptions: false
 };
 
 export default TypeAhead;

--- a/src/shared/common/forms/type-ahead.jsx
+++ b/src/shared/common/forms/type-ahead.jsx
@@ -6,7 +6,19 @@ class TypeAhead extends Component {
 
     constructor(props) {
         super(props);
-        const choices = Array.from(props.choices);
+        let choices = Array.from(props.choices);
+
+        // formatting input if it comes as key-value pairs (group is defined as blank string)
+        if (choices.length > 0 && choices[0].options === undefined) {
+            choices = choices
+                .map(d => ({
+                    label: '', options: [{
+                        label: d.label,
+                        value: d.value
+                    }]
+                }));
+        }
+
         choices.unshift({ label: '', options: [{ label: '', value: '' }] });
         this.state = {
             value: this.props.value,
@@ -40,7 +52,7 @@ class TypeAhead extends Component {
                 return reducer;
             }, []);
         } else {
-            options = [];
+            options = this.props.defaultOptions ? this.state.choices : [];
         }
         return callback(options);
     }
@@ -52,7 +64,8 @@ class TypeAhead extends Component {
             error,
             hint,
             label,
-            name
+            name,
+            defaultOptions
         } = this.props;
         const { choices } = this.state;
         return (
@@ -83,6 +96,7 @@ class TypeAhead extends Component {
                     error={error}
                     onChange={this.handleChange.bind(this)}
                     loadOptions={this.getOptions.bind(this)}
+                    defaultOptions={defaultOptions}
                     className={error ? ' govuk-typeahead__control--error' : null}
                 />
             </div >
@@ -146,13 +160,15 @@ TypeAhead.propTypes = {
     label: PropTypes.string,
     name: PropTypes.string.isRequired,
     updateState: PropTypes.func.isRequired,
-    value: PropTypes.string
+    value: PropTypes.string,
+    defaultOptions: PropTypes.bool,
 };
 
 TypeAhead.defaultProps = {
     clearable: true,
     disabled: false,
-    choices: []
+    choices: [],
+    defaultOptions: false,
 };
 
 export default TypeAhead;


### PR DESCRIPTION
- added wiring for MPAM campaigns
- type-ahead widget now supports flat key-value input (default format
for entity list values)
- defaultOptions property added to type-ahead widget, when true
all options are visible on blank entry