### PR TITLE
HOCS-2038: expandable checkbox no longer saves undefined

### DIFF
--- a/src/shared/common/forms/__tests__/expandable-checkbox.spec.js
+++ b/src/shared/common/forms/__tests__/expandable-checkbox.spec.js
@@ -105,10 +105,10 @@ describe('When the checkbox clicked', () => {
     });
 
     describe('And it is currently selected', () => {
-        it('should call the callback with undefined', () => {
+        it('should call the callback with empty', () => {
             const wrapper = mount(<ExpandableCheckbox choice={choice} data={{}} items={items} label="__label__" name="__name__" updateState={updateStateMock} value="__value__" />);
             wrapper.find('.govuk-checkboxes__input').at(0).simulate('change', { target: { value: '__value__' } });
-            expect(updateStateMock).toHaveBeenCalledWith({ '__name__': undefined });
+            expect(updateStateMock).toHaveBeenCalledWith({ '__name__': '' });
         });
     });
 });

--- a/src/shared/common/forms/expandable-checkbox.jsx
+++ b/src/shared/common/forms/expandable-checkbox.jsx
@@ -27,7 +27,7 @@ const expandableCheckbox = ({ choice, data, error, errors, hint, initiallyOpen, 
         setOpen(!isChecked);
 
         if (isChecked) {
-            updateState({ [name]: undefined });
+            updateState({ [name]: '' });
         } else {
             updateState({ [name]: targetValue });
         }


### PR DESCRIPTION
When unchecking a already selected expandable checkbox, previously this would save undefined as the value. Due to this the front-end summary page and the audit extracts show this value as undefined. This is not anticipated behaviour. This change fixes this by saving empty as the value, thus, fixing the summary page and the audit extraction.