### PR TITLE
HOCS-2309: change to send plain text in somu update data request

### DIFF
--- a/server/services/action.js
+++ b/server/services/action.js
@@ -213,11 +213,15 @@ const actions = {
                             await caseworkService.post(`/case/${caseId}/item/${somuTypeUuid}`, { data: somuItemData }, headers);
                             break;
                         case actionTypes.ADD_ADDITIONAL_CONTRIBUTION:
-                            await caseworkService.put(`/case/${caseId}/data/CaseContributions`, { data: somuTypeItems }, headers);
+                            await caseworkService.put(`/case/${caseId}/data/CaseContributions`,
+                                somuTypeItems,
+                                { headers: { ...headers.headers, 'Content-Type': 'text/plain' } });
                             await caseworkService.post(`/case/${caseId}/item/${somuTypeUuid}`, { data: somuItemData }, headers);
                             break;
                         case actionTypes.EDIT_CONTRIBUTION:
-                            await caseworkService.put(`/case/${caseId}/data/CaseContributions`, { data: somuTypeItems }, headers);
+                            await caseworkService.put(`/case/${caseId}/data/CaseContributions`,
+                                somuTypeItems,
+                                { headers: { ...headers.headers, 'Content-Type': 'text/plain' } });
                             await caseworkService.post(`/case/${caseId}/item/${somuTypeUuid}`, { uuid: somuItemUuid, data: somuItemData }, headers);
                             break;
                     }


### PR DESCRIPTION
When updating the case contributions data value, previously we sent an JSON object with a value of data that contained the somu type items. This change to hocs-casework has regressed functionality. To fix this regression, this change sends the data as plain text, overriding the default 'application/json'.