### PR TITLE
HOCS-2004: Handle multiple data value keys for workstack

### DIFF
--- a/src/shared/common/components/__tests__/__snapshots__/workstack.spec.jsx.snap
+++ b/src/shared/common/components/__tests__/__snapshots__/workstack.spec.jsx.snap
@@ -408,14 +408,14 @@ exports[`Workstack component should render with filtering 1`] = `
             },
             Object {
               "dataAdapter": "localDate",
-              "dataValueKey": "created",
+              "dataValueKey": "TEST,created",
               "displayName": "Case Date",
               "isFilterable": true,
               "renderer": null,
             },
             Object {
               "dataAdapter": "indicator",
-              "dataValueKey": "isActive",
+              "dataValueKey": "isActive,TEST",
               "displayName": "Active",
               "isFilterable": true,
               "renderer": null,
@@ -695,13 +695,13 @@ exports[`Workstack component should render with filtering 1`] = `
                             </td>
                             <td
                               className="govuk-table__cell"
-                              key="stage_uuid-456created"
+                              key="stage_uuid-456TEST,created"
                             >
                               29/10/2019
                             </td>
                             <td
                               className="govuk-table__cell"
-                              key="stage_uuid-456isActive"
+                              key="stage_uuid-456isActive,TEST"
                             >
                               is Active
                             </td>
@@ -822,14 +822,14 @@ exports[`Workstack component should sort descending when the column heading is c
             },
             Object {
               "dataAdapter": "localDate",
-              "dataValueKey": "created",
+              "dataValueKey": "TEST,created",
               "displayName": "Case Date",
               "isFilterable": true,
               "renderer": null,
             },
             Object {
               "dataAdapter": "indicator",
-              "dataValueKey": "isActive",
+              "dataValueKey": "isActive,TEST",
               "displayName": "Active",
               "isFilterable": true,
               "renderer": null,
@@ -1109,11 +1109,11 @@ exports[`Workstack component should sort descending when the column heading is c
                             </td>
                             <td
                               className="govuk-table__cell"
-                              key="stage_uuid-444created"
+                              key="stage_uuid-444TEST,created"
                             />
                             <td
                               className="govuk-table__cell"
-                              key="stage_uuid-444isActive"
+                              key="stage_uuid-444isActive,TEST"
                             />
                           </tr>
                           <tr
@@ -1201,11 +1201,11 @@ exports[`Workstack component should sort descending when the column heading is c
                             </td>
                             <td
                               className="govuk-table__cell"
-                              key="stage_uuid-432created"
+                              key="stage_uuid-432TEST,created"
                             />
                             <td
                               className="govuk-table__cell"
-                              key="stage_uuid-432isActive"
+                              key="stage_uuid-432isActive,TEST"
                             />
                           </tr>
                           <tr
@@ -1293,13 +1293,13 @@ exports[`Workstack component should sort descending when the column heading is c
                             </td>
                             <td
                               className="govuk-table__cell"
-                              key="stage_uuid-456created"
+                              key="stage_uuid-456TEST,created"
                             >
                               29/10/2019
                             </td>
                             <td
                               className="govuk-table__cell"
-                              key="stage_uuid-456isActive"
+                              key="stage_uuid-456isActive,TEST"
                             >
                               is Active
                             </td>
@@ -1420,14 +1420,14 @@ exports[`Workstack component should sort when the column heading is clicked 1`] 
             },
             Object {
               "dataAdapter": "localDate",
-              "dataValueKey": "created",
+              "dataValueKey": "TEST,created",
               "displayName": "Case Date",
               "isFilterable": true,
               "renderer": null,
             },
             Object {
               "dataAdapter": "indicator",
-              "dataValueKey": "isActive",
+              "dataValueKey": "isActive,TEST",
               "displayName": "Active",
               "isFilterable": true,
               "renderer": null,
@@ -1707,13 +1707,13 @@ exports[`Workstack component should sort when the column heading is clicked 1`] 
                             </td>
                             <td
                               className="govuk-table__cell"
-                              key="stage_uuid-456created"
+                              key="stage_uuid-456TEST,created"
                             >
                               29/10/2019
                             </td>
                             <td
                               className="govuk-table__cell"
-                              key="stage_uuid-456isActive"
+                              key="stage_uuid-456isActive,TEST"
                             >
                               is Active
                             </td>
@@ -1803,11 +1803,11 @@ exports[`Workstack component should sort when the column heading is clicked 1`] 
                             </td>
                             <td
                               className="govuk-table__cell"
-                              key="stage_uuid-432created"
+                              key="stage_uuid-432TEST,created"
                             />
                             <td
                               className="govuk-table__cell"
-                              key="stage_uuid-432isActive"
+                              key="stage_uuid-432isActive,TEST"
                             />
                           </tr>
                           <tr
@@ -1895,11 +1895,11 @@ exports[`Workstack component should sort when the column heading is clicked 1`] 
                             </td>
                             <td
                               className="govuk-table__cell"
-                              key="stage_uuid-444created"
+                              key="stage_uuid-444TEST,created"
                             />
                             <td
                               className="govuk-table__cell"
-                              key="stage_uuid-444isActive"
+                              key="stage_uuid-444isActive,TEST"
                             />
                           </tr>
                         </tbody>

--- a/src/shared/common/components/__tests__/workstack.spec.jsx
+++ b/src/shared/common/components/__tests__/workstack.spec.jsx
@@ -39,8 +39,8 @@ describe('Workstack component', () => {
             { displayName: 'Current Stage', dataAdapter: null, renderer: null, dataValueKey: 'stageTypeDisplay', isFilterable: true },
             { displayName: 'Owner', dataAdapter: null, renderer: null, dataValueKey: 'assignedUserDisplay', isFilterable: true },
             { displayName: 'Team', dataAdapter: null, renderer: null, dataValueKey: 'assignedTeamDisplay', isFilterable: true },
-            { displayName: 'Case Date', dataAdapter: 'localDate', renderer: null, dataValueKey: 'created', isFilterable: true },
-            { displayName: 'Active', dataAdapter: 'indicator', renderer: null, dataValueKey: 'isActive', isFilterable: true }
+            { displayName: 'Case Date', dataAdapter: 'localDate', renderer: null, dataValueKey: 'TEST,created', isFilterable: true },
+            { displayName: 'Active', dataAdapter: 'indicator', renderer: null, dataValueKey: 'isActive,TEST', isFilterable: true }
         ],
         selectable: true,
         baseUrl: 'base.url',


### PR DESCRIPTION
As a result of requested change by WCS, the capability to have multiple data_value_keys has been added. This allows the user to specify a data_value_key and if it is present it will show. If the key is not present it will then fallback to the next and so forth. 

Tests have been updated to resemble this new functionality.