### PR TITLE
HOCS-2316: Revert form-enabled somu change

### DIFF
--- a/src/shared/common/forms/composite/__tests__/somu-list.spec.jsx
+++ b/src/shared/common/forms/composite/__tests__/somu-list.spec.jsx
@@ -220,7 +220,7 @@ describe('Somu list component', () => {
         const SomuList = OUTER.props().children;
         mount(<SomuList />);
         expect(MOCK_CALLBACK).toHaveBeenCalledTimes(1);
-        expect(MOCK_CALLBACK).toHaveBeenCalledWith({ [DEFAULT_PROPS.name]: [] });
+        expect(MOCK_CALLBACK).toHaveBeenCalledWith({ [DEFAULT_PROPS.name]: '[]' });
     });
 
     it('should include hideSidebar query param on primary and item links', () => {

--- a/src/shared/common/forms/composite/somu-list.jsx
+++ b/src/shared/common/forms/composite/somu-list.jsx
@@ -135,7 +135,7 @@ class SomuList extends Component {
     componentDidMount() {
         const { name, somuItems } = this.props;
 
-        this.props.updateState({ [name]: somuItems });
+        this.props.updateState({ [name]: JSON.stringify(somuItems) });
     }
 
     renderItemLinks(somuItem) {

--- a/src/shared/pages/form-enabled.jsx
+++ b/src/shared/pages/form-enabled.jsx
@@ -115,7 +115,9 @@ function withForm(Page) {
                 const formData = new FormData();
                 Object.keys(form_data).filter(field => form_data[field] !== null).forEach(field => {
                     if (Array.isArray(form_data[field])) {
-                        formData.append(field, JSON.stringify(form_data[field]));
+                        form_data[field].map(value => {
+                            formData.append(`${field}[]`, value);
+                        });
                     } else {
                         formData.append(field, form_data[field]);
                     }


### PR DESCRIPTION
Due to a misunderstanding of the form-enabled submit handler, when a object array has been sent through it was not handling is correctly. This change reverts the somu change and ensures that the somu-list sends it through as a string instead of an object array.