### PR TITLE
HOCS-1970 : show the Remove link when primary correspondent isn't in …

### DIFF
--- a/src/shared/common/forms/composite/__tests__/__snapshots__/entity-list.spec.jsx.snap
+++ b/src/shared/common/forms/composite/__tests__/__snapshots__/entity-list.spec.jsx.snap
@@ -569,7 +569,14 @@ exports[`Entity list component should suppress remove link when passed in props 
           </td>
           <td
             class="govuk-table__cell"
-          />
+          >
+            <a
+              class="govuk-link"
+              href="/case/1234/stage/5678/entity/entity/CHOICE_A/remove?hideSidebar=false"
+            >
+              Remove
+            </a>
+          </td>
         </tr>
         <tr
           class="govuk-radios govuk-table__row"

--- a/src/shared/common/forms/composite/entity-list.jsx
+++ b/src/shared/common/forms/composite/entity-list.jsx
@@ -11,7 +11,7 @@ class EntityList extends Component {
         const fallbackValue = primaryChoice ? primaryChoice.value : this.props.choices[0] ? this.props.choices[0].value : null;
         const value = this.loadValue(this.props.value, this.props.choices) || fallbackValue;
         this.state = { ...props, value };
-        this.initialCheckedValue = this.props.checkedValue || this.state.value;
+        this.initialCheckedValue = this.props.checkedValue;
     }
 
     componentDidMount() {


### PR DESCRIPTION
…the database, making it editable on initial input, but still hidden when editing via People tab.