### PR TITLE
HOCS-2226: Update govuk-frontend package from 2.9.0 to 3.10.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const listConfiguration = require('./server/lists');
 const app = express();
 const port = process.env.PORT || 8080;
 
-app.use('/public', express.static(path.join(__dirname, 'node_modules', 'govuk-frontend'), { maxAge: 36000000 }));
+app.use('/public', express.static(path.join(__dirname, 'node_modules', 'govuk-frontend', 'govuk'), { maxAge: 36000000 }));
 app.use('/public', express.static(path.join(__dirname, 'build', 'public'), { maxAge: 36000000 }));
 
 app.use('/', applicationRouter);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7030,9 +7030,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.9.0.tgz",
-      "integrity": "sha512-aE8Jg82H76qpMPKtnnvZbkmDQAzAtuc5uMEffkWo0fv6sWEwTISrqUF5jXWZ8tmtdWF8JGeAp71oSCL2x+RkFg=="
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.10.0.tgz",
+      "integrity": "sha512-bMc487VcYUPc2XvOrVtGoW3wtmITUoDOd183KMIHVIknWl7wjnOh7uxTVYu4o89UmxgoQuFDDbHhrK0RL3o8gg=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "cookie-parser": "^1.4.4",
         "csurf": "^1.10.0",
         "express": "^4.16.4",
-        "govuk-frontend": "2.9.0",
+        "govuk-frontend": "3.10.0",
         "jsonwebtoken": "^8.5.1",
         "multer": "^1.4.2",
         "multer-s3": "^2.7.0",

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -6,7 +6,7 @@ $govuk-page-width: 1300px !default;
 $govuk-font-family: 'helvetica neue', Arial, Helvetica, sans-serif !default;
 $govuk-font-family-tabular: 'helvetica neue',Arial, Helvetica, sans-serif !default;
 
-@import "govuk-frontend/all.scss";
+@import "node_modules/govuk-frontend/govuk/all";
 
 @function tint($color, $percentage) {
   @return mix(white, $color, $percentage);
@@ -35,7 +35,7 @@ $govuk-font-family-tabular: 'helvetica neue',Arial, Helvetica, sans-serif !defau
 }
 
 .govuk-mapped-text {
-  background-color: govuk-colour("grey-4");
+  background-color: govuk-colour("light-grey");
   font-weight: 400;
   min-height: 20px;
   padding: 10px;
@@ -57,7 +57,7 @@ $govuk-font-family-tabular: 'helvetica neue',Arial, Helvetica, sans-serif !defau
   padding: 0 govuk-spacing(1);
   overflow-x: auto;
   color: govuk-colour("pink");
-  background-color: govuk-colour("grey-4");
+  background-color: govuk-colour("light-grey");
 }
 
 .notification {
@@ -75,7 +75,7 @@ $govuk-font-family-tabular: 'helvetica neue',Arial, Helvetica, sans-serif !defau
 }
 
 .document-preview {
-  background-color: govuk-colour("grey-4");
+  background-color: govuk-colour("light-grey");
   box-sizing: border-box;
   display: block;
   height: 700px;
@@ -197,7 +197,7 @@ $govuk-font-family-tabular: 'helvetica neue',Arial, Helvetica, sans-serif !defau
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  background-color: govuk-colour("grey-1");
+  background-color: govuk-colour("dark-grey");
   margin-bottom: 3px;
   width: 2px;
   box-sizing: border-box;
@@ -278,9 +278,9 @@ $govuk-font-family-tabular: 'helvetica neue',Arial, Helvetica, sans-serif !defau
   background-color: $govuk-focus-colour;
 }
 
-$panel-colour: govuk-colour("grey-3");
+$panel-colour: govuk-colour("light-grey");
 $text-colour: govuk-colour("blue");
-$highlight-colour: govuk-colour("grey-4");
+$highlight-colour: govuk-colour("light-grey");
 $link-colour: $govuk-link-colour;
 $link-hover-colour: $govuk-link-hover-colour;
 
@@ -509,7 +509,7 @@ td {
         height: govuk-spacing(2);
         border-radius: 50%;
         background-color: white;
-        border: 4px solid govuk-colour("grey-1");
+        border: 4px solid govuk-colour("dark-grey");
         position: absolute;
         z-index: 2;
         left: -31px;
@@ -586,7 +586,7 @@ td {
   background-color: $govuk-error-colour;
 }
 
-$border-colour: govuk-colour("grey-2");
+$border-colour: govuk-colour("mid-grey");
 
 .tabs > ol, .tabs > ul {
   @include govuk-clearfix;


### PR DESCRIPTION
note: The guidance I used to replace the old colours is here: https://frontend.design-system.service.gov.uk/migrating-from-legacy-products/#2-turn-off-compatibility-mode