### PR TITLE
HOCS-1897 Disabled fields have too low contrast

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -41,9 +41,13 @@ $govuk-font-family-tabular: 'helvetica neue',Arial, Helvetica, sans-serif !defau
   padding: 10px;
 }
 
-.govuk-input:disabled, .govuk-textarea:disabled{
-  background-color: govuk-colour("grey-4");
-  border-color: govuk-colour("grey-4");
+.govuk-input:disabled, .govuk-textarea:disabled {
+  /* This overrides the .govuk-input styles and browser styles
+     and make them just look like a <p> */
+  background-color: inherit;
+  border: inherit;
+  color: inherit;
+  padding: inherit;
 }
 
 // Code block styling:


### PR DESCRIPTION
We previously (HOCS-754) overrode the style of disabled fields to be
more consistent with the rest of DECS and the GOV.UK style.

However, the new styles failed WCAG 2.1 contrast ratios. The browser
style also seems to fail that standard, so this commit makes disabled
text fields -- which are only used in DECS to relay information to the
user about previously set fields they cannot change -- look more like
<p> or <dt> elements. This successfully conveys to the user the message
that these fields cannot be changed, while ensuring we comply with the
contrast ratio.

This commit has implications for the DECS accessibility statement, which
needs to be amended to remove references to the problem this commit
fixes.