### PR TITLE
HOCS-2015 UKVI Reference Type Change

### DIFF
--- a/server/services/form.js
+++ b/server/services/form.js
@@ -16,14 +16,7 @@ async function getFormSchemaFromWorkflowService(requestId, options, user) {
     } catch (error) {
         switch (error.response.status) {
             case 401:
-                // handle no permission to allocate
-                try {
-                    const { readOnlyCaseViewAdapter } = await listService.getInstance(requestId, user).fetch('S_SYSTEM_CONFIGURATION');
-                    const response = await listService.getInstance(requestId, user).fetch(readOnlyCaseViewAdapter, { caseId });
-                    return { form: response };
-                } catch (error) {
-                    return { error: new PermissionError('You are not authorised to work on this case') };
-                }
+                return { error: new PermissionError('You are not authorised to work on this case') };
             case 403:
                 // handle not allocated
                 /* eslint-disable-next-line no-case-declarations */


### PR DESCRIPTION
The workflow service correctly returns a 401 when user changes reference type to a non-assigned team.
Front-end modified to propagate the error so that the dashboard is shown, not the case form.