### PR TITLE
HOCS-2395-Remove-broken-aria-reference

### DIFF
--- a/src/shared/common/forms/__tests__/__snapshots__/radio-group.spec.js.snap
+++ b/src/shared/common/forms/__tests__/__snapshots__/radio-group.spec.js.snap
@@ -145,7 +145,6 @@ exports[`Form radio group component should render error message for textarea if 
             Some error message
           </span>
           <textarea
-            aria-describedby="ValueAText  ValueAText-error"
             class="govuk-textarea  govuk-textarea--error"
             id="ValueAText"
             name="ValueAText"
@@ -661,7 +660,6 @@ exports[`Form radio group component should textarea if conditional content exist
             someLabel
           </label>
           <textarea
-            aria-describedby="ValueAText "
             class="govuk-textarea "
             id="ValueAText"
             name="ValueAText"

--- a/src/shared/common/forms/radio-group.jsx
+++ b/src/shared/common/forms/radio-group.jsx
@@ -163,7 +163,6 @@ class Radio extends Component {
                                                     name={`${choice.value}Text`}
                                                     disabled={disabled}
                                                     rows="4"
-                                                    aria-describedby={`${choice.value}Text ${this.isConditionalContentError(errors, `${choice.value}Text`) ? ` ${choice.value}Text-error` : ''}`}
                                                     onChange={e => this.handleChangeForTextArea(e)}
                                                     value={this.returnConditionalContentValue(`${value}Text`)}
                                                 />


### PR DESCRIPTION
The other input fields do not use aria labels, so for consistency:
* remove broken aria-describeby and rely on form label for screenreader description