### PR TITLE
HOCS-1929 - Offline QA dropdown shows wrong team

### DIFF
--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -253,7 +253,7 @@ module.exports = {
             adapter: teamsAdapter
         },
         USERS_FOR_CASE: {
-            client: 'INFO',
+            client: 'CASEWORK',
             endpoint: '/case/${caseId}/stage/${stageId}/team/members',
             adapter: usersAdapter
         },


### PR DESCRIPTION
- fetching users for case using new logic in CASEWORK,
in the background this looks up current stage team.