### PR TITLE
HOCS-1853: return all standard lines

### DIFF
--- a/server/routes/api/standardLines.js
+++ b/server/routes/api/standardLines.js
@@ -1,7 +1,7 @@
 const router = require('express').Router();
-const { getUsersStandardLines, getOriginalDocument, standardLinesApiResponseMiddleware } = require('../../middleware/standardLine.js');
+const { getAllStandardLines, getOriginalDocument, standardLinesApiResponseMiddleware } = require('../../middleware/standardLine.js');
 
-router.get('/', getUsersStandardLines, standardLinesApiResponseMiddleware);
+router.get('/', getAllStandardLines, standardLinesApiResponseMiddleware);
 
 router.get('/download/:documentId', getOriginalDocument);
 


### PR DESCRIPTION
As a result of misunderstanding of tickets, when on the view standard lines page, all of the standard lines should be returned regardless of whether they have access to a particular team. This pull request brings in this functionality. Alongside this, tests have been added to cover this new functionality.