### PR TITLE
HOCS-2473: Allow UKVI to mark overdue contribution as received

### DIFF
--- a/server/services/forms/schemas/contribution-request.js
+++ b/server/services/forms/schemas/contribution-request.js
@@ -62,7 +62,7 @@ module.exports = async options => {
             Component('date', 'contributionDueDate')
                 .withValidator('required')
                 .withValidator('isValidDate')
-                .withValidator('isAfterToday')
+                .withValidator('isValidWithinDate')
                 .withProp('label', 'Contribution due date')
                 .withProp('disabled', isReadOnly)
                 .build()


### PR DESCRIPTION
This PR changes the contributionDueDate validator to allow dates to be 6 months in the past.