### PR TITLE
HOCS-1853: add the Standard Lines page with routing

### DIFF
--- a/server/clients/index.js
+++ b/server/clients/index.js
@@ -5,6 +5,7 @@ const {
     WORKFLOW_SERVICE,
     INFO_SERVICE,
     TEMPLATES_SERVICE,
+    DOCUMENT_SERVICE,
     WORKFLOW_BASIC_AUTH
 } = require('../config').forContext('server');
 
@@ -28,9 +29,15 @@ const templatesService = createClient({
     auth: WORKFLOW_BASIC_AUTH
 });
 
+const documentService = createClient({
+    baseURL: DOCUMENT_SERVICE,
+    auth: WORKFLOW_BASIC_AUTH
+});
+
 module.exports = {
     caseworkService,
     workflowService,
     infoService,
-    templatesService
+    templatesService,
+    documentService
 };

--- a/server/config.js
+++ b/server/config.js
@@ -10,6 +10,7 @@ const config = {
             CASEWORK_SERVICE: process.env.CASEWORK_SERVICE || 'http://localhost:8082',
             INFO_SERVICE: process.env.INFO_SERVICE || 'http://localhost:8085',
             TEMPLATES_SERVICE: process.env.TEMPLATES_SERVICE || 'http://localhost:8090',
+            DOCUMENT_SERVICE: process.env.DOCUMENT_SERVICE || 'http://localhost:8083',
             DOCUMENT_WHITELIST: (process.env.ALLOWED_FILE_EXTENSIONS || 'txt,doc,docx,tiff,tif,xlsx,pdf').split(',').map(extension => extension.trim()),
             DOCUMENT_BULK_LIMIT: process.env.DOCUMENT_BULK_LIMIT || 40,
             VALID_DAYS_RANGE: process.env.VALID_DAYS_RANGE || 180

--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -283,6 +283,11 @@ module.exports = {
             endpoint: '/case/${caseId}/correspondentType',
             adapter: correspondentTypeAdapter
         },
+        TOPICS: {
+            client: 'INFO',
+            endpoint: '/topics',
+            type: listService.types.DYNAMIC,
+        },
         TOPICS_USER: {
             client: 'INFO',
             endpoint: '/topics/MIN',
@@ -354,7 +359,12 @@ module.exports = {
             client: 'WORKFLOW',
             endpoint: '/case/details/${caseId}',
             adapter: caseViewReadOnlyAdapter
-        }
+        },
+        DCU_POLICY_TEAM_FOR_TOPIC: {
+            client: 'INFO',
+            endpoint: '/team/topic/stage/DCU_DTEN_INITIAL_DRAFT',
+            type: listService.types.DYNAMIC,
+        },
     },
     clients: {
         CASEWORK: caseworkService,

--- a/server/middleware/__tests__/standardLines.spec.js
+++ b/server/middleware/__tests__/standardLines.spec.js
@@ -1,0 +1,130 @@
+const {
+    getUsersStandardLines,
+    getOriginalDocument,
+} = require('./../standardLine');
+
+jest.mock('../../clients/index');
+jest.mock('../../models/user');
+const { infoService, documentService } = require('../../clients/index');
+const User = require('../../models/user');
+
+const next = jest.fn();
+let req = {};
+let res = {};
+
+const mockUser = { username: 'TEST_USER', uuid: 'TEST', roles: [], groups: [] };
+const headers = '__headers__';
+
+describe('standard lines middlware', () => {
+
+    describe('getUsersStandardLines is called', () => {
+
+        const MOCK_STANDARD_LINE = {
+            data: [{
+                uuid: 'test',
+                displayName: 'test',
+                topicUUID: 'test',
+                expires: '9999-12-31',
+                documentUUID: 'test'
+            }]
+        };
+
+        beforeEach(() => {
+            next.mockReset();
+            req = {
+                listService: {
+                    fetch: jest.fn(async (list) => {
+                        if (list === 'TOPICS') {
+                            return Promise.resolve(['MOCK_TOPICS']);
+                        } else if (list === 'DCU_POLICY_TEAM_FOR_TOPIC') {
+                            return Promise.resolve(['MOCK_TEAMS']);
+                        }
+                        return Promise.reject();
+                    })
+                },
+                user: mockUser,
+                requestId: 'reqid',
+            };
+            res = {
+                locals: {}
+            };
+        });
+
+        it('should call next with an error if unable to retrieve topics data', async () => {
+            req.listService.fetch.mockImplementation(() => Promise.reject('MOCK_ERROR'));
+            await getUsersStandardLines(req, res, next);
+            expect(res.locals.standardLines).not.toBeDefined();
+            expect(next).toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith('MOCK_ERROR');
+        });
+
+        it('should call next with an error if unable to retrieve topics data', async () => {
+            req.listService.fetch.mockImplementation((list ) => {
+                if (list === 'TOPICS') {
+                    return Promise.resolve(['MOCK_TOPICS']);
+                }
+                return Promise.reject('MOCK_ERROR');
+            });
+            await getUsersStandardLines(req, res, next);
+            expect(res.locals.standardLines).not.toBeDefined();
+            expect(next).toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith('MOCK_ERROR');
+        });
+
+        it('should call the user create headers method', async () => {
+            await getUsersStandardLines(req, res, next);
+            expect(User.createHeaders).toHaveBeenCalled();
+        });
+
+        it('should call the get method on the info service', async () => {
+            User.createHeaders.mockImplementation(() => headers);
+            await getUsersStandardLines(req, res, next);
+            expect(infoService.get).toHaveBeenCalledWith(`/user/${req.user.uuid}/standardLine`, { }, { headers: headers });
+        });
+
+        it('should call the get method on the info service', async () => {
+            User.createHeaders.mockImplementation(() => headers);
+            infoService.get.mockImplementation(() => Promise.resolve(MOCK_STANDARD_LINE));
+            await getUsersStandardLines(req, res, next);
+            expect(infoService.get).toHaveBeenCalledWith(`/user/${req.user.uuid}/standardLine`, { }, { headers: headers });
+            expect(res.locals.standardLines).toEqual(
+                [{ 'displayName': 'test', 'documentUUID': 'test', 'expiryDate': '31/12/9999','isExpired': false,'team': 'test','topic': 'test','uuid': 'test' }]
+            );
+            expect(next).toHaveBeenCalled();
+        });
+    });
+
+    describe('getOriginalDocument is called', () => {
+
+        const mockResponse = { data: {}, headers: { 'content-disposition': 'TEST' } };
+
+        beforeEach(() => {
+            next.mockReset();
+            req = { params: { documentId: '1234' }, user: mockUser };
+            res = { setHeader: jest.fn() };
+            mockResponse.status = 200;
+            mockResponse.data.on = jest.fn();
+            mockResponse.data.pipe = jest.fn();
+        });
+
+        it('should pipe the response on success', async () => {
+            documentService.get.mockImplementation(() => Promise.resolve(mockResponse));
+            await getOriginalDocument(req, res, next);
+            expect(documentService.get).toHaveBeenCalled();
+            expect(documentService.get).toHaveBeenCalledWith(`/document/${req.params.documentId}/file`, { headers:headers, responseType: 'stream' });
+            expect(res.setHeader).toHaveBeenCalled();
+            expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'max-age=86400');
+            expect(mockResponse.data.pipe).toHaveBeenCalled();
+            expect(mockResponse.data.pipe).toHaveBeenCalledWith(res);
+        });
+
+        it('should call next with an error if request fails', async () => {
+            const mockError = new Error('Unable to retrieve original document');
+            documentService.get.mockImplementation(() => Promise.reject(mockError));
+            await getOriginalDocument(req, res, next);
+            expect(next).toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith(mockError);
+        });
+
+    });
+});

