### PR TITLE
HOCS-2444 Add health-checks to Compose; add Readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,156 @@
+# docker-compose
+
+This directory contains configuration for Docker Compose, a quick way to get a
+local HOCS environment on your computer.
+
+To start all services, do:
+```console
+$ docker-compose up
+```
+
+This might take over five minutes to run.
+The first time you run it Compose will download the latest images; this could
+take an additional fifteen minutes, depending on your connection.
+
+You&rsquo;ll also need to configure the database schema;
+[see below for details](#missing-sql-tables).
+
+You can also ask Compose to background the process (detach) once everything is
+up and running:
+```console
+$ docker-compose up -d
+```
+
+To turn the containers off, press CTRL and C at the same time in that terminal
+(SIGINT). Alternatively, run:
+```console
+$ docker-compose down
+```
+
+This will tear down the environment, so you&rsquo;ll have a lengthy wait when
+starting the containers next time. If you&rsquo;re going to need the environment
+again soon, consider instead using the equivalent of standby:
+
+```console
+$ docker-compose pause
+$ docker-compose unpause
+```
+
+To only run the infrastructure containers (like PostgreSQL, AWS and ClamAV),
+or to run the other HOCS services that aren&rsquo;t frontend, do:
+```console
+$ ./scripts/infrastructure.sh
+$ ./scripts/services.sh
+```
+
+You can also run individual services. For example:
+```console
+$ docker-compose up frontend # localhost:8080
+```
+
+If you ask to bring up a service with a dependency, Compose will treat this
+command as an implicit request to bring up the dependencies before bringing
+up the dependant. If you don&rsquo;t want that, use:
+
+```console
+$ docker-compose up --no-deps frontend
+```
+
+If Docker doesn&rsquo;t have the images it needs, it will automatically
+pull them. However, it won&rsquo;t pull existing images. If you want to run
+the latest versions of services, remember to ask for them first:
+
+```console
+$ docker-compose pull
+$ docker-compose up
+```
+
+## Troubleshooting
+### Unhealthy containers
+
+Docker Compose is configured so that containers that depend on other containers
+don't get started until their dependencies are not only running, but also ready
+for use.
+
+If a container doesn't start working after a certain period of time, it will be
+marked as &ldquo;unhealthy&rdquo; and Docker Compose will exit.
+
+The error mesage will look something like this:
+
+```console
+ERROR: for frontend  Container "fe34db64b428" is unhealthy.
+ERROR: Encountered errors while bringing up the project.
+```
+
+The hexadecimal number is the problematic container's ID.
+You can check to see which container is misbehaving with:
+
+```console
+$ docker container ls
+$ docker container logs fe34db64b428
+```
+
+(If you&rsquo;re new to Docker, the duration under &ldquo;STATUS&rdquo; is
+generally more applicable here than the one under &ldquo;CREATED&rdquo;.)
+
+This error is often due the process simply taking longer than usual to start,
+and waiting a bit longer is enough to resolve the issue.
+
+However, if you grow tired of waiting, or the logs look strange, you can usually
+fix the problem by restarting the container:
+
+```console
+$ docker container restart fe34db64b428
+```
+
+Once the container is marked as &ldquo;healthy&rdquo; you can just pick the
+the Docker Compose startup from where you left off:
+
+```console
+$ docker-compose up
+```
+
+For more serious problems you might need to tear down the environment with
+`docker-compose down` and start again.
+
+### Missing SQL tables
+
+The info-service doesn&rsquo;t come with its schema, so if your PostgreSQL
+container is new, like when yoursquo;re setting up your environment for the
+first time, your info-service will complain about missing data;
+you&rsquo;ll need to set the schema up manually.
+
+The info-service schema isn&rsquo;t currently available publicly, and is stored
+in a private repository on GitHub. Request access from an existing team member.
+If you&rsquo;re working in Government but aren&rsquo;t a member of the DECS
+development team, ask someone from the Home Office in the cross-Government Slack
+channel to ask us on your behalf.
+
+Depending on which version of HOCS you wish to run, clone the repository and
+run the Docker Compose included in that repo:
+
+```console
+$ git clone git@github.com:UKHomeOffice/hocs-data.git
+$ cd hocs-data
+$ docker-compose up
+```
+
+```console
+$ git clone git@github.com:UKHomeOffice/hocs-data-wcs.git
+$ cd hocs-data-wcs
+$ docker-compose up
+```
+
+You need to do this after the PostgreSQL server is ready, but before the
+info-service pod is running. When you `docker-compose up` for the first time,
+there&rsquo;s usually a short delay immediately after, when Localstack is
+getting ready. That&rsquo;s the best time to `cd` into the schema and run these
+commands.
+
+### 403 on Frontend
+
+The frontend container doesn&rsquo;t handle authentication, as it is handled
+by a proxy before it hits the app. You&rsquo;ll need to set authentication
+headers yourself using (for example) a browser extension. Ask an existing
+developer for their copy. This might manifest itself as a browser timeout:
+check stderr before assuming something else is wrong.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -257,7 +257,7 @@ services:
     - hocs-network
     environment:
       SPRING_PROFILES_ACTIVE: 'development, local, postgres'
-      SPRING_FLYWAY_SCHEMAS: 'docs'
+      SPRING_FLYWAY_SCHEMAS: 'document'
       SERVER_PORT: 8080
       DOCS_QUEUE_NAME: 'document-queue'
       DOCS_QUEUE_DLQ_NAME: 'document-queue-dlq'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,9 +1,11 @@
-version: '3.1'
+version: '2.4' # v3 doesn't support depends_on condition
 
 services:
 
   postgres:
     image: postgres:9.6
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
     restart: always
     ports:
     - 5432:5432
@@ -18,6 +20,9 @@ services:
     - /var/lib/postgresql
 
   clamd:
+    healthcheck:
+      test: [ "CMD", "./check.sh"]
+      start_period: 2m
     image: mkodockx/docker-clamav:buster-slim
     ports:
     - "3310:3310/tcp"
@@ -25,6 +30,9 @@ services:
     - hocs-network
 
   clamav:
+    healthcheck:
+      # -f makes curl exit with 22 on error (it doesn't normally)
+      test: ["CMD", "curl", "-f", "http://localhost:8080"]
     image: lokori/clamav-rest
     environment:
     - CLAMD_HOST=clamd
@@ -33,9 +41,12 @@ services:
     networks:
     - hocs-network
     depends_on:
-    - clamd
+      clamd:
+        condition: service_healthy
 
   keycloak:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/auth"]
     image: jboss/keycloak:5.0.0
     restart: always
     ports:
@@ -52,6 +63,17 @@ services:
     - ${PWD}/keycloak:/tmp
 
   localstack:
+    healthcheck:
+      test:
+        - CMD
+        - bash
+        - -c
+        - awslocal es list-domain-names
+          && awslocal s3 ls
+          && awslocal sqs list-queues
+      interval: 5s
+      timeout: 10s
+      start_period: 90s
     image: localstack/localstack:0.9.5
     ports:
       - 9000:8080
@@ -98,9 +120,12 @@ services:
     networks:
     - hocs-network
     depends_on:
-    - localstack
+      localstack:
+        condition: service_healthy
 
   frontend:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
     image: quay.io/ukhomeofficedigital/hocs-frontend
     # image: hocs-frontend-test
     ports:
@@ -119,13 +144,21 @@ services:
       S3_BUCKET: 'untrusted-bucket'
       S3_ENDPOINT: http://localstack:4572
     depends_on:
-    - workflow
-    - casework
-    - info
-    - documents
-    - localstack
+      workflow:
+        condition: service_healthy
+      casework:
+        condition: service_healthy
+      info:
+        condition: service_healthy
+      documents:
+        condition: service_healthy
+      localstack:
+        condition: service_healthy
 
   casework:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      start_period: 240s
     image: quay.io/ukhomeofficedigital/hocs-casework
     #image: hocs-casework-test
     ports:
@@ -143,10 +176,15 @@ services:
       HOCS_DOCUMENT_SERVICE: 'http://documents:8080'
       AUDIT_TOPIC_NAME: "hocs-audit-topic"
     depends_on:
-    - postgres
-    - localstack
+      postgres:
+        condition: service_healthy
+      localstack:
+        condition: service_healthy
 
   workflow:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      start_period: 240s
     image: quay.io/ukhomeofficedigital/hocs-workflow
     # image: hocs-workflow-test
     ports:
@@ -168,10 +206,17 @@ services:
       DB_SCHEMA_NAME: 'workflow'
       AWS_LOCAL_HOST: 'localstack'
     depends_on:
-    - postgres
-    - localstack
+      postgres:
+        condition: service_healthy
+      localstack:
+        condition: service_healthy # this waits until healthcheck passes
+      aws_cli:
+        condition: service_started # this doesn't
 
   audit:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      start_period: 60s
     image: quay.io/ukhomeofficedigital/hocs-audit
     #image: hocs-audit-test
     ports:
@@ -187,10 +232,15 @@ services:
       HOCS_INFO_SERVICE: 'http://info:8080'
       AWS_LOCAL_HOST: 'localstack'
     depends_on:
-    - postgres
-    - localstack
+      postgres:
+        condition: service_healthy
+      localstack:
+        condition: service_healthy
 
   search:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      start_period: 180s
     image: quay.io/ukhomeofficedigital/hocs-search
     #image: hocs-search-test
     ports:
@@ -212,10 +262,16 @@ services:
       AWS_SQS_ACCESS_KEY: 'UNSET'
       AWS_SQS_SECRET_KEY: 'UNSET'
     depends_on:
-    - postgres
-    - localstack
+      postgres:
+        condition: service_healthy
+      localstack:
+        condition: service_healthy
+      aws_cli:
+        condition: service_started
 
   info:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
     image: quay.io/ukhomeofficedigital/hocs-info-service
     #image: hocs-info-service-test
     ports:
@@ -237,10 +293,15 @@ services:
       AUDIT_QUEUE_DLQ_NAME: 'audit-queue-dlq'
       HOCS_AUDIT_SERVICE: 'http://audit:8080'
     depends_on:
-    - postgres
-    - localstack
-
+      postgres:
+        condition: service_healthy
+      localstack:
+        condition: service_healthy
+      aws_cli:
+        condition: service_started
   converter:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
     image: quay.io/ukhomeofficedigital/hocs-docs-converter
     ports:
     - 8084:8080
@@ -250,6 +311,9 @@ services:
       SERVER_PORT: 8080
 
   documents:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      start_period: 90s
     image: quay.io/ukhomeofficedigital/hocs-docs
     ports:
     - 8083:8080
@@ -270,11 +334,20 @@ services:
       DB_HOST: 'postgres'
       AWS_LOCAL_HOST: 'localstack'
     depends_on:
-    - converter
-    - postgres
-    - localstack
+      clamav:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      localstack:
+        condition: service_healthy
+      converter:
+        condition: service_healthy
+      aws_cli:
+        condition: service_started
 
   templates:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
     image: quay.io/ukhomeofficedigital/hocs-templates
     ports:
       - 8090:8080
@@ -285,6 +358,12 @@ services:
       HOCS_INFO_SERVICE: 'http://info:8080'
       HOCS_AUDITSERVICE: 'http://casework:8080'
       HOCS_SEARCH_SERVICE: 'http://documents:8080'
-
+    depends_on:
+      info:
+        condition: service_healthy
+      audit:
+        condition: service_healthy
+      documents:
+        condition: service_healthy
 networks:
   hocs-network:


### PR DESCRIPTION
This commit improves the Docker Compose experience for Frontend
somewhat, by adding documentation for Docker Compose, and making sure
that Docker brings the containers up in a sensible order (postgres
before info-service, for example; or Localstack before docs). I think
this has always been the intention with the Docker Compose file, as the
`depends_on` properties were already defined -- however, they only
waited for containers to *start*, and didn't wait for the containers to
be *ready* (which is now the new behaviour).

The feature this relies on was removed from Docker 3, but we're not
using any Docker 3 features so it's safe to drop it back down to Docker
2. (We're not using Docker Swarm, you see.) Any docker-compose version
devs are already using will still support this older version of the
syntax.

We add a Readme as this is likely the first part of DECS a new developer
will touch, so this improves the onboarding slightly.

Startup times for Docker Compose might be increased by a minute or so
compared to previously, as we now wait for Localstack to come up safely
before running most of the services. This commit might also mean that
there are more errors than previously -- Compose might complain about
unhealthy containers -- but this is actually just Docker being louder:
these errors will have still existed, but you wouldn't have noticed them
previously.

This commit probably removes the requirement to have separate
"infrastructure" and "services" startup scripts, but I've left them in
so I don't disrupt existing developer workflow.