### PR TITLE
HOCS-1996 - UKVI - when a second correspondent

### DIFF
--- a/src/shared/common/forms/composite/entity-list.jsx
+++ b/src/shared/common/forms/composite/entity-list.jsx
@@ -7,7 +7,8 @@ class EntityList extends Component {
 
     constructor(props) {
         super(props);
-        const fallbackValue = this.props.choices[0] ? this.props.choices[0].value : null;
+        const primaryChoice = this.props.choices ? this.props.choices.find(choice => choice.isPrimary === true) : null;
+        const fallbackValue = primaryChoice ? primaryChoice.value : this.props.choices[0] ? this.props.choices[0].value : null;
         const value = this.loadValue(this.props.value, this.props.choices) || fallbackValue;
         this.state = { ...props, value };
     }


### PR DESCRIPTION
- added missing logic that picks up on 'primary' property of
choice object in entity list. When primary flag is present and set
to 'true' the selection is defaulted to that object.

Leaving the existing logic behind means that when no primary flag is set
the first item will still be selected as per old solution.