### PR TITLE
HOCS-1990: remove unnecessary ES file

### DIFF
--- a/docker/scripts/services.sh
+++ b/docker/scripts/services.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 echo "Pulling latest and setting up services"
-curl -X PUT http://localstack:4571/local-case -H "Content-Type: application/json" -d @elastic-search-index.json
 docker-compose up documents audit workflow casework info search templates


### PR DESCRIPTION
As a result of the elastic search index being moved to our private repo, we no longer have a need to instantiate with this empty file. General cleanup.