### PR TITLE
HOCS-2643: migrate from drone 0.8 to 1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .idea
-build
 node_modules
 .iml
 .git

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,218 +1,257 @@
-pipeline:
+---
+kind: pipeline
+type: kubernetes
+name: build
 
-    build-docker-image:
-      group: lint-build-steps
-      image: docker:17.09.1
-      environment:
-        - DOCKER_HOST=tcp://172.17.0.1:2375
-      commands:
-        - docker build -t hocs-frontend .
-      when:
-        event: push
+steps:
+  - name: install dependencies
+    image: node:14.15.4-alpine
+    commands:
+      - npm --loglevel warn install --production=false --no-optional
 
-    lint:
-      group: lint-build-steps
-      image: node:14.15.4-alpine
-      commands:
-        - npm i eslint@7.20.0
-        - npm run lint
-      when:
-        event: [push, pull_request]
+  - name: build project
+    image: node:14.15.4-alpine
+    commands:
+      - npm run build-prod
+    depends_on:
+      - install dependencies
 
-    install-docker-image-latest:
-      image: docker:17.09.1
-      environment:
-        - DOCKER_HOST=tcp://172.17.0.1:2375
-      secrets:
-        - docker_password
-      commands:
-        - docker login -u="ukhomeofficedigital+hocs" -p=$${DOCKER_PASSWORD} quay.io
-        - docker tag hocs-frontend quay.io/ukhomeofficedigital/hocs-frontend:latest
-        - docker push quay.io/ukhomeofficedigital/hocs-frontend:latest
-      when:
-        branch: master
-        event: push
+  - name: test project
+    image: node:14.15.4-alpine
+    commands:
+      - npm test
+    depends_on:
+      - install dependencies
 
