### PR TITLE
HOCS-2680: move sign off minister

### DIFF
--- a/server/middleware/__tests__/searchHandler.spec.js
+++ b/server/middleware/__tests__/searchHandler.spec.js
@@ -94,8 +94,8 @@ describe('handleSearch', () => {
             correspondentNameNotMember: 'Bobby',
             correspondentReference: '',
             topic: 'Test Topic',
+            poTeamUuid: 'Min123',
             data: {
-                POTeamUUID: 'Min123',
                 FullName: 'test Name',
                 DateOfBirth: '12-11-1967',
                 NI: 'SJ0000000',

--- a/server/middleware/searchHandler.js
+++ b/server/middleware/searchHandler.js
@@ -24,8 +24,8 @@ async function handleSearch(req, res, next) {
             correspondentReference: formData['correspondentReference'] ? formData['correspondentReference'].trim().toLowerCase() : '',
             correspondentExternalKey: formData['correspondentExternalKey'] ? await getMemberExternalKey(formData['correspondentExternalKey']) : undefined,
             topic: formData['topic'],
+            poTeamUuid: formData['signOffMinister'],
             data: {
-                POTeamUUID: formData['signOffMinister'],
                 FullName: formData['claimantName'],
                 DateOfBirth: formData['claimantDOB'],
                 NI: formData['niNumber'],


### PR DESCRIPTION
Move the `signOffMinister` to the main section so we can differentiate it
and have custom logic for the `OverridePOTeamUUID`.