### PR TITLE
HOCS-2235: add ability to render somu list

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,10 @@ module.exports = {
             "error",
             "unix"
         ],
+        "no-unused-vars": [
+            "error", 
+            { "argsIgnorePattern": "^_$"  }
+        ],
         "quotes": [
             "error",
             "single"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2794,7 +2794,7 @@
     },
     "async": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "async-each": {
@@ -3084,7 +3084,7 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-preset-jest": {
@@ -3431,7 +3431,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -3751,7 +3751,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -4305,7 +4305,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -4318,7 +4318,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -4857,7 +4857,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -5445,7 +5445,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "evp_bytestokey": {
@@ -5928,7 +5928,7 @@
     },
     "file-type": {
       "version": "3.9.0",
-      "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
       "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
     },
     "file-uri-to-path": {
@@ -7934,7 +7934,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -11370,7 +11370,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -12323,7 +12323,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         },
@@ -12516,7 +12516,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -14258,7 +14258,7 @@
     },
     "readable-stream": {
       "version": "1.1.14",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -14895,7 +14895,7 @@
     },
     "sax": {
       "version": "1.2.1",
-      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "saxes": {
@@ -15074,7 +15074,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -16159,7 +16159,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -17477,7 +17477,7 @@
     },
     "webpack-node-externals": {
       "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
       "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==",
       "dev": true
     },
@@ -17740,7 +17740,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlchars": {

--- a/server/lists/adapters/__tests__/__snapshots__/somu.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/somu.spec.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Somu Adapter Somu Item Adapter should transform somu type with data 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "test": 1,
+    },
+  ],
+  "deleted": false,
+  "uuid": "00000000-0000-0000-0000-000000000000",
+}
+`;
+
+exports[`Somu Adapter Somu Item Adapter should transform somu type with deleted set as true 1`] = `
+Object {
+  "data": null,
+  "deleted": true,
+  "uuid": "00000000-0000-0000-0000-000000000000",
+}
+`;
+
+exports[`Somu Adapter Somu Type Adapter should transform somu type 1`] = `
+Array [
+  Object {
+    "key": Array [
+      "TestCaseType",
+      "TestType",
+    ],
+    "value": Object {
+      "active": true,
+      "caseType": "TestCaseType",
+      "schema": Object {
+        "test": 1,
+      },
+      "type": "TestType",
+      "uuid": "00000000-0000-0000-0000-000000000000",
+    },
+  },
+]
+`;

--- a/server/lists/adapters/__tests__/somu.spec.js
+++ b/server/lists/adapters/__tests__/somu.spec.js
@@ -1,0 +1,48 @@
+const {
+    somuTypesAdapter,
+    somuItemsAdapter } = require('../somu');
+
+const mockLogger = {
+    debug: () => { },
+    info: () => { },
+    warn: () => { },
+    error: () => { }
+};
+
+describe('Somu Adapter', () => {
+
+    describe('Somu Type Adapter', () => {
+        const mockData = [
+            { uuid: '00000000-0000-0000-0000-000000000000', caseType: 'TestCaseType', type: 'TestType', schema: '{"test":1}', active: true }
+        ];
+
+        it('should transform somu type', async () => {
+            const results = await somuTypesAdapter(mockData, { logger: mockLogger });
+
+            expect(results).toBeDefined();
+            expect(results).toMatchSnapshot();
+        });
+    });
+
+    describe('Somu Item Adapter', () => {
+
+        it('should transform somu type with data', async () => {
+            const mockData = { uuid: '00000000-0000-0000-0000-000000000000', data: '[{"test":1}]', deleted: false };
+
+            const results = await somuItemsAdapter(mockData, { logger: mockLogger });
+
+            expect(results).toBeDefined();
+            expect(results).toMatchSnapshot();
+        });
+
+        it('should transform somu type with deleted set as true', async () => {
+            const mockData = { uuid: '00000000-0000-0000-0000-000000000000', data: null, deleted: true };
+
+            const results = await somuItemsAdapter(mockData, { logger: mockLogger });
+
+            expect(results).toBeDefined();
+            expect(results).toMatchSnapshot();
+        });
+    });
+
+});

--- a/server/lists/adapters/somu.js
+++ b/server/lists/adapters/somu.js
@@ -1,0 +1,24 @@
+const somuTypesAdapter = async (data, { logger }) => {
+    logger.debug('REQUEST_SOMU_TYPE_ALL', { somuTypes: data.length });
+
+    return data
+        .map(({ uuid, caseType, type, schema, active }) => {
+            return ({ key: [caseType, type], value: { uuid, caseType, type, active, schema: JSON.parse(schema) } });
+        });
+};
+
+const somuItemsAdapter = async (data, { logger }) => {
+    logger.debug('REQUEST_CASE_SOMU_ITEM', { somuItems: data });
+
+    let parsedData = null;
+    if (data.data && !data.deleted) {
+        parsedData = JSON.parse(data.data);
+    }
+
+    return ({ uuid: data.uuid, data: parsedData, deleted: data.deleted });
+};
+
+module.exports = {
+    somuTypesAdapter,
+    somuItemsAdapter
+};

--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -23,6 +23,7 @@ const {
     correspondentTypeAdapter,
     caseCorrespondentsAllAdapter
 } = require('./adapters/correspondents');
+const { somuTypesAdapter, somuItemsAdapter } = require('./adapters/somu');
 
 module.exports = {
     lists: {
@@ -365,6 +366,18 @@ module.exports = {
             client: 'INFO',
             endpoint: '/team/topic/stage/DCU_DTEN_INITIAL_DRAFT',
             type: listService.types.DYNAMIC,
+        },
+        SOMU_TYPES: {
+            client: 'INFO',
+            endpoint: '/somuType',
+            type: listService.types.STATIC,
+            adapter: somuTypesAdapter
+        },
+        CASE_SOMU_ITEM: {
+            client: 'CASEWORK',
+            endpoint: '/case/${caseId}/item/${somuTypeId}',
+            type: listService.types.DYNAMIC,
+            adapter: somuItemsAdapter
         },
     },
     clients: {

--- a/server/services/form.js
+++ b/server/services/form.js
@@ -88,7 +88,7 @@ async function getFormSchema(options) {
 
 async function hydrateField(field, req) {
     if (field.props) {
-        const { choices, items, sections, conditionChoices } = field.props;
+        const { choices, items, sections, conditionChoices, somuType } = field.props;
 
         if (conditionChoices) {
             for (var i = 0; i < conditionChoices.length; i++) {
@@ -121,13 +121,27 @@ async function hydrateField(field, req) {
                 await Promise.all(fieldRequests);
             });
             await Promise.all(sectionRequests);
+        } else if (somuType) {
+            const { choices, caseType, type } = somuType;
+
+            if (choices) {
+                field.props.choices = await req.listService.fetch(choices, req.params);
+            }
+
+            const somuTypeItem = await req.listService.getFromStaticList(
+                'SOMU_TYPES',
+                [caseType, type]
+            );
+            field.props.somuType = somuTypeItem;
+
+            const somuItem = await req.listService.fetch('CASE_SOMU_ITEM', { ...req.params, somuTypeId: somuTypeItem.uuid });
+            field.props.somuItems = somuItem;
         }
     }
     return field;
 }
 
 const hydrateFields = async (req, res, next) => {
-
     const logger = getLogger(req.requestId);
 
     if (req.form) {
@@ -188,7 +202,6 @@ const getFormForAction = async (req, res, next) => {
 };
 
 const getFormForCase = async (req, res, next) => {
-
     const logger = getLogger(req.requestId);
     logger.info('GET_FORM', { ...req.params });
 
@@ -202,7 +215,28 @@ const getFormForCase = async (req, res, next) => {
             return next(new PermissionError('You are not authorised to work on this case'));
         }
         return next(new FormServiceError('Failed to fetch form'));
+    }
+};
 
+const getSomuFormForCase = async (req, res, next) => {
+    const logger = getLogger(req.requestId);
+    logger.info('GET_FORM_FOR _SOMU', { ...req.params });
+
+    try {
+        const schema = await listService.getInstance(req.requestId, req.user).getFromStaticList('SOMU_TYPES', [req.params.caseType, req.params.type]);
+        const formSchema = schema.forms[req.params.action.toUpperCase()];
+
+        if (formSchema) {
+            //req.form = parseSomuForm(formSchema);
+        } else {
+            return next(new FormServiceError('Form schema for somu action does not exist'));
+        }
+    } catch (error) {
+        logger.error('CASE_FORM_FAILURE', { message: error.message, stack: error.stack });
+        if (error.response !== undefined && error.response.status === 401) {
+            return next(new PermissionError('You are not authorised to work on this case'));
+        }
+        return next(new FormServiceError('Failed to fetch form'));
     }
 };
 

--- a/server/services/list/__tests__/service.spec.js
+++ b/server/services/list/__tests__/service.spec.js
@@ -26,6 +26,96 @@ describe('List Service', () => {
         });
     });
 
+    describe('fetchStaticList', () => {
+        it ('should return value with key', async () => {
+            const lists = {
+                test_static: {
+                    client: 'test',
+                    endpoint: '/test/api',
+                    type: listService.types.STATIC,
+                    data: [{ key: 'test', value: 'TEST_VALUE' }]
+                }
+            };
+
+            listService.initialise(lists);
+            const instance = await listService.getInstance(mockUUID, mockUser);
+            const result = await instance.getFromStaticList('test_static', 'test');
+
+            expect(result).toBeDefined();
+            expect(result).toEqual('TEST_VALUE');
+        });
+
+        it ('should return null if pair array against non array key', async () => {
+            const lists = {
+                test_static: {
+                    client: 'test',
+                    endpoint: '/test/api',
+                    type: listService.types.STATIC,
+                    data: [{ key: ['test_1', 'test_2'], value: 'TEST_VALUE' }]
+                }
+            };
+
+            listService.initialise(lists);
+            const instance = await listService.getInstance(mockUUID, mockUser);
+            const result = await instance.getFromStaticList('test_static', 'test');
+
+            expect(result).toBeNull();
+        });
+
+        it ('should return value when both arrays are present with correct keys', async () => {
+            const lists = {
+                test_static: {
+                    client: 'test',
+                    endpoint: '/test/api',
+                    type: listService.types.STATIC,
+                    data: [{ key: ['test_1', 'test_2'], value: 'TEST_VALUE' }]
+                }
+            };
+
+            listService.initialise(lists);
+            const instance = await listService.getInstance(mockUUID, mockUser);
+            const result = await instance.getFromStaticList('test_static', ['test_1', 'test_2']);
+
+            expect(result).toBeDefined();
+            expect(result).toEqual('TEST_VALUE');
+        });
+
+        it ('should return null when only partial array key match ', async () => {
+            const lists = {
+                test_static: {
+                    client: 'test',
+                    endpoint: '/test/api',
+                    type: listService.types.STATIC,
+                    data: [{ key: ['test_1', 'test_2'], value: 'TEST_VALUE' }]
+                }
+            };
+
+            listService.initialise(lists);
+            const instance = await listService.getInstance(mockUUID, mockUser);
+            const result = await instance.getFromStaticList('test_static', ['test_1', 'test_this_is_not_present']);
+
+            expect(result).toBeNull();
+        });
+
+        it ('should return value if value matches inputted key and key not in data', async () => {
+            const lists = {
+                test_static: {
+                    client: 'test',
+                    endpoint: '/test/api',
+                    type: listService.types.STATIC,
+                    data: [{ value: 'TEST_VALUE', label: 'TEST' }]
+                }
+            };
+
+            listService.initialise(lists);
+            const instance = await listService.getInstance(mockUUID, mockUser);
+            const result = await instance.getFromStaticList('test_static', 'TEST_VALUE');
+
+            expect(result).toBeDefined();
+            expect(result).toEqual('TEST');
+        });
+    });
+
     describe('fetchList', () => {
         it('should support configured lists', async () => {
             const lists = {

--- a/server/services/list/service.js
+++ b/server/services/list/service.js
@@ -87,7 +87,7 @@ const getInstance = (requestId, user) => {
                 // list items come back as:
                 // a) object with 'key' and 'value' where key is the id. We return 'value' in this instance.
                 // b) object with 'value' and 'label' where value is the id. We return 'label' in this instance.
-                const result = item.find(item => item.key ? item.key === key : item.value === key);
+                const result = item.find(item => listContains(item, key));
                 if (result) {
                     return result.key ? result.value : result.label;
                 } else if (flushIfNull) {
@@ -98,6 +98,18 @@ const getInstance = (requestId, user) => {
             } else return defaultValue;
         } else {
             return defaultValue;
+        }
+    };
+
+    const listContains = (item, key) => {
+        if (item.key) {
+            if (Array.isArray(item.key) && Array.isArray(key)) {
+                return (item.key.every(keyValue => key.includes(keyValue)));
+            } else {
+                return (item.key === key);
+            }
+        } else {
+            return (item.value === key);
         }
     };
 

--- a/src/shared/common/forms/composite/__tests__/__snapshots__/somu-list.spec.jsx.snap
+++ b/src/shared/common/forms/composite/__tests__/__snapshots__/somu-list.spec.jsx.snap
@@ -1,0 +1,426 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Somu list component should include hideSidebar query param on primary and item links 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="somu_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="somu_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      >
+        <tr
+          class="govuk-table__row"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            <label
+              class="govuk-label"
+            >
+              test
+            </label>
+          </td>
+          <td
+            class="govuk-table__cell"
+          >
+            <a
+              class="govuk-link"
+              href="/case/1234/stage/5678/somu/test/testType/tesCaseType/item/test/remove?hideSidebar=true"
+            >
+              Remove
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <p>
+      <a
+        class="govuk-body govuk-link"
+        href="/case/1234/stage/5678/somu/test/testType/tesCaseType/add?hideSidebar=true"
+      >
+        Add
+      </a>
+    </p>
+  </fieldset>
+</div>
+`;
+
+exports[`Somu list component should render with add link when passed in props 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="somu_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="somu_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      />
+    </table>
+    <p>
+      <a
+        class="govuk-body govuk-link"
+        href="/case/1234/stage/5678/somu/test/testType/tesCaseType/add?hideSidebar=false"
+      >
+        Add
+      </a>
+    </p>
+  </fieldset>
+</div>
+`;
+
+exports[`Somu list component should render with additional when passed in props 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset my-css-class"
+    id="somu_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="somu_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      />
+    </table>
+  </fieldset>
+</div>
+`;
+
+exports[`Somu list component should render with choices when table renderer exists 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="somu_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="somu_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      >
+        <tr
+          class="govuk-table__row"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            <label
+              class="govuk-label"
+            >
+              TestBusinessArea - Test Team
+            </label>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </fieldset>
+</div>
+`;
+
+exports[`Somu list component should render with default props 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="somu_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="somu_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      />
+    </table>
+  </fieldset>
+</div>
+`;
+
+exports[`Somu list component should render with default render when empty renderer added 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="somu_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="somu_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      >
+        <tr
+          class="govuk-table__row"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            <label
+              class="govuk-label"
+            >
+              test
+            </label>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </fieldset>
+</div>
+`;
+
+exports[`Somu list component should render with default render when renderers object doesn't exist 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="somu_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="somu_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      >
+        <tr
+          class="govuk-table__row"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            <label
+              class="govuk-label"
+            >
+              test
+            </label>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </fieldset>
+</div>
+`;
+
+exports[`Somu list component should render with default render when table renderer exists 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="somu_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="somu_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      >
+        <tr
+          class="govuk-table__row"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            <label
+              class="govuk-label"
+            >
+              TestBusinessArea - TestTeam
+            </label>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </fieldset>
+</div>
+`;
+
+exports[`Somu list component should render with error when passed in props 1`] = `
+<div
+  class="govuk-form-group govuk-form-group--error"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="somu_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="somu_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <span
+      class="govuk-error-message"
+      id="somu_list-error"
+    >
+      Validation has failed
+    </span>
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      />
+    </table>
+  </fieldset>
+</div>
+`;
+
+exports[`Somu list component should render with item link passed in props 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="somu_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="somu_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      >
+        <tr
+          class="govuk-table__row"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            <label
+              class="govuk-label"
+            >
+              test
+            </label>
+          </td>
+          <td
+            class="govuk-table__cell"
+          >
+            <a
+              class="govuk-link"
+              href="/case/1234/stage/5678/somu/test/testType/tesCaseType/item/test/remove?hideSidebar=false"
+            >
+              Remove
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </fieldset>
+</div>
+`;
+
+exports[`Somu list component should render with label when passed in props 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="somu_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="somu_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      >
+        Test somu list
+      </span>
+    </legend>
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      />
+    </table>
+  </fieldset>
+</div>
+`;

--- a/src/shared/common/forms/composite/__tests__/somu-list.spec.jsx
+++ b/src/shared/common/forms/composite/__tests__/somu-list.spec.jsx
@@ -1,0 +1,258 @@
+import React from 'react';
+import WrappedSomuList from '../somu-list.jsx';
+import { MemoryRouter } from 'react-router-dom';
+
+describe('Somu list component', () => {
+
+    const PAGE = { params: { caseId: '1234', stageId: '5678' } };
+    const NAME = 'somu_list';
+    const ITEM_NAME = 'item';
+    const BASE_URL = 'http://localhost:8080';
+    const MOCK_CALLBACK = jest.fn();
+
+    const DEFAULT_PROPS = {
+        page: PAGE,
+        name: NAME,
+        itemName: ITEM_NAME,
+        baseUrl: BASE_URL,
+        updateState: MOCK_CALLBACK
+    };
+
+    beforeEach(() => {
+        MOCK_CALLBACK.mockReset();
+    });
+
+    it('should render with default props', () => {
+        const OUTER = shallow(<WrappedSomuList {...DEFAULT_PROPS} />);
+        const SomuList = OUTER.props().children;
+        const WRAPPER = render(<SomuList />);
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+    });
+
+    it('should render with label when passed in props', () => {
+        const PROPS = {
+            ...DEFAULT_PROPS,
+            label: 'Test somu list'
+        };
+        const OUTER = shallow(<WrappedSomuList {...PROPS} />);
+        const SomuList = OUTER.props().children;
+        const WRAPPER = render(<SomuList />);
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+    });
+
+    it('should render with error when passed in props', () => {
+        const PROPS = {
+            ...DEFAULT_PROPS,
+            error: 'Validation has failed'
+        };
+        const OUTER = shallow(<WrappedSomuList {...PROPS} />);
+        const SomuList = OUTER.props().children;
+        const WRAPPER = render(<SomuList />);
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+    });
+
+    it('should render with additional when passed in props', () => {
+        const PROPS = {
+            ...DEFAULT_PROPS,
+            className: 'my-css-class'
+        };
+        const OUTER = shallow(<WrappedSomuList {...PROPS} />);
+        const SomuList = OUTER.props().children;
+        const WRAPPER = render(<SomuList />);
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+    });
+
+    it('should render with item link passed in props', () => {
+        const somuType = { uuid: 'test',
+            caseType: 'tesCaseType',
+            type: 'testType',
+            schema: { },
+            active: true };
+        const somuItems = { uuid: 'test', data: [{ uuid: 'test', businessArea: 'TestBusinessArea', businessUnit: 'TestTeam' }], deleted: false };
+        const PROPS = {
+            ...DEFAULT_PROPS,
+            somuType,
+            somuItems,
+            itemLinks: [
+                {
+                    'action': 'remove',
+                    'label': 'Remove'
+                }
+            ]
+        };
+        const OUTER = shallow(<WrappedSomuList {...PROPS} />);
+        const SomuList = OUTER.props().children;
+        const WRAPPER = render(
+            <MemoryRouter>
+                <SomuList page={PAGE} />
+            </MemoryRouter>);
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+    });
+
+    it('should render with default render when table renderer exists', () => {
+        const somuType = { uuid: 'test',
+            caseType: 'tesCaseType',
+            type: 'testType',
+            schema: { renderers: { table: 'MpamTable' } },
+            active: true };
+        const somuItems = { uuid: 'test', data: [{ uuid: 'test', businessArea: 'TestBusinessArea', businessUnit: 'TestTeam' }], deleted: false };
+        const PROPS = {
+            ...DEFAULT_PROPS,
+            somuType,
+            somuItems,
+        };
+        const OUTER = shallow(<WrappedSomuList {...PROPS} />);
+        const SomuList = OUTER.props().children;
+        const WRAPPER = render(
+            <MemoryRouter>
+                <SomuList page={PAGE} />
+            </MemoryRouter>);
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+    });
+
+    it('should render with default render when empty renderer added', () => {
+        const somuType = { uuid: 'test',
+            caseType: 'tesCaseType',
+            type: 'testType',
+            schema: { renderers: { } },
+            active: true };
+        const somuItems = { uuid: 'test', data: [{ uuid: 'test', businessArea: 'TestBusinessArea', businessUnit: 'TestTeam' }], deleted: false };
+        const PROPS = {
+            ...DEFAULT_PROPS,
+            somuType,
+            somuItems,
+        };
+        const OUTER = shallow(<WrappedSomuList {...PROPS} />);
+        const SomuList = OUTER.props().children;
+        const WRAPPER = render(
+            <MemoryRouter>
+                <SomuList page={PAGE} />
+            </MemoryRouter>);
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+    });
+
+    it('should render with default render when renderers object doesn\'t exist', () => {
+        const somuType = { uuid: 'test',
+            caseType: 'tesCaseType',
+            type: 'testType',
+            schema: { },
+            active: true };
+        const somuItems = { uuid: 'test', data: [{ uuid: 'test', businessArea: 'TestBusinessArea', businessUnit: 'TestUnit' }], deleted: false };
+        const PROPS = {
+            ...DEFAULT_PROPS,
+            somuType,
+            somuItems,
+        };
+        const OUTER = shallow(<WrappedSomuList {...PROPS} />);
+        const SomuList = OUTER.props().children;
+        const WRAPPER = render(
+            <MemoryRouter>
+                <SomuList page={PAGE} />
+            </MemoryRouter>);
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+    });
+
+    it('should render with choices when table renderer exists', () => {
+        const somuType = { uuid: 'test',
+            caseType: 'tesCaseType',
+            type: 'testType',
+            schema: { renderers: { table: 'MpamTable' } },
+            active: true };
+        const somuItems = { uuid: 'test', data: [{ uuid: 'test', businessArea: 'TestBusinessArea', businessUnit: 'TestTeam' }], deleted: false };
+        const PROPS = {
+            ...DEFAULT_PROPS,
+            somuType,
+            somuItems,
+            choices: [ {
+                'value': 'TestTeam',
+                'label': 'Test Team'
+            }]
+        };
+        const OUTER = shallow(<WrappedSomuList {...PROPS} />);
+        const SomuList = OUTER.props().children;
+        const WRAPPER = render(
+            <MemoryRouter>
+                <SomuList page={PAGE} />
+            </MemoryRouter>);
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+    });
+
+    it('should render with add link when passed in props', () => {
+        const somuType = { uuid: 'test',
+            caseType: 'tesCaseType',
+            type: 'testType',
+            schema: { renderers: { table: 'MpamTable' } },
+            active: true };
+        const PROPS = {
+            ...DEFAULT_PROPS,
+            somuType,
+            primaryLink: {
+                'action': 'add',
+                'label': 'Add'
+            }
+        };
+        const OUTER = shallow(<WrappedSomuList {...PROPS} />);
+        const SomuList = OUTER.props().children;
+        const WRAPPER = render(
+            <MemoryRouter>
+                <SomuList page={PAGE} />
+            </MemoryRouter>);
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+    });
+
+    it('should execute callback on initialization', () => {
+        const PROPS = {
+            ...DEFAULT_PROPS,
+        };
+        const OUTER = shallow(<WrappedSomuList {...PROPS} />);
+        const SomuList = OUTER.props().children;
+        mount(<SomuList />);
+        expect(MOCK_CALLBACK).toHaveBeenCalledTimes(1);
+        expect(MOCK_CALLBACK).toHaveBeenCalledWith({ [DEFAULT_PROPS.name]: undefined });
+    });
+
+    it('should include hideSidebar query param on primary and item links', () => {
+        const somuType = { uuid: 'test',
+            caseType: 'tesCaseType',
+            type: 'testType',
+            schema: { renderers: { } },
+            active: true };
+        const somuItems = { uuid: 'test', data: [{ uuid: 'test', businessArea: 'TestBusinessArea', businessUnit: 'TestTeam' }], deleted: false };
+        const PROPS = {
+            ...DEFAULT_PROPS,
+            somuType,
+            somuItems,
+            hideSidebar: true,
+            itemLinks: [
+                {
+                    'action': 'remove',
+                    'label': 'Remove'
+                }
+            ],
+            primaryLink: {
+                'action': 'add',
+                'label': 'Add'
+            }
+        };
+
+        const OUTER = shallow(<WrappedSomuList { ...PROPS} />);
+        const SomuList = OUTER.props().children;
+        const WRAPPER = render(
+            <MemoryRouter>
+                <SomuList page={PAGE} />
+            </MemoryRouter>);
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+    });
+
+});

--- a/src/shared/common/forms/composite/somu-list.jsx
+++ b/src/shared/common/forms/composite/somu-list.jsx
@@ -1,0 +1,142 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { ApplicationConsumer } from '../../../contexts/application.jsx';
+
+class SomuList extends Component {
+
+    constructor(props) {
+        super(props);
+
+        this.state = { ...props };
+    }
+
+    componentDidMount() {
+        const { name, somuItems } = this.props;
+
+        this.props.updateState({ [name]: somuItems.data });
+    }
+
+    loadValue(value, choices) {
+        const choice = choices.find(x => x.value === value);
+
+        return choice ? choice.label : value;
+    }
+
+    renderIdRow(schema, somuItem) {
+        const renderers = schema.renderers;
+        const choices = this.props.choices;
+
+        if (renderers) {
+            const tableRenderer = renderers.table || '';
+            switch (tableRenderer) {
+                case 'MpamTable': {
+                    return (<td className='govuk-table__cell'>
+                        <label className="govuk-label">{somuItem.businessArea} - {this.loadValue(somuItem.businessUnit, choices)}</label>
+                    </td>);
+                }
+            }
+        }
+        return (<td className='govuk-table__cell'>
+            <label className="govuk-label">{somuItem.uuid}</label>
+        </td>);
+    }
+
+    renderItemLinks(somuItem) {
+        const { itemLinks, somuType, page, hideSidebar }  = this.props;
+
+        if (itemLinks && Array.isArray(itemLinks)) {
+            const links = itemLinks.map(({ action, label }, i) => {
+                return (<td key={i} className='govuk-table__cell'>
+                    <Link to={`/case/${page.params.caseId}/stage/${page.params.stageId}/somu/${somuType.uuid}/${somuType.type}/${somuType.caseType}/item/${somuItem.uuid}/${action}?hideSidebar=${hideSidebar}`}
+                        className="govuk-link">{label}</Link>
+                </td>);
+            });
+            return links;
+        }
+        return undefined;
+    }
+
+    render() {
+        const {
+            page,
+            somuType,
+            somuItems,
+            disabled,
+            error,
+            primaryLink,
+            label,
+            name,
+            className
+        } = this.props;
+
+        const { hideSidebar } = this.props;
+
+        return (
+            <div className={`govuk-form-group${error ? ' govuk-form-group--error' : ''}`}>
+
+                <fieldset id={name} className={`govuk-fieldset ${className ? className : ''}`} disabled={disabled}>
+
+                    <legend id={`${name}-legend`} className="govuk-fieldset__legend">
+                        <span className="govuk-fieldset__heading govuk-label--s">{label}</span>
+                    </legend>
+
+                    {error && <span id={`${name}-error`} className="govuk-error-message">{error}</span>}
+
+                    <table className='govuk-table'>
+                        <tbody className='govuk-table__body'>
+                            {somuItems && somuItems.data != null && somuItems.data.length > 0 && somuItems.data.map((somuItem, i) => {
+                                return (
+                                    <tr className='govuk-table__row' key={i}>
+                                        { this.renderIdRow(somuType.schema, somuItem) }
+                                        { this.renderItemLinks(somuItem) }
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
+                    {primaryLink &&
+                        <p>
+                            <Link to={`/case/${page.params.caseId}/stage/${page.params.stageId}/somu/${somuType.uuid}/${somuType.type}/${somuType.caseType}/${primaryLink.action}?hideSidebar=${hideSidebar}`} className="govuk-body govuk-link">{primaryLink.label}</Link>
+                        </p>
+                    }
+                </fieldset>
+
+            </div>
+        );
+    }
+}
+
+SomuList.propTypes = {
+    baseUrl: PropTypes.string.isRequired,
+    className: PropTypes.string,
+    somuType: PropTypes.object.isRequired,
+    somuItems: PropTypes.object.isRequired,
+    disabled: PropTypes.bool,
+    error: PropTypes.string,
+    itemLinks: PropTypes.arrayOf(PropTypes.object),
+    primaryLink: PropTypes.object,
+    name: PropTypes.string.isRequired,
+    label: PropTypes.string,
+    updateState: PropTypes.func.isRequired,
+    page: PropTypes.object.isRequired,
+    hideSidebar: PropTypes.bool.isRequired,
+    choices: PropTypes.arrayOf(PropTypes.object),
+};
+
+SomuList.defaultProps = {
+    choices: [],
+    somuType: {},
+    somuItems: {},
+    disabled: false,
+    page: {},
+    hideSidebar: false,
+};
+
+const WrappedSomuList = props => (
+    <ApplicationConsumer>
+        {({ page }) => <SomuList {...props} page={page} />}
+    </ApplicationConsumer>
+);
+
+export default WrappedSomuList;

--- a/src/shared/common/forms/form-repository.jsx
+++ b/src/shared/common/forms/form-repository.jsx
@@ -3,6 +3,7 @@ import TextInput from './text.jsx';
 import MappedText from './mapped-text.jsx';
 import MappedDisplay from './mapped-display.jsx';
 import ChangeLink from './composite/change-link.jsx';
+import SomuList from './composite/somu-list.jsx';
 import Radio from './radio-group.jsx';
 import DateInput from './date.jsx';
 import Checkbox from './checkbox-group.jsx';
@@ -91,6 +92,14 @@ export function formComponentFactory(field, options) {
             return renderFormComponent(AddDocument, { key, config, errors, callback });
         case 'entity-list':
             return renderFormComponent(EntityList, {
+                key,
+                config: { ...config, baseUrl: options.baseUrl },
+                data,
+                errors,
+                callback
+            });
+        case 'somu-list':
+            return renderFormComponent(SomuList, {
                 key,
                 config: { ...config, baseUrl: options.baseUrl },
                 data,

--- a/src/shared/pages/form-enabled.jsx
+++ b/src/shared/pages/form-enabled.jsx
@@ -115,9 +115,7 @@ function withForm(Page) {
                 const formData = new FormData();
                 Object.keys(form_data).filter(field => form_data[field] !== null).forEach(field => {
                     if (Array.isArray(form_data[field])) {
-                        form_data[field].map(value => {
-                            formData.append(`${field}[]`, value);
-                        });
+                        formData.append(field, JSON.stringify(form_data[field]));
                     } else {
                         formData.append(field, form_data[field]);
                     }
@@ -149,8 +147,6 @@ function withForm(Page) {
                             })
                             .catch(error => {
                                 this.setState({ submittingForm: false });
-                                // TODO: Remove
-                                /* eslint-disable-next-line no-console */
                                 return dispatch(updateApiStatus(status.SUBMIT_FORM_FAILURE))
                                     .then(() => dispatch(setError(error.response)));
                             });


### PR DESCRIPTION
This change adds the new somu list into the application, fully complete with all tests required. The somu list allows for a range of configuration highlighted below: 

- itemLinks (optional): add links to a new column in the table with a user specified action and label on a somu item
- primaryLink (optional): add a add link below the table that has a user specified action and label that impacts a somu type
- somuType (required): contains the following:
    - choices (optional): pulls the list from the list service with the request parameters
    - type (required): the type that the somu type links to (i.e. 'CONTRIBUTIONS')
    - caseType (required): the case type the somu type links to (i.e. 'TEAM') 
