### PR TITLE
HOCS-1867 Add footer, a11y statement to DECS

### DIFF
--- a/server/tenantConfig.js
+++ b/server/tenantConfig.js
@@ -33,7 +33,9 @@ async function layoutConfig() {
             }
         },
         footer: {
-            isVisible: false
+            isVisible: true,
+            showOGL: false,
+            links: getFooterLinks()
         },
         maxSearchResults: 500,
         maxUploadSize: process.env.MAX_UPLOAD_SIZE || 10485760,
@@ -41,6 +43,17 @@ async function layoutConfig() {
         defaultTimeoutSeconds: isNaN(defaultTimeoutSeconds) ? 1200 : defaultTimeoutSeconds,
         countDownForSeconds: isNaN(countDownForSeconds) ? 60 : countDownForSeconds
     };
+}
+
+function getFooterLinks() {
+    const links = [];
+    if (process.env.ACCESSIBILITY_STATEMENT_URL) {
+        links.push({
+            target: process.env.ACCESSIBILITY_STATEMENT_URL,
+            label: 'Accessibility'
+        });
+    }
+    return links;
 }
 
 async function fetchConfiguration() {

--- a/src/shared/layouts/components/__tests__/__snapshots__/footer.spec.js.snap
+++ b/src/shared/layouts/components/__tests__/__snapshots__/footer.spec.js.snap
@@ -30,33 +30,6 @@ exports[`Layout footer component should render with default props 1`] = `
              in Sheffield
           </li>
         </ul>
-        <svg
-          class="govuk-footer__licence-logo"
-          focusable="false"
-          height="17"
-          role="presentation"
-          viewBox="0 0 483.2 195.7"
-          width="41"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-            fill="currentColor"
-          />
-        </svg>
-        <span
-          class="govuk-footer__licence-description"
-        >
-          All content is available under the 
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >
-            Open Government Licence v3.0
-          </a>
-          , except where otherwise stated
-        </span>
       </div>
       <div
         class="govuk-footer__meta-item"
@@ -111,6 +84,52 @@ exports[`Layout footer component should render with links when passed 1`] = `
             </a>
           </li>
         </ul>
+        <ul
+          class="govuk-footer__inline-list"
+        >
+          <li
+            class="govuk-footer__inline-list-item"
+          >
+            Built by the 
+            <a
+              class="govuk-footer__link"
+              href="https://www.gov.uk/government/organisations/home-office"
+            >
+              Home Office
+            </a>
+             in Sheffield
+          </li>
+        </ul>
+      </div>
+      <div
+        class="govuk-footer__meta-item"
+      >
+        <a
+          class="govuk-footer__link govuk-footer__copyright-logo"
+          href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+        >
+          © Crown copyright
+        </a>
+      </div>
+    </div>
+  </div>
+</footer>
+`;
+
+exports[`Layout footer component should show OGL when asked 1`] = `
+<footer
+  class="govuk-footer "
+  role="contentinfo"
+>
+  <div
+    class="govuk-width-container "
+  >
+    <div
+      class="govuk-footer__meta"
+    >
+      <div
+        class="govuk-footer__meta-item govuk-footer__meta-item--grow"
+      >
         <ul
           class="govuk-footer__inline-list"
         >

--- a/src/shared/layouts/components/__tests__/footer.spec.js
+++ b/src/shared/layouts/components/__tests__/footer.spec.js
@@ -18,4 +18,12 @@ describe('Layout footer component', () => {
             render(<Footer {...props} />)
         ).toMatchSnapshot();
     });
+    it('should show OGL when asked', () => {
+        const props = {
+            showOGL: true
+        };
+        expect(
+            render(<Footer {...props} />)
+        ).toMatchSnapshot();
+    });
 });

--- a/src/shared/layouts/components/footer.jsx
+++ b/src/shared/layouts/components/footer.jsx
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 class Footer extends Component {
     render() {
         const {
-            links
+            links,
+            showOGL
         } = this.props;
 
         return (
@@ -31,21 +32,28 @@ class Footer extends Component {
                                   Built by the <a className="govuk-footer__link" href="https://www.gov.uk/government/organisations/home-office">Home Office</a> in Sheffield
                                 </li>
                             </ul>
-
-                            <svg role="presentation" focusable="false" className="govuk-footer__licence-logo"
-                                xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
-                                <path
-                                    fill="currentColor"
-                                    d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-                                />
-                            </svg>
-                            <span className="govuk-footer__licence-description">
-                                All content is available under the <a
-                                    className="govuk-footer__link"
-                                    href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-                                    rel="license"
-                                >Open Government Licence v3.0</a>, except where otherwise stated
-                            </span>
+                            {
+                                showOGL && (
+                                    <svg role="presentation" focusable="false" className="govuk-footer__licence-logo"
+                                        xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+                                        <path
+                                            fill="currentColor"
+                                            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+                                        />
+                                    </svg>
+                                )
+                            }
+                            {
+                                showOGL && (
+                                    <span className="govuk-footer__licence-description">
+                                        All content is available under the <a
+                                            className="govuk-footer__link"
+                                            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                            rel="license"
+                                        >Open Government Licence v3.0</a>, except where otherwise stated
+                                    </span>
+                                )
+                            }
                         </div>
                         <div className="govuk-footer__meta-item">
                             <a className="govuk-footer__link govuk-footer__copyright-logo"
@@ -60,11 +68,13 @@ class Footer extends Component {
 }
 
 Footer.propTypes = {
-    links: PropTypes.arrayOf(PropTypes.object)
+    links: PropTypes.arrayOf(PropTypes.object),
+    showOGL: PropTypes.bool
 };
 
 Footer.defaultProps = {
-    links: []
+    links: [],
+    showOGL: false
 };
 
 export default Footer;


### PR DESCRIPTION
This commit enables the pre-existing Footer component to be shown on all
pages. Previously there was just a white box where the footer would
usually be.

We additionally create a `showOGL` property for the footer and default
it to disabled. This property determines whether the footer should have
the "All content is available under the Open Government Licence v3.0"
message. We disable it by default as it is misleading for internal
services.

We retain the (c) Crown Copyright and the coat of arms of the British
Government.

This commit also adds a new environment variable,
ACCESSIBILITY_STATEMENT_URL. If this variable is set, we show an
"Accessibility" link in the footer that links to that URL. If it's
disabled, we don't. It's set as an environment variable instead of
hardcoded into the codebase so that it is simple to change, and to avoid
the URL (which is likely an Intranet webpage) from being published to
GitHub. Different environments could reasonably use different
accessibility statements.