### PR TITLE
HOCS-2325: Change to use the data of contribution

### DIFF
--- a/src/shared/common/components/__tests__/__snapshots__/workstack.spec.jsx.snap
+++ b/src/shared/common/components/__tests__/__snapshots__/workstack.spec.jsx.snap
@@ -651,7 +651,7 @@ exports[`Workstack component should render with filtering 1`] = `
               "caseUUID": "case_uuid-efg",
               "created": null,
               "data": Object {
-                "CaseContributions": "[{\\"contributionDueDate\\":\\"2020-12-12\\"}]",
+                "CaseContributions": "[{\\"data\\":{\\"contributionDueDate\\":\\"2020-12-12\\"}}]",
               },
               "fullName": "Dave Jones",
               "isActive": "YES",
@@ -1132,7 +1132,7 @@ exports[`Workstack component should sort descending when the column heading is c
               "caseUUID": "case_uuid-efg",
               "created": null,
               "data": Object {
-                "CaseContributions": "[{\\"contributionDueDate\\":\\"2020-12-12\\"}]",
+                "CaseContributions": "[{\\"data\\":{\\"contributionDueDate\\":\\"2020-12-12\\"}}]",
               },
               "fullName": "Dave Jones",
               "isActive": "YES",
@@ -1985,7 +1985,7 @@ exports[`Workstack component should sort when the column heading is clicked 1`] 
               "caseUUID": "case_uuid-efg",
               "created": null,
               "data": Object {
-                "CaseContributions": "[{\\"contributionDueDate\\":\\"2020-12-12\\"}]",
+                "CaseContributions": "[{\\"data\\":{\\"contributionDueDate\\":\\"2020-12-12\\"}}]",
               },
               "fullName": "Dave Jones",
               "isActive": "YES",

--- a/src/shared/common/components/__tests__/workstack.spec.jsx
+++ b/src/shared/common/components/__tests__/workstack.spec.jsx
@@ -42,7 +42,7 @@ describe('Workstack component', () => {
                 caseReference: 'case4', caseUUID: 'case_uuid-efg', uuid: 'stage_uuid-445', fullName: 'Dave Jones',
                 stageTypeDisplay: 'Stage D', assignedUserDisplay: 'User4', assignedTeamDisplay: 'team4',
                 created: null, isActive: 'YES', stageType: 'MPAM_DRAFT',
-                data: { CaseContributions: '[{"contributionDueDate":"2020-12-12"}]' }
+                data: { CaseContributions: '[{"data":{"contributionDueDate":"2020-12-12"}}]' }
             },
             {
                 caseReference: 'case5', caseUUID: 'case_uuid-hij', uuid: 'stage_uuid-446', fullName: 'Mick Smith',

--- a/src/shared/common/components/workstack.jsx
+++ b/src/shared/common/components/workstack.jsx
@@ -288,10 +288,11 @@ class WorkstackAllocate extends Component {
                 }
                 return <td key={row.uuid + column.dataValueKey} className='govuk-table__cell'>{value}</td>;
             case ColumnRenderer.DUE_DATE_WARNING:
+                console.log(row.data);
                 if (row.data.CaseContributions) {
                     const dueContribution = JSON.parse(row.data.CaseContributions)
-                        .filter(contribution => !contribution.contributionStatus)
-                        .map(contribution => contribution.contributionDueDate)
+                        .filter(contribution => contribution.data && !contribution.data.contributionStatus)
+                        .map(contribution => contribution.data.contributionDueDate)
                         .sort()
                         .shift();
 


### PR DESCRIPTION
Currently we check the contributionStatus on each of the core contribution items. This does not work as the contributionStatus is currently within a data object of the contribution item. This change changes the current check to use the data and ensures the data is there to stop undefined errors. Tests have been updated to ensure validity of action.