### PR TITLE
HOCS-1980 Add skip link to header

### DIFF
--- a/src/shared/layouts/components/__tests__/__snapshots__/header.spec.js.snap
+++ b/src/shared/layouts/components/__tests__/__snapshots__/header.spec.js.snap
@@ -9,6 +9,12 @@ exports[`Layout header component should render with default props 1`] = `
   <div
     className="govuk-header__container govuk-width-container"
   >
+    <a
+      className="govuk-skip-link"
+      href="#main-content"
+    >
+      Skip to main content
+    </a>
     <div
       className="govuk-header__logo"
     >
@@ -88,6 +94,12 @@ exports[`Layout header component should render without crest when service is not
   <div
     className="govuk-header__container govuk-width-container"
   >
+    <a
+      className="govuk-skip-link"
+      href="#main-content"
+    >
+      Skip to main content
+    </a>
     <div
       className="govuk-header__logo"
     >

--- a/src/shared/layouts/components/header.jsx
+++ b/src/shared/layouts/components/header.jsx
@@ -7,6 +7,7 @@ class Header extends Component {
     createLogotype(service, serviceLink, bulkCreateEnabled) {
         return (
             <div className='govuk-header__container govuk-width-container'>
+                <a href='#main-content' className='govuk-skip-link'>Skip to main content</a>
                 <div className='govuk-header__logo'>
                     <span className='govuk-header__logotype'>
                         <Link to={serviceLink} className='govuk-header__link govuk-header__link--homepage govuk-header__logotype-text'>{service}</Link>


### PR DESCRIPTION
Prior to this commit, hocs-frontend failed WCAG 2.1 criterion 2.4.1
Bypass Blocks. This commit adds a skip link to the header, not visible
until focused, that allows users that navigate sequentially through
content more direct access to the primary content of the page.

This commit has implications for the DECS Accessibility Statement. When
this commit is merged to master, the accessibility statement should be
updated to remove references to failing WCAG 2.1 criterion 2.4.1.