### PR TITLE
HOCS-2623 Update docker-compose for case creator

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -65,6 +65,23 @@ $ docker-compose pull
 $ docker-compose up
 ```
 
+## .env file for using non-latest images
+By default, all images use the `latest` tag, however if you want to run the services
+locally with a specific image, create a `.env` file in this /docker directory with required 
+envvars, for example:
+```
+FRONTEND_TAG=my-tag-here
+CASEWORK_TAG=my-tag-here
+WORKFLOW_TAG=my-tag-here
+AUDIT_TAG=my-tag-here
+SEARCH_TAG=my-tag-here
+INFO_TAG=my-tag-here
+DOCS_CONVERTER_TAG=my-tag-here
+DOCS_TAG=my-tag-here
+TEMPLATES_TAG=my-tag-here
+CASE_CREATOR_TAG=my-tag-here
+```
+
 ## Troubleshooting
 ### Unhealthy containers
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -128,8 +128,7 @@ services:
   frontend:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
-    image: quay.io/ukhomeofficedigital/hocs-frontend
-    # image: hocs-frontend-test
+    image: quay.io/ukhomeofficedigital/hocs-frontend:${FRONTEND_TAG:-latest}
     ports:
     - 8080:8080
     networks:
@@ -161,8 +160,7 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       start_period: 240s
-    image: quay.io/ukhomeofficedigital/hocs-casework
-    #image: hocs-casework-test
+    image: quay.io/ukhomeofficedigital/hocs-casework:${CASEWORK_TAG-latest}
     ports:
     - 8082:8080
     networks:
@@ -187,8 +185,7 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       start_period: 240s
-    image: quay.io/ukhomeofficedigital/hocs-workflow
-    # image: hocs-workflow-test
+    image: quay.io/ukhomeofficedigital/hocs-workflow:${WORKFLOW_TAG-latest}
     ports:
     - 8091:8080
     networks:
@@ -219,8 +216,7 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       start_period: 60s
-    image: quay.io/ukhomeofficedigital/hocs-audit
-    #image: hocs-audit-test
+    image: quay.io/ukhomeofficedigital/hocs-audit:${AUDIT_TAG-latest}
     ports:
     - 8087:8080
     networks:
@@ -243,8 +239,7 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       start_period: 180s
-    image: quay.io/ukhomeofficedigital/hocs-search
-    #image: hocs-search-test
+    image: quay.io/ukhomeofficedigital/hocs-search:${SEARCH_TAG-latest}
     ports:
     - 8088:8080
     networks:
@@ -274,8 +269,7 @@ services:
   info:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
-    image: quay.io/ukhomeofficedigital/hocs-info-service
-    #image: hocs-info-service-test
+    image: quay.io/ukhomeofficedigital/hocs-info-service:${INFO_TAG-latest}
     ports:
     - 8085:8080
     networks:
@@ -304,7 +298,7 @@ services:
   converter:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
-    image: quay.io/ukhomeofficedigital/hocs-docs-converter
+    image: quay.io/ukhomeofficedigital/hocs-docs-converter:${DOCS_CONVERTER_TAG-latest}
     ports:
     - 8084:8080
     networks:
@@ -316,7 +310,7 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       start_period: 90s
-    image: quay.io/ukhomeofficedigital/hocs-docs
+    image: quay.io/ukhomeofficedigital/hocs-docs:${DOCS_TAG-latest}
     ports:
     - 8083:8080
     networks:
@@ -350,7 +344,7 @@ services:
   templates:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
-    image: quay.io/ukhomeofficedigital/hocs-templates
+    image: quay.io/ukhomeofficedigital/hocs-templates:${TEMPLATES_TAG-latest}
     ports:
       - 8090:8080
     networks:
@@ -372,7 +366,7 @@ services:
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
       start_period: 90s
-    image: quay.io/ukhomeofficedigital/hocs-case-creator
+    image: quay.io/ukhomeofficedigital/hocs-case-creator:${CASE_CREATOR_TAG-latest}
     ports:
       - 8092:8080
     networks:
@@ -383,10 +377,21 @@ services:
       AWS_LOCAL_HOST: 'localstack'
       HOCS_AUDITSERVICE: 'http://audit:8080'
       AUDIT_TOPIC_NAME: "hocs-audit-topic"
+      CASE_CREATOR_WORKFLOW_SERVICE: http://workflow:8080
+      CASE_CREATOR_CASE_SERVICE: http://case:8080
+      CASE_CREATOR_BASICAUTH: 'UNSET'
+      CASE_CREATOR_SQS_REGION: 'eu-west-2'
+      CASE_CREATOR_SQS_ACCOUNT_ID: '1234'
+      CASE_CREATOR_SQS_ACCESS_KEY: '1234'
+      CASE_CREATOR_SQS_SECRET_KEY: '1234'
+      CASE_CREATOR_UKVI_COMPLAINT_USER: 'UUID'
+      CASE_CREATOR_UKVI_COMPLAINT_GROUP: '/CMSMNIAZQXMZQ6IGEKTRWA'
+      CASE_CREATOR_UKVI_COMPLAINT_QUEUE_NAME: 'ukvi-complaint-queue'
+      CASE_CREATOR_UKVI_COMPLAINT_DL_QUEUE_NAME: 'ukvi-complaint-queue-dlq'
     depends_on:
       localstack:
         condition: service_healthy
       aws_cli:
-        condition: service_healthy
+        condition: service_started
 networks:
   hocs-network:


### PR DESCRIPTION
Adds required envvars for case creator and updates docker compose to use tags on images rather than pulling latest by default. Allows for running services depending on current workstream.