### PR TITLE
HOCS-2222: change the case type topics to dynamic

### DIFF
--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -296,6 +296,7 @@ module.exports = {
         TOPICS_CASETYPE: {
             client: 'INFO',
             endpoint: '/case/${caseId}/topiclist',
+            type: listService.types.DYNAMIC,
             adapter: topicAdapter
         },
         CASE_TOPICS: {


### PR DESCRIPTION
At present the case types are loaded as a static list, this is an issue as we allow for topics to be added to teams through MUI. This change forced the list to be dynamic, which means that every time they are needed they are loaded in. This will allow new cases that are assigned to teams to show in the core application.