### PR TITLE
HOCS-2274: add validator and update workstack display

### DIFF
--- a/server/lists/adapters/workstacks.js
+++ b/server/lists/adapters/workstacks.js
@@ -130,8 +130,8 @@ const bindDisplayElements = fromStaticList => async (stage) => {
 
     if (stage.data && stage.data.CaseContributions) {
         const dueContribution = JSON.parse(stage.data.CaseContributions)
-            .filter(contribution => !contribution.contributionStatus)
-            .map(contribution => contribution.contributionDueDate)
+            .filter(contribution => !contribution.data.contributionStatus)
+            .map(contribution => contribution.data.contributionDueDate)
             .sort()
             .shift();
 
@@ -140,9 +140,14 @@ const bindDisplayElements = fromStaticList => async (stage) => {
             'MPAM_DRAFT'
         ];
 
-        if (dueContribution) {
+        const contributionRequestedStages = [
+            'MPAM_TRIAGE_REQUESTED_CONTRIBUTION',
+            'MPAM_DRAFT_REQUESTED_CONTRIBUTION'
+        ];
+
+        if (contributionRequestedStages.includes(stage.stageType) && dueContribution) {
             stage.stageTypeWithDueDateDisplay = `${stage.stageTypeDisplay} due: ${formatDate(dueContribution)}`;
-        } else if (contributionReceivedStages.includes(stage.stageType)) {
+        } else if (contributionReceivedStages.includes(stage.stageType) && !dueContribution) {
             stage.stageTypeWithDueDateDisplay = `${stage.stageTypeDisplay} (Contributions Received)`;
         } else {
             stage.stageTypeWithDueDateDisplay = stage.stageTypeDisplay;

--- a/server/middleware/__tests__/validation.spec.js
+++ b/server/middleware/__tests__/validation.spec.js
@@ -25,6 +25,24 @@ describe('Validators', () => {
         });
     });
 
+    describe('Required array validator', () => {
+        it('should reject an empty field', () => {
+            expect(validators.requiredArray({})).not.toEqual(null);
+        });
+        it('should reject with value of undefined', () => {
+            expect(validators.requiredArray({ value: undefined })).not.toEqual(null);
+        });
+        it('should reject with value that is not an array', () => {
+            expect(validators.requiredArray({ value: 'test' })).not.toEqual(null);
+        });
+        it('should reject with value that is an empty array', () => {
+            expect(validators.requiredArray({ value: '[]' })).not.toEqual(null);
+        });
+        it('should accept with value that is an array with atleast 1 item', () => {
+            expect(validators.requiredArray({ value: '[1]' })).toEqual(null);
+        });
+    });
+
     describe('Alphanumeric validator', () => {
         it('should reject symbols', () => {
             expect(validators.alphanumeric({  label: 'test',value: '!@£$' })).toEqual('test must be alphanumeric');

--- a/server/middleware/validation.js
+++ b/server/middleware/validation.js
@@ -49,9 +49,23 @@ const validators = {
         }
         return null;
     },
+    requiredArray: ({ label, value, message }) => {
+        let valid = true;
+
+        try {
+            if (!value || JSON.parse(value).length === 0) {
+                valid = false;
+            }
+        } catch (error) {
+            // If the parsing of the value is false, then we know that the value is not an array
+            valid = false;
+        }
+
+        return valid ? null : (message || validationErrors.required(label));
+    },
     required: ({ label, value, message }) => {
         if (!value || value === '') {
-            return message || validationErrors.required(label);
+            return (message || validationErrors.required(label));
         }
         return null;
     },


### PR DESCRIPTION
This PR adds a requiredArray validator that allows for the checking that an inputted string can be parsed as an array and contains at least 1 item. Also improves the workstack display to only show information when at the required stage.