### PR TITLE
HOCS-2472: MPAM super user cannot view closed cases

### DIFF
--- a/server/services/__tests__/form.spec.js
+++ b/server/services/__tests__/form.spec.js
@@ -193,7 +193,7 @@ describe('getFormForStage', () => {
         expect(next).toHaveBeenCalled();
     });
 
-    it('should return form with defined schema if repository returns form with null schema', async () => {
+    it('should return form correct form object if repository returns null form', async () => {
         req = {
             params: {
                 action: 'ACTION'
@@ -206,7 +206,7 @@ describe('getFormForStage', () => {
         };
 
         const { workflowService } = require('../../clients');
-        workflowService.get.mockImplementation(() => Promise.resolve({ data: { form: { schema: null } } }));
+        workflowService.get.mockImplementation(() => Promise.resolve({ data: { form: null } }));
         const { getFormForStage } = require('../form');
         await getFormForStage(req, res, next);
 

--- a/server/services/__tests__/form.spec.js
+++ b/server/services/__tests__/form.spec.js
@@ -9,6 +9,16 @@ jest.mock('../../clients', () => ({
     }
 }));
 
+jest.mock('../list/service', () => ({
+    getInstance: function () {
+        return {
+            fetch: function () {
+                return mockActionForm;
+            }
+        };
+    }
+}));
+
 const mockActionForm = {
     schema: {
         fields: []
@@ -180,6 +190,28 @@ describe('getFormForStage', () => {
         const { getFormForStage } = require('../form');
         await getFormForStage(req, res, next);
         expect(req.form).toBeDefined();
+        expect(next).toHaveBeenCalled();
+    });
+
+    it('should return form with defined schema if repository returns form with null schema', async () => {
+        req = {
+            params: {
+                action: 'ACTION'
+            },
+            user: {
+                id: 'test',
+                roles: [],
+                groups: []
+            }
+        };
+
+        const { workflowService } = require('../../clients');
+        workflowService.get.mockImplementation(() => Promise.resolve({ data: { form: { schema: null } } }));
+        const { getFormForStage } = require('../form');
+        await getFormForStage(req, res, next);
+
+        expect(req.form.schema).toEqual({ fields: [] });
+        expect(req.form).toEqual(mockActionForm);
         expect(next).toHaveBeenCalled();
     });
 

--- a/server/services/form.js
+++ b/server/services/form.js
@@ -70,6 +70,11 @@ async function getFormSchemaFromWorkflowService(requestId, options, user) {
                 return { error: new Error(`Failed to retrieve form: ${error.response.status}`) };
         }
     }
+    if (response.data.form.schema === null) {
+        const { readOnlyCaseViewAdapter } = await  listService.getInstance(requestId, user).fetch('S_SYSTEM_CONFIGURATION');
+        const response = await listService.getInstance(requestId, user).fetch(readOnlyCaseViewAdapter, { caseId });
+        return { form: response };
+    }
     const { stageUUID, caseReference, allocationNote } = response.data;
     const mockAllocationNote = allocationNote || null;
     const { schema, data } = response.data.form;

--- a/server/services/form.js
+++ b/server/services/form.js
@@ -70,8 +70,8 @@ async function getFormSchemaFromWorkflowService(requestId, options, user) {
                 return { error: new Error(`Failed to retrieve form: ${error.response.status}`) };
         }
     }
-    if (response.data.form.schema === null) {
-        const { readOnlyCaseViewAdapter } = await  listService.getInstance(requestId, user).fetch('S_SYSTEM_CONFIGURATION');
+    if (response.data.form === null) {
+        const { readOnlyCaseViewAdapter } = await listService.getInstance(requestId, user).fetch('S_SYSTEM_CONFIGURATION');
         const response = await listService.getInstance(requestId, user).fetch(readOnlyCaseViewAdapter, { caseId });
         return { form: response };
     }

--- a/server/services/form.js
+++ b/server/services/form.js
@@ -7,6 +7,13 @@ const User = require('../models/user');
 const FormBuilder = require('./forms/form-builder');
 const { Component } = require('./forms/component-builder');
 
+async function returnReadOnlyCaseViewForm(requestId, user, caseId) {
+    const { readOnlyCaseViewAdapter } = await listService
+        .getInstance(requestId, user)
+        .fetch('S_SYSTEM_CONFIGURATION');
+    return await listService.getInstance(requestId, user).fetch(readOnlyCaseViewAdapter, { caseId });
+}
+
 async function getFormSchemaFromWorkflowService(requestId, options, user) {
     const { caseId, stageId } = options;
     const headers = User.createHeaders(user);
@@ -18,9 +25,7 @@ async function getFormSchemaFromWorkflowService(requestId, options, user) {
             case 401:
                 // handle no permission to allocate
                 try {
-                    const { readOnlyCaseViewAdapter } = await listService.getInstance(requestId, user).fetch('S_SYSTEM_CONFIGURATION');
-                    const response = await listService.getInstance(requestId, user).fetch(readOnlyCaseViewAdapter, { caseId });
-                    return { form: response };
+                    return { form: await returnReadOnlyCaseViewForm(requestId, user, caseId) };
                 } catch (error) {
                     return { error: new PermissionError('You are not authorised to work on this case') };
                 }
@@ -37,8 +42,7 @@ async function getFormSchemaFromWorkflowService(requestId, options, user) {
                     usersInTeam = [];
                 }
                 try {
-                    const { readOnlyCaseViewAdapter } = await listService.getInstance(requestId, user).fetch('S_SYSTEM_CONFIGURATION');
-                    caseView = await listService.getInstance(requestId, user).fetch(readOnlyCaseViewAdapter, { caseId });
+                    caseView = await returnReadOnlyCaseViewForm(requestId, user, caseId);
                 } catch (error) {
                     caseView = null;
                 }
@@ -71,8 +75,7 @@ async function getFormSchemaFromWorkflowService(requestId, options, user) {
         }
     }
     if (response.data.form === null) {
-        const { readOnlyCaseViewAdapter } = await listService.getInstance(requestId, user).fetch('S_SYSTEM_CONFIGURATION');
-        const response = await listService.getInstance(requestId, user).fetch(readOnlyCaseViewAdapter, { caseId });
+        const response = await returnReadOnlyCaseViewForm(requestId, user, caseId);
         return { form: response };
     }
     const { stageUUID, caseReference, allocationNote } = response.data;


### PR DESCRIPTION
Currently for all non super users; to access a closed case we rely on receiving a 401 response from workflow service then we populate a read-only form. With the super user functionality (see HOCS-2027) a 401 response is not sent, and a form is returned with a null value, this fix generates the form exactly the same way as we do for non supers when accessing a closed case by populating the form using the `readOnlyCaseViewAdapter` adapter functionality.