--- a/server/middleware/standardLine.js
+++ b/server/middleware/standardLine.js
@@ -1,0 +1,93 @@
+const { infoService, documentService } = require('../clients');
+const { DocumentError } = require('../models/error');
+const User = require('../models/user');
+const getLogger = require('../libs/logger');
+
+
+const getUsersStandardLines = async (req, res, next) => {
+    const logger = getLogger(req.requestId);
+    const userUUID = req.user.uuid;
+
+    try {
+        logger.info('REQUEST_USER_STANDARD_LINES', { ...req.params });
+
+        const topicList = await req.listService.fetch('TOPICS', req.params);
+        const policyTeamForTopicList = await req.listService.fetch('DCU_POLICY_TEAM_FOR_TOPIC', req.params);
+
+        const response = await infoService.get(`/user/${userUUID}/standardLine`, {}, { headers: User.createHeaders(req.user) });
+        res.locals.standardLines = response.data.map(({ uuid, displayName, topicUUID, expires, documentUUID }) => {
+            const expiry = formatDate(expires);
+            return ({
+                uuid: uuid, documentUUID: documentUUID, displayName: displayName, topic: getLabelForValue(topicList, topicUUID),
+                expiryDate: expiry, isExpired: deriveIsExpired(expiry), team: getLabelForValue(policyTeamForTopicList, topicUUID)
+            });
+        });
+        next();
+    } catch (error) {
+        logger.error('REQUEST_USER_STANDARD_LINES_FAILURE', { message: error.message, stack: error.stack });
+        next(error);
+    }
+}
+
+const getOriginalDocument = async (req, res, next) => {
+    const logger = getLogger(req.requestId);
+    const { documentId } = req.params;
+    let options = {
+        headers: User.createHeaders(req.user),
+        responseType: 'stream'
+    };
+    logger.info('REQUEST_DOCUMENT_ORIGINAL', { ...req.params });
+    try {
+        const response = await documentService.get(`/document/${documentId}/file`, options);
+        res.setHeader('Cache-Control', 'max-age=86400');
+        res.setHeader('Content-Disposition', response.headers['content-disposition']);
+        response.data.on('finish', () => logger.debug('REQUEST_DOCUMENT_ORIGINAL_SUCCESS', { ...req.params }));
+        response.data.pipe(res);
+    } catch (error) {
+        logger.error('REQUEST_DOCUMENT_ORIGINAL_FAILURE', { ...req.params });
+        return next(new DocumentError('Unable to retrieve original document'));
+    }
+};
+
+const standardLinesApiResponseMiddleware = (_, res) => {
+    res.json(res.locals.standardLines);
+};
+
+const getLabelForValue = (list, value) => {
+    if (list && value) {
+        for (var i = 0; i < list.length; i++) {
+            if (list[i].value === value) {
+                return list[i].label;
+            }
+        }
+    }
+
+    return value;
+};
+
+const deriveIsExpired = (expiry) => {
+    if (expiry) {
+        const splitDate = expiry.split('/');
+        const expiryDate = new Date(parseInt(splitDate[2], 10), parseInt(splitDate[1], 10) - 1, parseInt(splitDate[0], 10));
+
+        return new Date(expiryDate) <= new Date();
+    }
+
+    return false;
+};
+
+const parseDate = (rawDate) => {
+    const [date] = rawDate.match(/\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])/g) || [];
+    if (!date) {
+        return null;
+    }
+    const [year, month, day] = date.split('-');
+    return `${day}/${month}/${year}`;
+};
+const formatDate = (date) => date ? parseDate(date) : null;
+
+module.exports = {
+    getUsersStandardLines,
+    getOriginalDocument,
+    standardLinesApiResponseMiddleware
+};

