### PR TITLE
HOCS-2259: change exporting

### DIFF
--- a/server/libs/dateHelpers.js
+++ b/server/libs/dateHelpers.js
@@ -1,13 +1,15 @@
-export const addDays = (dateString, days) => {
+const addDays = (dateString, days) => {
     const date = new Date(dateString);
     date.setDate(date.getDate() + days);
     return date;
 };
 
 // Returns today's date in format (yyyy-MM-dd)
-export const getUtcDateString = (date) => {
+const getUtcDateString = (date) => {
     if (date && date instanceof Date) {
         return date.toISOString().split('T')[0];
     }
     return undefined;
 };
+
+module.exports = { addDays, getUtcDateString };


### PR DESCRIPTION
When building we currently don't support ES6 exporting of functions. We are currently restricted to using module.exports.