### PR TITLE
HOCS-1992 Add case ref to w'stack checkbox labels

### DIFF
--- a/src/shared/common/components/__tests__/__snapshots__/workstack.spec.jsx.snap
+++ b/src/shared/common/components/__tests__/__snapshots__/workstack.spec.jsx.snap
@@ -108,7 +108,13 @@ Array [
                             <label
                               class="govuk-label govuk-checkboxes__label"
                               for="selected_cases_case_uuid-123"
-                            />
+                            >
+                              <span
+                                class="govuk-visually-hidden"
+                              >
+                                case1
+                              </span>
+                            </label>
                           </div>
                         </div>
                       </td>
@@ -175,7 +181,13 @@ Array [
                             <label
                               class="govuk-label govuk-checkboxes__label"
                               for="selected_cases_case_uuid-789"
-                            />
+                            >
+                              <span
+                                class="govuk-visually-hidden"
+                              >
+                                case2
+                              </span>
+                            </label>
                           </div>
                         </div>
                       </td>
@@ -238,7 +250,13 @@ Array [
                             <label
                               class="govuk-label govuk-checkboxes__label"
                               for="selected_cases_case_uuid-abc"
-                            />
+                            >
+                              <span
+                                class="govuk-visually-hidden"
+                              >
+                                case3
+                              </span>
+                            </label>
                           </div>
                         </div>
                       </td>
@@ -618,7 +636,13 @@ exports[`Workstack component should render with filtering 1`] = `
                                   <label
                                     className="govuk-label govuk-checkboxes__label"
                                     htmlFor="selected_cases_case_uuid-123"
-                                  />
+                                  >
+                                    <span
+                                      className="govuk-visually-hidden"
+                                    >
+                                      case1
+                                    </span>
+                                  </label>
                                 </div>
                               </div>
                             </td>
@@ -1026,7 +1050,13 @@ exports[`Workstack component should sort descending when the column heading is c
                                   <label
                                     className="govuk-label govuk-checkboxes__label"
                                     htmlFor="selected_cases_case_uuid-abc"
-                                  />
+                                  >
+                                    <span
+                                      className="govuk-visually-hidden"
+                                    >
+                                      case3
+                                    </span>
+                                  </label>
                                 </div>
                               </div>
                             </td>
@@ -1112,7 +1142,13 @@ exports[`Workstack component should sort descending when the column heading is c
                                   <label
                                     className="govuk-label govuk-checkboxes__label"
                                     htmlFor="selected_cases_case_uuid-789"
-                                  />
+                                  >
+                                    <span
+                                      className="govuk-visually-hidden"
+                                    >
+                                      case2
+                                    </span>
+                                  </label>
                                 </div>
                               </div>
                             </td>
@@ -1198,7 +1234,13 @@ exports[`Workstack component should sort descending when the column heading is c
                                   <label
                                     className="govuk-label govuk-checkboxes__label"
                                     htmlFor="selected_cases_case_uuid-123"
-                                  />
+                                  >
+                                    <span
+                                      className="govuk-visually-hidden"
+                                    >
+                                      case1
+                                    </span>
+                                  </label>
                                 </div>
                               </div>
                             </td>
@@ -1606,7 +1648,13 @@ exports[`Workstack component should sort when the column heading is clicked 1`] 
                                   <label
                                     className="govuk-label govuk-checkboxes__label"
                                     htmlFor="selected_cases_case_uuid-123"
-                                  />
+                                  >
+                                    <span
+                                      className="govuk-visually-hidden"
+                                    >
+                                      case1
+                                    </span>
+                                  </label>
                                 </div>
                               </div>
                             </td>
@@ -1696,7 +1744,13 @@ exports[`Workstack component should sort when the column heading is clicked 1`] 
                                   <label
                                     className="govuk-label govuk-checkboxes__label"
                                     htmlFor="selected_cases_case_uuid-789"
-                                  />
+                                  >
+                                    <span
+                                      className="govuk-visually-hidden"
+                                    >
+                                      case2
+                                    </span>
+                                  </label>
                                 </div>
                               </div>
                             </td>
@@ -1782,7 +1836,13 @@ exports[`Workstack component should sort when the column heading is clicked 1`] 
                                   <label
                                     className="govuk-label govuk-checkboxes__label"
                                     htmlFor="selected_cases_case_uuid-abc"
-                                  />
+                                  >
+                                    <span
+                                      className="govuk-visually-hidden"
+                                    >
+                                      case3
+                                    </span>
+                                  </label>
                                 </div>
                               </div>
                             </td>

--- a/src/shared/common/components/workstack.jsx
+++ b/src/shared/common/components/workstack.jsx
@@ -215,7 +215,9 @@ class WorkstackAllocate extends Component {
                                 onChange={handleChange.bind(this)}
                                 className={'govuk-checkboxes__input'}
                             />
-                            <label className='govuk-label govuk-checkboxes__label' htmlFor={`selected_cases_${item.caseUUID}`}></label>
+                            <label className='govuk-label govuk-checkboxes__label' htmlFor={`selected_cases_${item.caseUUID}`}>
+                                <span className='govuk-visually-hidden'>{item.caseReference}</span>
+                            </label>
                         </div>
                     </div>
                 </td>}


### PR DESCRIPTION
Previously we had an empty label element next to the big checkboxes in
workstack view. These labels were required to make the checkboxes render
properly. However, because the labels were empty, they didn't help
screen-readers to understand what the checkboxes were associated with.

This commit adds the case's reference (e.g. HOCS/12345/20) to the
contents of the label, and wraps it in a CSS class that hides it
visually (as it's only useful to screen-readers).

This now means that VoiceOver announces the case reference when you tab
into the associated checkbox, instead of having to tab to the next
column and back again.

This commit fixes an issue that is listed in the DECS accessibility
statement. When this commit gets deployed to production, the
accessibility statement should be updated to reflect that this bug is
fixed.