--- a/server/routes/api/index.js
+++ b/server/routes/api/index.js
@@ -5,6 +5,7 @@ const apiActionRouter = require('./action');
 const apiCaseRouter = require('./case');
 const apiWorkstackRouter = require('./workstack');
 const apiKeepaliveRouter = require('./keepalive');
+const apiStandardLines = require('./standardLines');
 const { apiErrorMiddleware } = require('../../middleware/request');
 
 router.use('/form', apiFormRouter);
@@ -13,6 +14,7 @@ router.use('/action', apiActionRouter);
 router.use('/case', apiCaseRouter);
 router.use('/workstack', apiWorkstackRouter);
 router.use('/keepalive', apiKeepaliveRouter);
+router.use('/standard-lines', apiStandardLines);
 
 router.use('*', apiErrorMiddleware);
 

--- a/server/routes/api/standardLines.js
+++ b/server/routes/api/standardLines.js
@@ -1,0 +1,8 @@
+const router = require('express').Router();
+const { getUsersStandardLines, getOriginalDocument, standardLinesApiResponseMiddleware } = require('../../middleware/standardLine.js');
+
+router.get('/', getUsersStandardLines, standardLinesApiResponseMiddleware);
+
+router.get('/download/:documentId', getOriginalDocument);
+
+module.exports = router;

