### PR TITLE
HOCS-2040: change to use 24 hour clock

### DIFF
--- a/server/lists/adapters/case-notes.js
+++ b/server/lists/adapters/case-notes.js
@@ -126,7 +126,8 @@ const formatDate = (rawDate) => {
         day: 'numeric',
         hour: 'numeric',
         minute: 'numeric',
-        timeZone: 'Europe/London'
+        timeZone: 'Europe/London',
+        hour12: false
     }).formatToParts(date)
         .reduce((parts, { type, value }) => {
             parts[type] = value;


### PR DESCRIPTION
Previously when looking at case notes in the timeline we showed the 12 hour clock. This could get unnecessarily confusing as a case note that is added at 7:31pm would just show 7:31 without the meridiem at the end, meaning the user could be confused as to whether this is AM/PM.

This update toggles the International Date Format to use 24 hour time so the previous example would show 19:31 instead of 7:31.