### PR TITLE
HOCS-2240 Push images on some non-master branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,6 +9,20 @@ pipeline:
       when:
         event: push
 
+    install-docker-image-latest:
+      image: docker:17.09.1
+      environment:
+        - DOCKER_HOST=tcp://172.17.0.1:2375
+      secrets:
+        - docker_password
+      commands:
+        - docker login -u="ukhomeofficedigital+hocs" -p=$${DOCKER_PASSWORD} quay.io
+        - docker tag hocs-frontend quay.io/ukhomeofficedigital/hocs-frontend:latest
+        - docker push quay.io/ukhomeofficedigital/hocs-frontend:latest
+      when:
+        branch: master
+        event: push
+
     install-docker-image:
       image: docker:17.09.1
       environment:
@@ -18,13 +32,14 @@ pipeline:
       commands:
         - docker login -u="ukhomeofficedigital+hocs" -p=$${DOCKER_PASSWORD} quay.io
         - docker tag hocs-frontend quay.io/ukhomeofficedigital/hocs-frontend:build-$${DRONE_BUILD_NUMBER}
-        - docker tag hocs-frontend quay.io/ukhomeofficedigital/hocs-frontend:latest
+        - export BRANCH_NAME_TAGFRIENDLY=`echo "$${DRONE_COMMIT_BRANCH}" | sed 's$/$_$g'` # sed can use any character as delimiter
+        - docker tag hocs-frontend quay.io/ukhomeofficedigital/hocs-frontend:branch-$${BRANCH_NAME_TAGFRIENDLY}
         - docker push quay.io/ukhomeofficedigital/hocs-frontend:build-$${DRONE_BUILD_NUMBER}
-        - docker push quay.io/ukhomeofficedigital/hocs-frontend:latest
+        - docker push quay.io/ukhomeofficedigital/hocs-frontend:branch-$${BRANCH_NAME_TAGFRIENDLY}
       when:
-        branch: master
+        branch: [master, epic/*]
         event: push
-  
+
     sonar-scanner:
       image: quay.io/ukhomeofficedigital/sonar-scanner:v3.0.2
       when:


### PR DESCRIPTION
This commit tells Drone to build a Docker image on every push, instead
of just pushes to master, which should increase the chances of the build
failing if the Dockerfile is malformed.

We also push images to our image registry, quay.io, on every push to a
branch starting with "epic/", in addition to the usual master branch.

Docker doesn't permit slashes in tag names, so we transform the branch
name first, replacing all slashes with underscores before pushing. In
Drone 1.0 you can simplify it by using Bash-style string manipulation
syntax in the double-dollar reference itself, but for Drone 0.8 we need
to instead rely on calling sed directly.