### PR TITLE
HOCS-2048 Build image on every push

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,9 +7,8 @@ pipeline:
       commands:
         - docker build -t hocs-frontend .
       when:
-        branch: master
         event: push
-  
+
     install-docker-image:
       image: docker:17.09.1
       environment:


### PR DESCRIPTION
Prior to this commit Drone was only building the Docker image on a push
to master. As tests are currently only run on Docker build, it means
that the automated tests aren't run until merge to master.

Worse, as pipelines are set up for this repository on push and
pull_request, GitHub will display a reassuring green checkmark shortly
after a PR is opened -- even though the PR has no meaningful tests run
on it.

This commit ensures that we build the image on every push event, and
therefore indirectly ensure that every pull request runs the test pack.