### PR TITLE
HOCS-2051 ukvi search by correspondent results page

### DIFF
--- a/server/lists/adapters/workstacks.js
+++ b/server/lists/adapters/workstacks.js
@@ -109,6 +109,11 @@ const returnMyCasesWorkstackColumns = (configuration, workstackData) => {
     return getColumnsForMyCases.workstackColumns;
 };
 
+const getCorrespondentsNameByType = (correspondents, types) =>
+    correspondents.correspondents.filter(correspondent => types.includes(correspondent.type))
+        .map(correspondent => correspondent.fullname)
+        .join(', ');
+
 const bindDisplayElements = fromStaticList => async (stage) => {
     stage.assignedTeamDisplay = await fromStaticList('S_TEAMS', stage.teamUUID);
     stage.caseTypeDisplayFull = await fromStaticList('S_CASETYPES', stage.caseType);
@@ -155,6 +160,12 @@ const bindDisplayElements = fromStaticList => async (stage) => {
     } else {
         stage.stageTypeWithDueDateDisplay = stage.stageTypeDisplay;
     }
+
+    if (stage.correspondents && stage.correspondents.correspondents) {
+        stage.memberCorrespondentDisplay = getCorrespondentsNameByType(stage.correspondents, ['MEMBER']);
+        stage.applicantOrConstituentCorrespondentDisplay = getCorrespondentsNameByType(stage.correspondents, ['APPLICANT', 'CONSTITUENT']);
+    }
+
     return stage;
 };
 


### PR DESCRIPTION
This change is part of HOCS-2051 to allow UKVI users to filter by correspondent. This PR populates workstack display elements for correspondents

This should be merged in at the same time as the following PRs:
https://github.com/UKHomeOffice/hocs-frontend/pull/565
https://github.com/UKHomeOffice/hocs-data/pull/489
https://github.com/UKHomeOffice/hocs-casework/pull/367