--- a/server/tenantConfig.js
+++ b/server/tenantConfig.js
@@ -23,7 +23,8 @@ async function layoutConfig() {
             logoLinkTitle: '',
             propositionHeader: '',
             propositionHeaderLink: '/',
-            bulkCreateEnabled: configuration.bulkCreateEnabled
+            bulkCreateEnabled: configuration.bulkCreateEnabled,
+            viewStandardLinesEnabled: configuration.viewStandardLinesEnabled
         },
         body: {
             phaseBanner: {
@@ -60,7 +61,6 @@ async function fetchConfiguration() {
     const listServiceInstance = listService.getInstance(uuid(), null);
     return listServiceInstance.fetch('S_SYSTEM_CONFIGURATION');
 }
-
 
 module.exports = {
     renderConfig, layoutConfig

--- a/src/shared/contexts/application.jsx
+++ b/src/shared/contexts/application.jsx
@@ -7,9 +7,6 @@ import types from './actions/types.jsx';
 export const Context = React.createContext();
 
 const reducer = (state, action) => {
-    // TODO: REMOVE
-    /* eslint-disable-next-line  no-console*/
-    console.log(`ACTION: ${action.type} PAYLOAD: ${JSON.stringify(action.payload)}`);
     // ------------
     switch (action.type) {
         case types.UPDATE_FORM:

--- a/src/shared/helpers/api-status.js
+++ b/src/shared/helpers/api-status.js
@@ -43,6 +43,9 @@ const status = {
     REQUEST_WORKSTACK_DATA_FAILURE: { display: 'Unable to fetch workstack', level: 0, type: 'ERROR', timeoutPeriod: timeout.ERROR },
     UPDATE_WORKSTACK_DATA_SUCCESS: { display: 'Updating workstack', level: 3, type: 'OK', timeoutPeriod: timeout.STANDARD },
     UPDATE_WORKSTACK_DATA_FAILURE: { display: 'Failed to update workstack', level: 0, type: 'ERROR', timeoutPeriod: timeout.ERROR },
+    REQUEST_STANDARD_LINES_DATA: { display: 'Requesting standard lines', level: 1, type: 'OK', timeoutPeriod: timeout.STANDARD },
+    REQUEST_STANDARD_LINES_DATA_SUCCESS: { display: 'Standard lines received', level: 3, type: 'OK', timeoutPeriod: timeout.ERROR },
+    REQUEST_STANDARD_LINES_DATA_FAILURE: { display: 'Unable to fetch standard lines', level: 0, type: 'ERROR', timeoutPeriod: timeout.ERROR },
 };
 
 export default status;

--- a/src/shared/layouts/components/header.jsx
+++ b/src/shared/layouts/components/header.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 class Header extends Component {
 
-    createLogotype(service, serviceLink, bulkCreateEnabled) {
+    createLogotype(service, serviceLink, bulkCreateEnabled, viewStandardLinesEnabled) {
         return (
             <div className='govuk-header__container govuk-width-container'>
                 <a href='#main-content' className='govuk-skip-link'>Skip to main content</a>
@@ -23,6 +23,9 @@ class Header extends Component {
                                 <Link to='/action/bulk/workflow' className='govuk-header__link'>Create Bulk Cases</Link>
                             </li>
                             }
+                            {viewStandardLinesEnabled && <li className='govuk-header__navigation-item'>
+                                <Link to='/view-standard-lines' className='govuk-header__link'>View Standard Lines</Link>
+                            </li>}
                             <li className='govuk-header__navigation-item'>
                                 <Link to='/search' className='govuk-header__link'>Search</Link>
                             </li>
@@ -37,10 +40,10 @@ class Header extends Component {
     }
 
     render() {
-        const { service, serviceLink, bulkCreateEnabled } = this.props;
+        const { service, serviceLink, bulkCreateEnabled, viewStandardLinesEnabled } = this.props;
         return (
             <header className='govuk-header ' role='banner' data-module='header'>
-                {this.createLogotype(service, serviceLink, bulkCreateEnabled)}
+                {this.createLogotype(service, serviceLink, bulkCreateEnabled, viewStandardLinesEnabled)}
             </header>
         );
     }
@@ -50,7 +53,8 @@ class Header extends Component {
 Header.propTypes = {
     service: PropTypes.string.isRequired,
     serviceLink: PropTypes.string.isRequired,
-    bulkCreateEnabled: PropTypes.bool.isRequired
+    bulkCreateEnabled: PropTypes.bool.isRequired,
+    viewStandardLinesEnabled: PropTypes.bool.isRequired
 };
 
 Header.defaultProps = {

--- a/src/shared/pages/__tests__/__snapshots__/snapshot.spec.jsx.snap
+++ b/src/shared/pages/__tests__/__snapshots__/snapshot.spec.jsx.snap
@@ -1,0 +1,229 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Workstack page component should render with default props 1`] = `
+<Component
+  dispatch={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          undefined,
+        ],
+        Array [
+          undefined,
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": Promise {},
+        },
+        Object {
+          "type": "return",
+          "value": Promise {},
+        },
+      ],
+    }
+  }
+  track={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          "PAGE_VIEW",
+          Object {
+            "path": "/standard-lines",
+            "title": undefined,
+          },
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+>
+  <StandardLinesView
+    dispatch={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            undefined,
+          ],
+          Array [
+            undefined,
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+          Object {
+            "type": "return",
+            "value": Promise {},
+          },
+        ],
+      }
+    }
+    match={
+      Object {
+        "url": "/standard-lines",
+      }
+    }
+    track={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "PAGE_VIEW",
+            Object {
+              "path": "/standard-lines",
+              "title": undefined,
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
+  >
+    <div
+      className="govuk-form-group"
+    >
+      <div>
+        <h1
+          className="govuk-heading-xl"
+        >
+          View standard lines
+        </h1>
+        <div>
+          <div
+            className="govuk-grid-row"
+          >
+            <div
+              className="govuk-grid-column-one-third"
+            >
+              <div
+                className="govuk-form-group filter-row"
+              >
+                <Text
+                  autoFocus={true}
+                  disabled={false}
+                  label="Filter"
+                  name="filter"
+                  type="text"
+                  updateState={[Function]}
+                  value=""
+                >
+                  <div
+                    className="govuk-form-group "
+                  >
+                    <label
+                      className="govuk-label govuk-label--s"
+                      htmlFor="filter"
+                      id="filter-label"
+                    >
+                      Filter
+                    </label>
+                    <div>
+                      <input
+                        className="govuk-input"
+                        disabled={false}
+                        id="filter"
+                        name="filter"
+                        onChange={[Function]}
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </Text>
+                <span
+                  aria-live="polite"
+                  className="govuk-hint"
+                >
+                  0 Items
+                </span>
+              </div>
+              <div
+                className="govuk-grid-row margin-bottom--small"
+              >
+                <div
+                  className="govuk-grid-column-two-thirds govuk-label--s padding-top--small"
+                >
+                  Exclude expired
+                </div>
+                <div
+                  className="govuk-grid-column-one-third bigger"
+                >
+                  <input
+                    checked={true}
+                    name="excludeExpired"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="scrollableTable"
+          >
+            <table
+              className="govuk-table"
+            >
+              <thead
+                className="govuk-table__head"
+              >
+                <tr
+                  className="govuk-table__row"
+                >
+                  <th
+                    className="govuk-table__header"
+                    scope="col"
+                  >
+                    Topic
+                  </th>
+                  <th
+                    className="govuk-table__header"
+                    scope="col"
+                  >
+                    Team
+                  </th>
+                  <th
+                    className="govuk-table__header"
+                    scope="col"
+                  >
+                    Filename
+                  </th>
+                  <th
+                    className="govuk-table__header"
+                    scope="col"
+                  >
+                    Expiry date
+                  </th>
+                  <th
+                    className="govuk-table__header"
+                    scope="col"
+                  >
+                    Action
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                className="govuk-table__body"
+              />
+            </table>
+          </div>
+        </div>
+        <br />
+      </div>
+    </div>
+  </StandardLinesView>
+</Component>
+`;

--- a/src/shared/pages/__tests__/snapshot.spec.jsx
+++ b/src/shared/pages/__tests__/snapshot.spec.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+const BASE_URL = '/api';
+const MOCK_MATCH = { url: '/standard-lines' };
+
+jest.mock('axios', () => ({
+    get: jest.fn((url) => {
+        switch (url) {
+            case '/user/__TEST__/standardLine':
+                return Promise.resolve({
+                    data: [{
+                        uuid: 'test',
+                        displayName: 'test',
+                        topicUUID: 'test',
+                        expires: '9999-12-31',
+                        documentUUID: 'test'
+                    }]
+                });
+            default:
+                return Promise.reject({
+                    response: {
+                        data: {}
+                    }
+                });
+        }
+    })
+}));
+jest.mock('../../contexts/actions/index.jsx', () => ({
+    updateApiStatus: jest.fn(),
+    clearApiStatus: jest.fn(),
+}));
+
+import axios from 'axios';
+import WrappedStandardLines from '../standardLines/standardLinesView.jsx';
+const FLUSH_PROMISES = () => new Promise(resolve => setImmediate(resolve));
+
+describe('Workstack page component', () => {
+
+    const MOCK_DISPATCH = jest.fn();
+    const MOCK_TRACK = jest.fn();
+
+    beforeEach(() => {
+        MOCK_DISPATCH.mockReset();
+        MOCK_TRACK.mockReset();
+        MOCK_DISPATCH.mockReturnValue(Promise.resolve());
+        axios.get.mockClear();
+    });
+
+    it('should render with default props', async () => {
+        const OUTER = shallow(<WrappedStandardLines match={MOCK_MATCH}/>);
+        const StandardLinesPage = OUTER.props().children;
+        const WRAPPER = mount(
+            <StandardLinesPage dispatch={MOCK_DISPATCH} track={MOCK_TRACK} />
+        );
+        await FLUSH_PROMISES();
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+        expect(MOCK_DISPATCH).toHaveBeenCalled();
+        expect(axios.get).toHaveBeenCalled();
+        expect(axios.get).toHaveBeenCalledWith(BASE_URL + MOCK_MATCH.url);
+    });
+});

--- a/src/shared/pages/standardLines/standardLinesReducer.js
+++ b/src/shared/pages/standardLines/standardLinesReducer.js
@@ -1,0 +1,46 @@
+const reducer = (state, action) => {
+    switch (action.type) {
+        case 'PopulateStandardLines':
+            return { ...state, allStandardLines: action.payload, activeStandardLines: filterLines(action.payload, state.filter.toUpperCase(), state.excludeExpired), standardLinesLoaded: true };
+        case 'FilterStandardLines':
+            return { ...state, filter: action.payload, activeStandardLines: filterLines(state.allStandardLines, action.payload.toUpperCase(), state.excludeExpired) };
+        case 'ExcludeExpiredCheckTrigger':
+            return { ...state, excludeExpired: action.payload, activeStandardLines: filterLines(state.allStandardLines, state.filter.toUpperCase(), action.payload) };
+    }
+    return state;
+};
+
+const filterLines = (standardLines, filter, excludeExpired) => {
+    let filteredStandardLines = standardLines;
+    if (standardLines && filter) {
+        filteredStandardLines = [];
+        for (let i = 0; i < standardLines.length; i += 1) {
+            const standardLine = standardLines[i];
+            if (doesFilterMatchValue(standardLine.topic, filter) || doesFilterMatchValue(standardLine.displayName, filter)
+                || doesFilterMatchValue(standardLine.expiryDate, filter) || doesFilterMatchValue(standardLine.team, filter)) {
+                filteredStandardLines.push(standardLine);
+            }
+        }
+    }
+    return excludeExpired ? removeExpiredStarndardLines(filteredStandardLines) : filteredStandardLines;
+};
+
+const doesFilterMatchValue = (value, filter) => {
+    return value && filter && value.toUpperCase && value.toUpperCase().indexOf(filter) !== -1;
+};
+
+const removeExpiredStarndardLines = (standardLines) => {
+    if (standardLines) {
+        const filteredStandardLines = [];
+        for (let i = 0; i < standardLines.length; i += 1) {
+            const standardLine = standardLines[i];
+            if (!standardLine.isExpired) {
+                filteredStandardLines.push(standardLine);
+            }
+        }
+        return filteredStandardLines;
+    }
+    return standardLines;
+};
+
+export default reducer;

--- a/src/shared/pages/standardLines/standardLinesView.jsx
+++ b/src/shared/pages/standardLines/standardLinesView.jsx
@@ -1,0 +1,160 @@
+import React, { Fragment, useEffect, useReducer } from 'react';
+import PropTypes from 'prop-types';
+import { clearApiStatus, updateApiStatus } from '../../contexts/actions/index.jsx';
+import { ApplicationConsumer } from '../../contexts/application.jsx';
+import reducer from './standardLinesReducer';
+import axios from 'axios';
+import status from '../../helpers/api-status.js';
+import Text from '../../common/forms/text.jsx';
+
+const StandardLinesView = (props) => {
+
+    const [state, reducerDispatch] = useReducer(reducer, initialState);
+
+    useEffect(() => {
+        const { track, title, match } = props;
+        loadStandardLines();
+        track('PAGE_VIEW', { title, path: match.url });
+    }, []);
+
+    const loadStandardLines = () =>  {
+        const { dispatch } = props;
+
+        dispatch(updateApiStatus(status.REQUEST_STANDARD_LINES_DATA))
+            .then(() => {
+                axios.get('/api/standard-lines')
+                    .then(response => {
+                        dispatch(updateApiStatus(status.REQUEST_STANDARD_LINES_DATA_SUCCESS))
+                            .then(() => reducerDispatch({ type: 'PopulateStandardLines', payload: response.data }))
+                            .then(() => dispatch(clearApiStatus()))
+                            .catch(() => {
+                                dispatch(updateApiStatus(status.REQUEST_STANDARD_LINES_DATA_FAILURE));
+                            });
+                    })
+                    .catch(() => {
+                        dispatch(updateApiStatus(status.REQUEST_STANDARD_LINES_DATA_FAILURE));
+                    });
+            });
+    };
+
+    const RenderFilter = () => {
+        return (<div className="govuk-grid-row">
+            <div className="govuk-grid-column-one-third">
+                <div className="govuk-form-group filter-row">
+                    <Text
+                        label="Filter"
+                        name="filter"
+                        type="text"
+                        updateState={(inputEvent) => reducerDispatch({ type: 'FilterStandardLines', payload: inputEvent.filter })}
+                        value={state.filter}
+                        autoFocus={true}
+                    />
+                    <span className="govuk-hint" aria-live="polite">
+                        {`${state.activeStandardLines.length} Items`}
+                    </span>
+                </div>
+                <div className="govuk-grid-row margin-bottom--small">
+                    <div className="govuk-grid-column-two-thirds govuk-label--s padding-top--small">Exclude expired</div>
+                    <div className="govuk-grid-column-one-third bigger">
+                        <input
+                            name="excludeExpired"
+                            type="checkbox"
+                            checked={state.excludeExpired}
+                            onChange={event => reducerDispatch({ type: 'ExcludeExpiredCheckTrigger', payload: event.target.checked })}
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>);
+    };
+
+    const DisplayStandardLinesTable = () => {
+        return (<Fragment>
+            {state.activeStandardLines && RenderFilter()}
+            {state.activeStandardLines && (
+                <div className="scrollableTable">
+
+                    < table className="govuk-table">
+                        <thead className="govuk-table__head">
+                            <tr className="govuk-table__row">
+                                <th className="govuk-table__header" scope="col">Topic</th>
+                                <th className="govuk-table__header" scope="col">Team</th>
+                                <th className="govuk-table__header" scope="col">Filename</th>
+                                <th className="govuk-table__header" scope="col">Expiry date</th>
+                                <th className="govuk-table__header" scope="col">Action</th>
+                            </tr>
+                        </thead>
+                        <tbody className="govuk-table__body">
+                            {
+                                state.activeStandardLines.map((standardLine) => {
+                                    return (
+                                        <tr className="govuk-table__row" key={standardLine.uuid}>
+                                            <td className="govuk-table__cell">{standardLine.topic}</td>
+                                            <td className="govuk-table__cell">{standardLine.team}</td>
+                                            <td className="govuk-table__cell">{standardLine.displayName}</td>
+                                            {RenderExpiryDateCell(standardLine)}
+                                            <td className="govuk-table__cell govuk-!-width-one-quarter">
+                                                <span>
+                                                    <a href={`/api/standard-lines/download/${standardLine.documentUUID}`} className="govuk-link">Download</a>
+                                                </span>
+                                            </td>
+                                        </tr>
+                                    );
+                                })
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            )
+            }
+        </Fragment >);
+    };
+
+    const RenderExpiryDateCell = (standardLine) => {
+        if (standardLine.isExpired) {
+            return <td className="govuk-table__cell date-warning"><span>{standardLine.expiryDate}</span></td>;
+        }
+        return <td className="govuk-table__cell date-standard"><span>{standardLine.expiryDate}</span></td>;
+    };
+
+
+    return (<div className="govuk-form-group">
+        <div>
+            <h1 className="govuk-heading-xl">View standard lines</h1>
+            { state.activeStandardLines ?
+                <div>
+                    {DisplayStandardLinesTable()}
+                </div> :
+                <div>
+                    <p className="govuk-body">Loading...</p>
+                </div>
+            }
+            <br />
+        </div>
+    </div>);
+};
+
+const initialState = {
+    allStandardLines: [],
+    activeStandardLines: [],
+    standardLinesLoaded: false,
+    filter: '',
+    excludeExpired: true
+};
+
+StandardLinesView.propTypes = {
+    dispatch: PropTypes.func.isRequired,
+    match: PropTypes.object.isRequired,
+    track: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired,
+};
+
+const WrappedStandardLines = (props) => (
+    <ApplicationConsumer>
+        {({ dispatch, track }) => (
+            <StandardLinesView {...props} track={track} dispatch={dispatch} />
+        )}
+    </ApplicationConsumer>
+);
+
+export default WrappedStandardLines;

--- a/src/shared/router/routes/index.js
+++ b/src/shared/router/routes/index.js
@@ -5,6 +5,7 @@ import Error from '../../layouts/error.jsx';
 import MainPage from '../../pages/dashboard.jsx';
 import WorkstackPage from '../../pages/workstack.jsx';
 import Search from '../../pages/search.jsx';
+import StandardLinesView from '../../pages/standardLines/standardLinesView.jsx';
 
 const routes = [
     {
@@ -116,6 +117,12 @@ const routes = [
         exact: true,
         component: WorkstackPage,
         title: 'Stage Workstack'
+    },
+    {
+        path: '/view-standard-lines',
+        exact: true,
+        component: StandardLinesView,
+        title: 'View Standard Lines'
     },
     {
         component: Error,

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -370,20 +370,28 @@ a.card__body {
   background-color: tint(#B10E1E, 20%);
 }
 
+td {
+  padding-right: 5px;
+  &.date-standard {
+    span {
+      padding: 0.25em 0.5em 0.25em 0.5em;
+    }
+  }
+  &.date-warning {
+      span {
+        background-color: govuk-colour("red");
+        color: white;
+        padding: 0.25em 0.5em 0.25em 0.5em;
+      }
+  }
+}
+
 .workstack {
   overflow: scroll;
 
   td {
-      padding-right: 5px;
       &.wrap-text {
           word-break: break-all;
-      }
-      &.date-warning {
-          span {
-            background-color: govuk-colour("red");
-            color: white;
-            padding: 0.25em 0.5em 0.25em 0.5em;
-          }
       }
       &.indicator {
           span {
@@ -783,4 +791,24 @@ $border-colour: govuk-colour("grey-2");
 
     }
   }
+}
+
+.padding-top--small {
+  padding-top: govuk-spacing(2);
+}
+
+.bigger {
+  zoom: 1.5;
+  transform: scale(1.5);
+  -ms-transform: scale(1.5);
+  -webkit-transform: scale(1.5);
+  -o-transform: scale(1.5);
+  -moz-transform: scale(1.5);
+  transform-origin: 0 0;
+  -ms-transform-origin: 0 0;
+  -webkit-transform-origin: 0 0;
+  -o-transform-origin: 0 0;
+  -moz-transform-origin: 0 0;
+  padding: 0px;
+  margin: 0px;
 }


### PR DESCRIPTION
This PR introduces the following things: 

- Adds the StandardLineScreen. This also includes all of the routing for the frontend to show the component.
- Adds a 'View Standard Lines' button to the header if the configuration is enabled to show this, that allows for the traversing to the page. 
- Add the routing to the backend server to allow for communication with the info service to retrieve the users standard lines.
- Adds the document client to the backend to allow for the downloading of the standard lines.

Tests have been added for all functionality.