### PR TITLE
HOCS-2353-MPAM-Correspondent-In-Workstack-Not-Search

### DIFF
--- a/server/libs/__tests__/workstackColumnHelpers.spec.js
+++ b/server/libs/__tests__/workstackColumnHelpers.spec.js
@@ -1,0 +1,25 @@
+const { extractWorkstackTypeColumns } = require('../workstackColumnHelpers');
+
+describe('Workstack Type Columns helper', () => {
+    it('should return the specific workstack for the case type if it exists', () => {
+        const workstackTypeColumns = [
+            { workstackType: 'DEFAULT', workstackColumns: {} },
+            { workstackType: 'testType_SEARCH_RESULTS', workstackColumns: {} }
+        ];
+
+        const result = extractWorkstackTypeColumns('SEARCH_RESULTS')(workstackTypeColumns,  { caseType: 'testType' } );
+
+        expect(result).toEqual({ workstackType: 'testType_SEARCH_RESULTS', workstackColumns: {} } );
+    });
+
+    it('should return the default workstack if a specific one for the case type does not exist', () => {
+        const workstackTypeColumns = [
+            { workstackType: 'DEFAULT', workstackColumns: {} },
+            { workstackType: 'testType_SEARCH_RESULTS', workstackColumns: {} }
+        ];
+
+        const result = extractWorkstackTypeColumns('SEARCH_RESULTS')(workstackTypeColumns,  { caseType: 'testType2' } );
+
+        expect(result).toEqual({ workstackType: 'DEFAULT', workstackColumns: {} } );
+    });
+});

--- a/server/libs/workstackColumnHelpers.js
+++ b/server/libs/workstackColumnHelpers.js
@@ -1,0 +1,16 @@
+const extractWorkstackTypeColumns = (suffix) => (workstackTypeColumns, request) => {
+    let workstackColumns = workstackTypeColumns.find(
+        item => item.workstackType === `${request.caseType}_${suffix}`
+    );
+
+    if (workstackColumns === undefined) {
+        workstackColumns = workstackTypeColumns.find(
+            item => item.workstackType === 'DEFAULT'
+        );
+    }
+    return workstackColumns;
+};
+
+module.exports = {
+    extractWorkstackTypeColumns
+};

--- a/server/middleware/searchHandler.js
+++ b/server/middleware/searchHandler.js
@@ -1,3 +1,5 @@
+const { extractWorkstackTypeColumns } = require('../libs/workstackColumnHelpers');
+
 const { caseworkService } = require('../clients');
 const getLogger = require('../libs/logger');
 const User = require('../models/user');
@@ -7,6 +9,7 @@ const { infoService } = require('../clients');
 
 async function handleSearch(req, res, next) {
     const logger = getLogger(req.requestId);
+
     try {
         const formData = req.form.data;
         const request = {
@@ -47,10 +50,9 @@ async function handleSearch(req, res, next) {
             .sort(sortObjectByProp(workstackCase => workstackCase.caseReference))
             .map(bindDisplayElements(fromStaticList)));
         const { workstackTypeColumns } = await req.listService.fetch('S_SYSTEM_CONFIGURATION');
-        // using DEFAULT columns for search
-        const workstackTypeForSearch = workstackTypeColumns.find(
-            item => item.workstackType === 'DEFAULT'
-        );
+
+        const workstackTypeForSearch =
+            extractWorkstackTypeColumns('SEARCH_RESULTS')(workstackTypeColumns, request);
 
         res.locals.workstack = {
             label: 'Search Results',


### PR DESCRIPTION
This bug fix should merged alongside: https://github.com/UKHomeOffice/hocs-data/pull/503

* Look for caseType specific search stack