-    install-docker-image:
-      image: docker:17.09.1
-      environment:
-        - DOCKER_HOST=tcp://172.17.0.1:2375
-      secrets:
-        - docker_password
-      commands:
-        - docker login -u="ukhomeofficedigital+hocs" -p=$${DOCKER_PASSWORD} quay.io
-        - docker tag hocs-frontend quay.io/ukhomeofficedigital/hocs-frontend:build-$${DRONE_BUILD_NUMBER}
-        - export BRANCH_NAME_TAGFRIENDLY=`echo "$${DRONE_COMMIT_BRANCH}" | sed 's$/$_$g'` # sed can use any character as delimiter
-        - docker tag hocs-frontend quay.io/ukhomeofficedigital/hocs-frontend:branch-$${BRANCH_NAME_TAGFRIENDLY}
-        - docker push quay.io/ukhomeofficedigital/hocs-frontend:build-$${DRONE_BUILD_NUMBER}
-        - docker push quay.io/ukhomeofficedigital/hocs-frontend:branch-$${BRANCH_NAME_TAGFRIENDLY}
-      when:
-        branch: [master, epic/*, hotfix/*]
-        event: push
+  - name: lint project
+    image: node:14.15.4-alpine
+    commands:
+      - npm run lint
+    depends_on:
+      - install dependencies
 
-    sonar-scanner:
-      image: quay.io/ukhomeofficedigital/sonar-scanner:v3.0.2
-      when:
-        event: [push, pull_request, tag]
+  - name: sonar scanner
+    image: quay.io/ukhomeofficedigital/sonar-scanner:v3.0.2
+    depends_on:
+      - build project
+      - test project
 
+  - name: build & push
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/ukhomeofficedigital/hocs-frontend
+      tags:
+        - build_${DRONE_BUILD_NUMBER}
+        - ${DRONE_COMMIT_SHA}
+        - branch-${DRONE_COMMIT_BRANCH/\//_}
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    depends_on:
+      - build project
+      - test project
+      - lint project
 
+  - name: build & push latest
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/ukhomeofficedigital/hocs-frontend
+      tags:
+        - latest
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    when:
+      branch:
+        - main
+    depends_on:
+      - build project
+      - test project
+      - lint project
 
-    docker-semver-tag:
-      image: quay.io/ukhomeofficedigital/hocs-version-bot:build-25
-      environment:
-        - DOCKER_HOST=tcp://172.17.0.1:2375
-        - DOCKER_API_VERSION=1.37
-      secrets:
-        - github_password
-        - docker_password
-        - git_password
-      commands:
-        - /app/hocs-deploy --version=$${SEMVER} --serviceGitToken=$${GIT_PASSWORD} --service=hocs-frontend --gitToken=$${GITHUB_PASSWORD} --gitRepo="https://gitlab.digital.homeoffice.gov.uk/hocs/hocs-versions.git" --environment=qa --dockerRepository=quay.io/ukhomeofficedigital --sourceBuild=$${IMAGE_VERSION} --registryUser=ukhomeofficedigital+hocs --registryPassword=$${DOCKER_PASSWORD}
-      when:
-        event: deployment
-        environment: [cs-qa, wcs-qa, hocs-qax]
+trigger:
+  event:
+    - push
 
-    clone-kube-project:
-      image: plugins/git
-      commands:
-        - git clone https://github.com/UKHomeOffice/kube-hocs-frontend.git
-      when:
-        event: [push, deployment, tag]
+---
+kind: pipeline
+type: kubernetes
+name: deploy
+depends_on:
+  - build
+trigger:
+  event:
+    exclude:
+      - pull_request
+      - tag
 
-    deploy-to-cs-dev-from-build-number:
-      group: deploy-to-dev
-      image: quay.io/ukhomeofficedigital/kd:v1.16.0
-      environment:
-        - DOMAIN=cs
-        - ENVIRONMENT=cs-dev
-        - VERSION=build-${DRONE_BUILD_NUMBER}
-        - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      secrets:
-        - hocs_frontend_dev_cs
-      commands:
-        - cd kube-hocs-frontend
-        - ./deploy.sh
-      when:
-        branch: master
-        event: [push, tag]
+services:
+  - name: docker
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
 
-    deploy-to-wcs-dev-from-build-number:
-      group: deploy-to-dev
-      image: quay.io/ukhomeofficedigital/kd:v1.16.0
-      environment:
-        - DOMAIN=wcs
-        - ENVIRONMENT=wcs-dev
-        - VERSION=build-${DRONE_BUILD_NUMBER}
-        - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      secrets:
-        - hocs_frontend_dev_wcs
-      commands:
-        - cd kube-hocs-frontend
-        - ./deploy.sh
-      when:
-        branch: master
-        event: [push, tag]
+environment:
+  DOCKER_HOST: tcp://docker:2375
 
-    deployment:
-      image: quay.io/ukhomeofficedigital/kd:v1.16.0
-      environment:
-        - ENVIRONMENT=${DRONE_DEPLOY_TO}
-        - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      secrets:
-        - hocs_frontend_dev_cs
-        - hocs_frontend_demo_cs
-        - hocs_frontend_dev_wcs
-        - hocs_frontend_demo_wcs
-        - poise_whitelist
-      commands:
-        - cd kube-hocs-frontend
-        - ./deploy.sh
-      when:
-        event: deployment
-        environment: [cs-dev, cs-demo, wcs-dev, wcs-demo]
+steps:
+  - name: clone kube repo
+    image: plugins/git
+    commands:
+      - git clone https://github.com/UKHomeOffice/kube-hocs-frontend.git
 
-    deploy-to-qa-cs:
-      image: quay.io/ukhomeofficedigital/kd:v1.16.0
-      environment:
-        - DOMAIN=cs
-        - ENVIRONMENT=cs-qa
-        - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      secrets:
-        - hocs_frontend_qa_cs
-        - poise_whitelist
-      commands:
-        - source version.txt
-        - echo $VERSION
-        - cd kube-hocs-frontend
-        - ./deploy.sh
-      when:
-        event: deployment
-        environment: cs-qa
+  - name: deploy to cs-dev
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    environment:
+      ENVIRONMENT: cs-dev
+      VERSION: build_${DRONE_BUILD_NUMBER}
+      KUBE_TOKEN:
+        from_secret: hocs_frontend_cs_dev
+    commands:
+      - cd kube-hocs-frontend
+      - ./deploy.sh
+    when:
+      branch:
+        - main
+      event:
+        - push
+    depends_on:
+      - clone kube repo
 
-    deploy-to-qa-wcs:
-      image: quay.io/ukhomeofficedigital/kd:v1.16.0
-      environment:
-        - DOMAIN=wcs
-        - ENVIRONMENT=wcs-qa
-        - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      secrets:
-        - hocs_frontend_qa_wcs
-        - poise_whitelist
-      commands:
-        - source version.txt
-        - echo $VERSION
-        - cd kube-hocs-frontend
-        - ./deploy.sh
-      when:
-        event: deployment
-        environment: wcs-qa
+  - name: deploy to wcs-dev
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    environment:
+      ENVIRONMENT: wcs-dev
+      VERSION: build_${DRONE_BUILD_NUMBER}
+      KUBE_TOKEN:
+        from_secret: hocs_frontend_wcs_dev
+    commands:
+      - cd kube-hocs-frontend
+      - ./deploy.sh
+    when:
+      branch:
+        - main
+      event:
+        - push
+    depends_on:
+      - clone kube repo
 
-    deploy-to-hocs-qax:
-      image: quay.io/ukhomeofficedigital/kd:v1.16.0
-      environment:
-        - DOMAIN=cs
-        - ENVIRONMENT=hocs-qax
-        - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      secrets:
-        - hocs_frontend_qax
-        - poise_whitelist
-      commands:
-        - source version.txt
-        - echo $VERSION
-        - cd kube-hocs-frontend
-        - ./deploy.sh
-      when:
-        event: deployment
-        environment: hocs-qax
+  - name: wait for docker
+    image: docker
+    commands:
+      - n=0; until docker stats --no-stream; do echo "Waiting for Docker $n"; n=$((n +1)); sleep 1; done
+    when:
+      event:
+        - promote
+      target:
+        - release
 
-    deploy-to-prod-cs:
-      image: quay.io/ukhomeofficedigital/kd:v1.16.0
-      environment:
-        - DOMAIN=cs
-        - ENVIRONMENT=cs-prod
-        - KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
-      secrets:
-        - hocs_frontend_prod_cs
-        - poise_whitelist
-      commands:
-        - cd kube-hocs-frontend
-        - ./deploy.sh
-      when:
-        event: deployment
-        environment: cs-prod
+  - name: generate & tag build
+    image: quay.io/ukhomeofficedigital/hocs-version-bot:latest
+    commands:
+      - >
+        /app/hocs-deploy
+        --dockerRepository=quay.io/ukhomeofficedigital
+        --environment=qa
+        --registryPassword=$${DOCKER_PASSWORD}
+        --registryUser=ukhomeofficedigital+hocs_quay_robot
+        --service=hocs-frontend
+        --serviceGitToken=$${GITHUB_TOKEN}
+        --sourceBuild=$${VERSION}
+        --version=$${SEMVER}
+        --versionRepo="https://gitlab.digital.homeoffice.gov.uk/hocs/hocs-versions.git"
+        --versionRepoServiceToken=$${GITLAB_TOKEN}
+    environment:
+      DOCKER_API_VERSION: 1.40
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      GITLAB_TOKEN:
+        from_secret: GITLAB_TOKEN
+      GITHUB_TOKEN:
+        from_secret: GITHUB_TOKEN
+    depends_on:
+      - wait for docker
+    when:
+      event:
+        - promote
+      target:
+        - release
 
-    deploy-to-prod-wcs:
-      image: quay.io/ukhomeofficedigital/kd:v1.16.0
-      environment:
-        - DOMAIN=wcs
-        - ENVIRONMENT=wcs-prod
-        - KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
-      secrets:
-        - hocs_frontend_prod_wcs
-        - poise_whitelist
-      commands:
-        - cd kube-hocs-frontend
-        - ./deploy.sh
-      when:
-        event: deployment
-        environment: wcs-prod
+  - name: deploy to cs-qa
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - source version.txt
+      - echo $VERSION
+      - cd kube-hocs-frontend
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: cs-qa
+      KUBE_TOKEN:
+        from_secret: hocs_frontend_cs_qa
+    when:
+      event:
+        - promote
+      target:
+        - release
+    depends_on:
+      - clone kube repo
+      - generate & tag build
+
+  - name: deploy to wcs-qa
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - source version.txt
+      - echo $VERSION
+      - cd kube-hocs-frontend
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: wcs-qa
+      KUBE_TOKEN:
+        from_secret: hocs_frontend_wcs_qa
+    when:
+      event:
+        - promote
+      target:
+        - release
+    depends_on:
+      - clone kube repo
+      - generate & tag build
+
+  - name: deploy to not prod
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - cd kube-hocs-frontend
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: ${DRONE_DEPLOY_TO}
+      KUBE_TOKEN:
+        from_secret: hocs_frontend_${DRONE_DEPLOY_TO/-/_}
+    when:
+      event:
+        - promote
+      target:
+        exclude:
+          - release
+          - "*-prod"
+    depends_on:
+      - clone kube repo
+
+  - name: deploy to prod
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - cd kube-hocs-frontend
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: ${DRONE_DEPLOY_TO}
+      KUBE_TOKEN:
+        from_secret: hocs_frontend_${DRONE_DEPLOY_TO/-/_}
+    when:
+      event:
+        - promote
+      target:
+        include:
+          - "*-prod"
+    depends_on:
+      - clone kube repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,21 +5,12 @@ ENV USER_ID 1000
 ENV GROUP node
 ENV NAME hocs-frontend
 
-RUN mkdir -p /tmp && \
-    chown -R ${USER}:${GROUP} /tmp
-
-WORKDIR /tmp
-COPY . /tmp
-RUN npm --loglevel warn install --development --no-optional
-RUN npm test
-RUN npm run build-prod
-
 RUN mkdir -p /app && \
     chown -R ${USER}:${GROUP} /app
 
 WORKDIR /app
 COPY . /app
-RUN cp -a /tmp/build /app/build
+COPY /build /app/build
 RUN npm  --loglevel warn install --production --no-optional
 
 USER ${USER_ID}


### PR DESCRIPTION
This change implements the necessary changes to use Drone V1 as V0.8
is going to be deprecated. Changes include:
- Pull build, test out of Dockerfile into pipeline
- Removed pull request checks
- Changed to push to build_XXX instead of build-XXX
- Added commit sha tag
- Switched to using KUBE_TOKEN as defined in Drone rather than the kube
repo
- Added acyclic dependency graph for asynchronous build steps
- Made a QA release always release to both QA environments
consolidated build steps where possible