### PR TITLE
HOCS-2145: trim the correspondence reference number form value

### DIFF
--- a/server/middleware/searchHandler.js
+++ b/server/middleware/searchHandler.js
@@ -18,7 +18,7 @@ async function handleSearch(req, res, next) {
             },
             correspondentName: formData['correspondent'],
             correspondentNameNotMember: formData['correspondentNameNotMember'],
-            correspondentReference: formData['correspondentReference'] ? formData['correspondentReference'].toLowerCase() : '',
+            correspondentReference: formData['correspondentReference'] ? formData['correspondentReference'].trim().toLowerCase() : '',
             correspondentExternalKey: formData['correspondentExternalKey'] ? await getMemberExternalKey(formData['correspondentExternalKey']) : undefined,
             topic: formData['topic'],
             data: {


### PR DESCRIPTION
At present if a value is tokenized by elastic search to '1121' a search in the field '1121 ' will not return any results. In a normal system, values like this should be trimmed when searching, this in this case would trim to '1121' and therefore be matched by elastic search.