### PR TITLE
HOCS-2199: update multiple contribution field names

### DIFF
--- a/server/lists/adapters/__tests__/__snapshots__/workstacks.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/workstacks.spec.js.snap
@@ -592,7 +592,7 @@ Object {
       "deadlineDisplay": "03/01/2200",
       "stageType": "A",
       "stageTypeDisplay": "MOCK_STAGETYPE",
-      "stageTypeWithDueDateDisplay": "MOCK_STAGETYPE due: 12/12/2020",
+      "stageTypeWithDueDateDisplay": "MOCK_STAGETYPE",
       "teamUUID": 2,
       "userUUID": 2,
     },

--- a/server/lists/adapters/case-view-all-stages.js
+++ b/server/lists/adapters/case-view-all-stages.js
@@ -41,11 +41,10 @@ const renderSomuListItems = async ( { caseType, type, choices }, value, fromStat
 const parseMultipleContributions = async (value, choices, fromStaticList) => {
     const contributions = JSON.parse(value);
     const contributionStrings = await Promise.all(contributions.map(async (contribution) => {
-        console.log(contribution);
-        const { contributionStatus, contributionDueDate, businessUnit, businessArea } = contribution.data;
-        const status = getContributionStatusString({contributionDueDate, contributionStatus });
-        const values = await loadValue(businessUnit, choices, fromStaticList);
-        const title = `${businessArea} - ${values} (${status})`;
+        const { contributionStatus, contributionDueDate, contributionBusinessUnit, contributionBusinessArea } = contribution.data;
+        const status = getContributionStatusString({ contributionDueDate, contributionStatus });
+        const values = await loadValue(contributionBusinessUnit, choices, fromStaticList);
+        const title = `${contributionBusinessArea} - ${values} (${status})`;
         return title;
     }));
 

--- a/server/lists/adapters/workstacks.js
+++ b/server/lists/adapters/workstacks.js
@@ -130,7 +130,7 @@ const bindDisplayElements = fromStaticList => async (stage) => {
 
     if (stage.data && stage.data.CaseContributions) {
         const dueContribution = JSON.parse(stage.data.CaseContributions)
-            .filter(contribution => !contribution.data.contributionStatus)
+            .filter(contribution => contribution.data && !contribution.data.contributionStatus)
             .map(contribution => contribution.data.contributionDueDate)
             .sort()
             .shift();

--- a/server/services/forms/schemas/contribution-fulfillment.js
+++ b/server/services/forms/schemas/contribution-fulfillment.js
@@ -8,7 +8,7 @@ module.exports = async options => {
     return Form()
         .withTitle('Contribution Request Fulfillment')
         .withField(
-            Component('dropdown', 'businessArea')
+            Component('dropdown', 'contributionBusinessArea')
                 .withValidator('required', 'Business area is required')
                 .withProp('label', 'Business Area')
                 .withProp('disabled', true)
@@ -24,18 +24,18 @@ module.exports = async options => {
                 .build()
         )
         .withField(
-            Component('dropdown', 'businessUnit')
+            Component('dropdown', 'contributionBusinessUnit')
                 .withValidator('required', 'Business unit is required')
                 .withProp('label', 'Business Unit')
                 .withProp('disabled', true)
                 .withProp('conditionChoices', [
-                    ConditionChoice('businessArea', 'UKVI', 'S_MPAM_BUS_UNITS_1'),
-                    ConditionChoice('businessArea', 'BF', 'S_MPAM_BUS_UNITS_2'),
-                    ConditionChoice('businessArea', 'IE', 'S_MPAM_BUS_UNITS_3'),
-                    ConditionChoice('businessArea', 'EUSS', 'S_MPAM_BUS_UNITS_4'),
-                    ConditionChoice('businessArea', 'HMPO', 'S_MPAM_BUS_UNITS_5'),
-                    ConditionChoice('businessArea', 'Windrush', 'S_MPAM_BUS_UNITS_6'),
-                    ConditionChoice('businessArea', 'Coronavirus', 'S_MPAM_BUS_UNITS_7')
+                    ConditionChoice('contributionBusinessArea', 'UKVI', 'S_MPAM_BUS_UNITS_1'),
+                    ConditionChoice('contributionBusinessArea', 'BF', 'S_MPAM_BUS_UNITS_2'),
+                    ConditionChoice('contributionBusinessArea', 'IE', 'S_MPAM_BUS_UNITS_3'),
+                    ConditionChoice('contributionBusinessArea', 'EUSS', 'S_MPAM_BUS_UNITS_4'),
+                    ConditionChoice('contributionBusinessArea', 'HMPO', 'S_MPAM_BUS_UNITS_5'),
+                    ConditionChoice('contributionBusinessArea', 'Windrush', 'S_MPAM_BUS_UNITS_6'),
+                    ConditionChoice('contributionBusinessArea', 'Coronavirus', 'S_MPAM_BUS_UNITS_7')
                 ])
                 .build()
         )

--- a/server/services/forms/schemas/contribution-request.js
+++ b/server/services/forms/schemas/contribution-request.js
@@ -18,7 +18,7 @@ module.exports = async options => {
     const form = Form()
         .withTitle(`${isAdd ? 'Add' : isReadOnly ? 'View' : 'Edit'} Contribution Request`)
         .withField(
-            Component('dropdown', 'businessArea')
+            Component('dropdown', 'contributionBusinessArea')
                 .withValidator('required', 'Business area is required')
                 .withProp('label', 'Business Area')
                 .withProp('disabled', isReadOnly)
@@ -34,18 +34,18 @@ module.exports = async options => {
                 .build()
         )
         .withField(
-            Component('dropdown', 'businessUnit')
+            Component('dropdown', 'contributionBusinessUnit')
                 .withValidator('required', 'Business unit is required')
                 .withProp('label', 'Business Unit')
                 .withProp('disabled', isReadOnly)
                 .withProp('conditionChoices', [
-                    ConditionChoice('businessArea', 'UKVI', 'S_MPAM_BUS_UNITS_1'),
-                    ConditionChoice('businessArea', 'BF', 'S_MPAM_BUS_UNITS_2'),
-                    ConditionChoice('businessArea', 'IE', 'S_MPAM_BUS_UNITS_3'),
-                    ConditionChoice('businessArea', 'EUSS', 'S_MPAM_BUS_UNITS_4'),
-                    ConditionChoice('businessArea', 'HMPO', 'S_MPAM_BUS_UNITS_5'),
-                    ConditionChoice('businessArea', 'Windrush', 'S_MPAM_BUS_UNITS_6'),
-                    ConditionChoice('businessArea', 'Coronavirus', 'S_MPAM_BUS_UNITS_7')
+                    ConditionChoice('contributionBusinessArea', 'UKVI', 'S_MPAM_BUS_UNITS_1'),
+                    ConditionChoice('contributionBusinessArea', 'BF', 'S_MPAM_BUS_UNITS_2'),
+                    ConditionChoice('contributionBusinessArea', 'IE', 'S_MPAM_BUS_UNITS_3'),
+                    ConditionChoice('contributionBusinessArea', 'EUSS', 'S_MPAM_BUS_UNITS_4'),
+                    ConditionChoice('contributionBusinessArea', 'HMPO', 'S_MPAM_BUS_UNITS_5'),
+                    ConditionChoice('contributionBusinessArea', 'Windrush', 'S_MPAM_BUS_UNITS_6'),
+                    ConditionChoice('contributionBusinessArea', 'Coronavirus', 'S_MPAM_BUS_UNITS_7')
                 ])
                 .build()
         )

--- a/src/shared/common/forms/composite/__tests__/somu-list.spec.jsx
+++ b/src/shared/common/forms/composite/__tests__/somu-list.spec.jsx
@@ -74,7 +74,7 @@ describe('Somu list component', () => {
             type: 'testType',
             schema: { },
             active: true };
-        const somuItems = [{ uuid: 'test', data: { businessArea: 'TestBusinessArea', businessUnit: 'TestTeam' }, deleted: false }];
+        const somuItems = [{ uuid: 'test', data: { contributionBusinessArea: 'TestBusinessArea', contributionBusinessUnit: 'TestTeam' }, deleted: false }];
         const PROPS = {
             ...DEFAULT_PROPS,
             somuType,
@@ -102,7 +102,7 @@ describe('Somu list component', () => {
             type: 'testType',
             schema: { renderers: { table: 'MpamTable' } },
             active: true };
-        const somuItems = [{ uuid: 'test', data: { businessArea: 'TestBusinessArea', businessUnit: 'TestTeam' }, deleted: false }];
+        const somuItems = [{ uuid: 'test', data: { contributionBusinessArea: 'TestBusinessArea', contributionBusinessUnit: 'TestTeam' }, deleted: false }];
         const PROPS = {
             ...DEFAULT_PROPS,
             somuType,
@@ -124,7 +124,7 @@ describe('Somu list component', () => {
             type: 'testType',
             schema: { renderers: { } },
             active: true };
-        const somuItems = [{ uuid: 'test', data: { uuid: 'test', businessArea: 'TestBusinessArea', businessUnit: 'TestTeam' }, deleted: false }];
+        const somuItems = [{ uuid: 'test', data: { uuid: 'test', contributionBusinessArea: 'TestBusinessArea', contributionBusinessUnit: 'TestTeam' }, deleted: false }];
         const PROPS = {
             ...DEFAULT_PROPS,
             somuType,
@@ -146,7 +146,7 @@ describe('Somu list component', () => {
             type: 'testType',
             schema: { },
             active: true };
-        const somuItems = [{ uuid: 'test', data: { businessArea: 'TestBusinessArea', businessUnit: 'TestUnit' }, deleted: false }];
+        const somuItems = [{ uuid: 'test', data: { contributionBusinessArea: 'TestBusinessArea', contributionBusinessUnit: 'TestUnit' }, deleted: false }];
         const PROPS = {
             ...DEFAULT_PROPS,
             somuType,
@@ -168,7 +168,7 @@ describe('Somu list component', () => {
             type: 'testType',
             schema: { renderers: { table: 'MpamTable' } },
             active: true };
-        const somuItems = [{ uuid: 'test', data: { businessArea: 'TestBusinessArea', businessUnit: 'TestTeam' }, deleted: false }];
+        const somuItems = [{ uuid: 'test', data: { contributionBusinessArea: 'TestBusinessArea', contributionBusinessUnit: 'TestTeam' }, deleted: false }];
         const PROPS = {
             ...DEFAULT_PROPS,
             somuType,
@@ -229,7 +229,7 @@ describe('Somu list component', () => {
             type: 'testType',
             schema: { renderers: { } },
             active: true };
-        const somuItems = [{ uuid: 'test', data: { businessArea: 'TestBusinessArea', businessUnit: 'TestTeam' }, deleted: false }];
+        const somuItems = [{ uuid: 'test', data: { contributionBusinessArea: 'TestBusinessArea', contributionBusinessUnit: 'TestTeam' }, deleted: false }];
         const PROPS = {
             ...DEFAULT_PROPS,
             somuType,
@@ -266,36 +266,36 @@ describe('Somu list component', () => {
         const somuItems = [
             { uuid: 'test',
                 data: {
-                    businessArea: 'TestBusinessArea',
-                    businessUnit: 'TestTeam',
+                    contributionBusinessArea: 'TestBusinessArea',
+                    contributionBusinessUnit: 'TestTeam',
                     contributionStatus: 'contributionCancelled'
                 },
                 deleted: false },
             { uuid: 'test',
                 data: {
-                    businessArea: 'TestBusinessArea',
-                    businessUnit: 'TestTeam',
+                    contributionBusinessArea: 'TestBusinessArea',
+                    contributionBusinessUnit: 'TestTeam',
                     contributionStatus: 'contributionReceived'
                 },
                 deleted: false },
             { uuid: 'test',
                 data: {
-                    businessArea: 'TestBusinessArea',
-                    businessUnit: 'TestTeam',
+                    contributionBusinessArea: 'TestBusinessArea',
+                    contributionBusinessUnit: 'TestTeam',
                     contributionDueDate: '2020-01-01'
                 },
                 deleted: false },
             { uuid: 'test',
                 data: {
-                    businessArea: 'TestBusinessArea',
-                    businessUnit: 'TestTeam',
+                    contributionBusinessArea: 'TestBusinessArea',
+                    contributionBusinessUnit: 'TestTeam',
                     contributionDueDate:  '2050-01-01'
                 },
                 deleted: false },
             { uuid: 'test',
                 data: {
-                    businessArea: 'TestBusinessArea',
-                    businessUnit: 'TestTeam',
+                    contributionBusinessArea: 'TestBusinessArea',
+                    contributionBusinessUnit: 'TestTeam',
                     contributionDueDate: 'xx'
                 },
                 deleted: false }

--- a/src/shared/common/forms/composite/somu-list.jsx
+++ b/src/shared/common/forms/composite/somu-list.jsx
@@ -54,7 +54,7 @@ class SomuTableRenderer {
 
     renderMpamContribution(somuItem) {
         const { choices } = this.state;
-        const title = `${somuItem.businessArea} - ${this.loadValue(somuItem.businessUnit, choices)}`;
+        const title = `${somuItem.contributionBusinessArea} - ${this.loadValue(somuItem.contributionBusinessUnit, choices)}`;
         const contributionStatus = this.getContributionStatus(somuItem);
 
         return (<>


### PR DESCRIPTION
At present in Multiple Contributions screens we have the idea of a businessUnit and businessArea. This change re-words this to be contributionBusinessArea and contributionBusinessUnit. Also fixes a missed edge case where data could be null in contributions.