### PR TITLE
HOCS-2325: Allow for defaultValue prop to propagate

### DIFF
--- a/src/shared/common/forms/__tests__/form-repository.spec.js
+++ b/src/shared/common/forms/__tests__/form-repository.spec.js
@@ -126,4 +126,19 @@ describe('Form repository', () => {
         expect(Component).toBeNull();
     });
 
+    it('should set the value to the default value if set in props', () => {
+        let defaultHiddenComponent = { component: 'hidden', props: { name: 'hidden-component', defaultValue: 'Test' } };
+
+        const component = formComponentFactory(defaultHiddenComponent.component, {
+            key: 1,
+            config: defaultHiddenComponent.props,
+            callback: mockCallback
+        });
+
+        expect(component).toBeDefined();
+        expect(component.props).toBeDefined();
+        expect(component.props.defaultValue).toEqual('Test');
+        expect(component.props.value).toEqual('Test');
+    });
+
 });

--- a/src/shared/common/forms/form-repository.jsx
+++ b/src/shared/common/forms/form-repository.jsx
@@ -31,8 +31,10 @@ function defaultDataAdapter(name, data) {
 
 function renderFormComponent(Component, options) {
     const { key, config, data, errors, callback, dataAdapter, page } = options;
+    
     if (isComponentVisible(config, data)) {
-        let value = '';
+        let value = config.defaultValue ? config.defaultValue : '';
+
         if (data) {
             value = dataAdapter ? dataAdapter(config.name, data) : defaultDataAdapter(config.name, data);
         }
@@ -73,6 +75,12 @@ export function formComponentFactory(field, options) {
         case 'mapped-text':
             return renderFormComponent(MappedText, { key, config, data, errors, callback });
         case 'hidden':
+            console.log(1)
+            console.log(data)
+            console.log(2)
+            console.log(config)
+            console.log(3)
+            console.log(key)
             return renderFormComponent(Hidden, { key, config, data, errors, callback });
         case 'date':
             return renderFormComponent(DateInput, { key, config, data, errors, callback });


### PR DESCRIPTION
As a result of the multiple contributions piece, we removed a field. Unfortunately previous cases rely on this field, this change allows us to enter a field and pass in a defaultValue that effects the actual value on the field.