### PR TITLE
HOCS-2163: Enforce stricter case reference regex

### DIFF
--- a/server/middleware/__tests__/validation.spec.js
+++ b/server/middleware/__tests__/validation.spec.js
@@ -148,6 +148,29 @@ describe('Validators', () => {
         });
     });
 
+    describe('Case reference validation', () => {
+        it('should accept regardless of case', () => {
+            expect(validators.isValidCaseReference({ value: 'MiN/0000000/22' })).toEqual(null);
+        });
+        it('should accept spaces at the end', () => {
+            expect(validators.isValidCaseReference({ value: 'MIN/0000000/22 ' })).toEqual(null); // one space at the end
+            expect(validators.isValidCaseReference({ value: ' MIN/0000000/22' })).toEqual(null); // one space at the beginning
+            expect(validators.isValidCaseReference({ value: 'MIN/0000000/22     ' })).toEqual(null); // multiple spaces at the end
+            expect(validators.isValidCaseReference({ value: '     MIN/0000000/22' })).toEqual(null); // multiple spaces at the beginning
+        });
+        it('should reject if does not fit pattern', () => {
+            expect(validators.isValidCaseReference({ value: 'M/0000000/22' })).not.toEqual(null); // To little letters at start
+            expect(validators.isValidCaseReference({ value: 'MINTED/0000000/22' })).not.toEqual(null); // To many letters at start
+            expect(validators.isValidCaseReference({ value: 'MiN/000000/22' })).not.toEqual(null); // To little numbers in middle
+            expect(validators.isValidCaseReference({ value: 'MiN/00000000/22' })).not.toEqual(null); // To many numbers in middle
+            expect(validators.isValidCaseReference({ value: 'MiN/000000/2' })).not.toEqual(null); // To little numbers in final section
+            expect(validators.isValidCaseReference({ value: 'MiN/000000/222' })).not.toEqual(null); // To many numbers in final section
+        });
+        it('should reject if contains more than pattern', () => {
+            expect(validators.isValidCaseReference({ value: 'MIN/0000000/22-' })).not.toEqual(null); // invalid char at the end
+            expect(validators.isValidCaseReference({ value: '-MIN/0000000/22' })).not.toEqual(null); // invalid char at the beginning
+        });
+    });
 });
 
 describe('Validation middleware', () => {

--- a/server/middleware/validation.js
+++ b/server/middleware/validation.js
@@ -98,8 +98,8 @@ const validators = {
         return null;
     },
     isValidCaseReference: ({ value, message }) => {
-        const format = /\b[a-zA-Z]{2,4}\/[0-9]{7}\/[0-9]{2}\b/i;
-        if (value && !format.test(value)) {
+        const format = /^[a-z]{2,4}\/[0-9]{7}\/[0-9]{2}$/i;
+        if (value && !format.test(value.trim())) {
             return message || validationErrors.validCaseReference();
         }
         return null;

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -23,8 +23,9 @@ router.post(['/search/reference', '/api/search/reference'],
     validateForm,
     async (req, res, next) => {
         const logger = getLogger(req.requestId);
+
         try {
-            const caseRef = req.form.data['case-reference'].toUpperCase();
+            const caseRef = req.form.data['case-reference'].toUpperCase().trim();
 
             logger.info('SEARCH_REFERENCE', { reference: caseRef });
 

--- a/server/services/forms/schemas/dashboard-search.js
+++ b/server/services/forms/schemas/dashboard-search.js
@@ -8,7 +8,7 @@ module.exports = (options = {}) => {
             Component('text', 'case-reference')
                 .withProp('label', 'Load Case')
                 .withProp('hint', 'For example ABC/1234567/12')
-                .withValidator('isValidCaseReference', 'Case reference is invalid format')
+                .withValidator('isValidCaseReference', 'Enter a case reference in the correct format')
                 .withValidator('required', 'Case reference is required')
                 .build()
         )


### PR DESCRIPTION
At present when searching by a case reference we check to see if the field contains '\b[a-zA-Z]{2,4}\/[0-9]{7}\/[0-9]{2}\b'. This regex checks the entire field text and passes if it contains the basic case reference pattern. This is not acceptable though as you can have anything else either next to it/ before it that would also pass, 'test MIN/0000000/00' would still be valid. This regex has been updated to enforce that the field matches exactly with the case reference pattern.

Alongside this we are currently not in line with what the error message style guide states we should return as incorrect input. Before we had improper english and used the word invalid. This commit changes this to inform the user they have to enter a case reference in the correct format.

At present we don't have any tests for the isValidCaseReference validator. This adds tests that look for invalid formats, alongside checks that a valid one can be case insensitive.
