### PR TITLE
HOCS-1970 : hide the Remove link when primary correspondent

### DIFF
--- a/server/services/forms/schemas/manage-people.js
+++ b/server/services/forms/schemas/manage-people.js
@@ -26,6 +26,7 @@ module.exports = async (options) => {
                 .withProp('hasEditLink', true)
                 .withProp('hasAddLink', true)
                 .withProp('hasRemoveLink', true)
+                .withProp('hideRemovePrimary', true)
                 .withProp('action', 'MANAGE_PEOPLE')
                 .withProp('type', 'radio')
                 .withProp('checkedValue', person.value)

--- a/src/shared/common/forms/composite/__tests__/__snapshots__/entity-list.spec.jsx.snap
+++ b/src/shared/common/forms/composite/__tests__/__snapshots__/entity-list.spec.jsx.snap
@@ -518,3 +518,96 @@ exports[`Entity list component should render with remove link when passed in pro
   </fieldset>
 </div>
 `;
+
+exports[`Entity list component should suppress remove link when passed in props 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="entity_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="entity_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <br />
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      >
+        <tr
+          class="govuk-radios govuk-table__row"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            <div
+              class="govuk-radios__item"
+            >
+              <input
+                checked=""
+                class="govuk-radios__input"
+                id="entity_list-CHOICE_A"
+                name="entity_list"
+                type="radio"
+                value="CHOICE_A"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+                for="entity_list-CHOICE_A"
+              >
+                Choice A
+              </label>
+            </div>
+          </td>
+          <td
+            class="govuk-table__cell"
+          />
+        </tr>
+        <tr
+          class="govuk-radios govuk-table__row"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            <div
+              class="govuk-radios__item"
+            >
+              <input
+                class="govuk-radios__input"
+                id="entity_list-CHOICE_B"
+                name="entity_list"
+                type="radio"
+                value="CHOICE_B"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+                for="entity_list-CHOICE_B"
+              >
+                Choice B
+              </label>
+            </div>
+          </td>
+          <td
+            class="govuk-table__cell"
+          >
+            <a
+              class="govuk-link"
+              href="/case/1234/stage/5678/entity/entity/CHOICE_B/remove?hideSidebar=false"
+            >
+              Remove
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </fieldset>
+</div>
+`;

--- a/src/shared/common/forms/composite/__tests__/entity-list.spec.jsx
+++ b/src/shared/common/forms/composite/__tests__/entity-list.spec.jsx
@@ -98,6 +98,27 @@ describe('Entity list component', () => {
         expect(WRAPPER).toMatchSnapshot();
     });
 
+    it('should suppress remove link when passed in props', () => {
+        const choice = value => ({ label: `Choice ${value}`, value: `CHOICE_${value}` });
+        const PROPS = {
+            ...DEFAULT_PROPS,
+            choices: [
+                choice('A'),
+                choice('B')
+            ],
+            hasRemoveLink: true,
+            hideRemovePrimary: true
+        };
+        const OUTER = shallow(<WrappedEntityList {...PROPS} />);
+        const EntityList = OUTER.props().children;
+        const WRAPPER = render(
+            <MemoryRouter>
+                <EntityList page={PAGE} />
+            </MemoryRouter>);
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+    });
+
     it('should render with edit link when passed in props', () => {
         const choice = value => ({ label: `Choice ${value}`, value: `CHOICE_${value}` });
         const PROPS = {

--- a/src/shared/common/forms/composite/entity-list.jsx
+++ b/src/shared/common/forms/composite/entity-list.jsx
@@ -10,6 +10,7 @@ class EntityList extends Component {
         const fallbackValue = this.props.choices[0] ? this.props.choices[0].value : null;
         const value = this.loadValue(this.props.value, this.props.choices) || fallbackValue;
         this.state = { ...props, value };
+        this.initialCheckedValue = this.props.checkedValue || this.state.value;
     }
 
     componentDidMount() {
@@ -41,6 +42,7 @@ class EntityList extends Component {
             hasAddLink,
             hasEditLink,
             hasRemoveLink,
+            hideRemovePrimary,
             hint,
             label,
             name,
@@ -86,7 +88,7 @@ class EntityList extends Component {
                                             <Link to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/${entity}/${choice.value}/update?hideSidebar=${hideSidebar}`} className="govuk-link">Edit</Link>
                                         </td>}
                                         <td className='govuk-table__cell'>
-                                            {hasRemoveLink && <Link to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/${entity}/${choice.value}/remove?hideSidebar=${hideSidebar}`} className="govuk-link">Remove</Link>}
+                                            {hasRemoveLink && (!hideRemovePrimary || choice.value !== this.initialCheckedValue) && <Link to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/${entity}/${choice.value}/remove?hideSidebar=${hideSidebar}`} className="govuk-link">Remove</Link>}
                                         </td>
                                     </tr>
                                 );
@@ -112,6 +114,7 @@ EntityList.propTypes = {
     hasAddLink: PropTypes.bool,
     hasEditLink: PropTypes.bool,
     hasRemoveLink: PropTypes.bool,
+    hideRemovePrimary: PropTypes.bool,
     hint: PropTypes.string,
     label: PropTypes.string,
     name: PropTypes.string.isRequired,
@@ -127,6 +130,7 @@ EntityList.propTypes = {
 EntityList.defaultProps = {
     choices: [],
     disabled: false,
+    hideRemovePrimary: false,
     type: 'radio',
     page: {},
     hideSidebar: false


### PR DESCRIPTION
Entity list now accepts new property "hideRemovePrimary" to hide the remove link against the primary (initially selected) list item.