### PR TITLE
HOCS-2706: hide back button ability

### DIFF
--- a/server/services/__tests__/action.spec.js
+++ b/server/services/__tests__/action.spec.js
@@ -365,7 +365,7 @@ describe('Action service', () => {
             form: testForm,
             user: mockUser
         });
-        expect(mockRequestClient).toHaveBeenCalledTimes(1);
+        expect(mockRequestClient).toHaveBeenCalledTimes(2);
         expect(response).toBeDefined();
         expect(response).toHaveProperty('callbackUrl');
     });

--- a/server/services/action.js
+++ b/server/services/action.js
@@ -173,7 +173,7 @@ const actions = {
                         case actionTypes.IS_MEMBER:
                             if (form.data['isMember'] === 'true') {
                                 return ({ callbackUrl: `/case/${caseId}/stage/${stageId}/entity/member/add` });
-                            }    else {
+                            } else {
                                 return ({ callbackUrl: `/case/${caseId}/stage/${stageId}/entity/correspondent/details` });
                             }
                         case actionTypes.SELECT_MEMBER:
@@ -210,8 +210,6 @@ const actions = {
 
                     switch (form.action) {
                         case actionTypes.ADD_CONTRIBUTION:
-                            await caseworkService.post(`/case/${caseId}/item/${somuTypeUuid}`, { data: somuItemData }, headers);
-                            break;
                         case actionTypes.ADD_ADDITIONAL_CONTRIBUTION:
                             await caseworkService.put(`/case/${caseId}/data/CaseContributions`,
                                 somuTypeItems,

--- a/src/shared/common/forms/form-repository.jsx
+++ b/src/shared/common/forms/form-repository.jsx
@@ -24,6 +24,7 @@ import Accordion from './accordion.jsx';
 import Hidden from './hidden.jsx';
 import ExpandableCheckbox from './expandable-checkbox.jsx';
 import FlowDirectionLink from './flow-direction-link.jsx';
+import HideConditionFunctions from './../../helpers/hide-condition-functions';
 
 function defaultDataAdapter(name, data, currentValue) {
     return data[name] || currentValue;
@@ -69,7 +70,10 @@ function isComponentVisible(config, data) {
     if (hideConditions) {
         for (let i = 0; i < hideConditions.length; i++) {
             const condition = hideConditions[i];
-            if (data[condition.conditionPropertyName] && data[condition.conditionPropertyName] === condition.conditionPropertyValue) {
+
+            if (condition.function && Object.prototype.hasOwnProperty.call(HideConditionFunctions, condition.function)) {
+                isVisible = HideConditionFunctions[condition.function](data);
+            } else if (data[condition.conditionPropertyName] && data[condition.conditionPropertyName] === condition.conditionPropertyValue) {
                 isVisible = false;
             }
         }
@@ -160,15 +164,17 @@ export function formComponentFactory(field, options) {
 }
 
 export function secondaryActionFactory(field, options) {
-    const { key, config, page } = options;
+    const { key, data, config, page } = options;
     switch (field) {
         case 'backlink':
-            return renderFormComponent(BackLink, { key, config });
+            return renderFormComponent(BackLink, { data, key, config });
         case 'button':
-            return renderFormComponent(Button, { key, config });
+            return renderFormComponent(Button, { data, key, config });
         case 'backButton':
             return renderFormComponent(BackButton, {
-                key, config: {
+                data,
+                key,
+                config: {
                     ...config, caseId: page.caseId, stageId: page.stageId,
                     action: `/case/${page.caseId}/stage/${page.stageId}/direction/BACKWARD`
                 }

--- a/src/shared/helpers/__tests__/hide-condition-functions.spec.js
+++ b/src/shared/helpers/__tests__/hide-condition-functions.spec.js
@@ -1,0 +1,43 @@
+import HideConditionFunctions from './../hide-condition-functions';
+
+describe('HideConditionFunctions', () => {
+    describe('hasNoContributionsOrFulfilled', () => {
+        const mockData = [
+            {},
+            {
+                CaseContributions: '{}'
+            },
+            {
+                CaseContributions: 'INVALID_JSON'
+            },
+            {
+                CaseContributions: '[{"data": { "contributionStatus": "test"}}]'
+            },
+            {
+                CaseContributions: '[{"data": { "test": "test"}}]'
+            },
+            {
+                CaseContributions: '[{"data": { "contributionStatus": "test"}}, {"data": { "test": "test"}}]'
+            }
+        ];
+
+        it('returns true if CaseContributions does not exist', () => {
+            expect(HideConditionFunctions.hasNoContributionsOrFulfilled(mockData[0])).toBe(true);
+        });
+        it('returns true if CaseContributions is not an array', () => {
+            expect(HideConditionFunctions.hasNoContributionsOrFulfilled(mockData[1])).toBe(true);
+        });
+        it('returns true if CaseContributions is not valid JSON', () => {
+            expect(HideConditionFunctions.hasNoContributionsOrFulfilled(mockData[2])).toBe(true);
+        });
+        it('returns true if all contribitions have status', () => {
+            expect(HideConditionFunctions.hasNoContributionsOrFulfilled(mockData[3])).toBe(true);
+        });
+        it('returns false if contribution does not have status', () => {
+            expect(HideConditionFunctions.hasNoContributionsOrFulfilled(mockData[4])).toBe(false);
+        });
+        it('returns false if one of multiple contributions does not have status', () => {
+            expect(HideConditionFunctions.hasNoContributionsOrFulfilled(mockData[5])).toBe(false);
+        });
+    });
+});

--- a/src/shared/helpers/hide-condition-functions.js
+++ b/src/shared/helpers/hide-condition-functions.js
@@ -1,0 +1,22 @@
+const hideConditionFunctions = {
+    hasNoContributionsOrFulfilled: function (data) {
+        if (!data.CaseContributions) {
+            return true;
+        }
+
+        try {
+            const contributions = JSON.parse(data.CaseContributions);
+
+            if (!Array.isArray(contributions)) {
+                return true;
+            }
+
+            return contributions.filter(contribution => !contribution.data.contributionStatus).length === 0;
+        } catch (_) {
+            // If the CaseContributions is not a valid JSON we return true
+            return true;
+        }
+    }
+};
+
+export default hideConditionFunctions;


### PR DESCRIPTION
Currently, we only support the hiding fields based on a data key and value. As we need to check more intricate details of individual contributions we need to have more control. This change adds afunction that can be called through the form repository that allowsfor checking if a contribution has an inner field of`contributionStatus`. To also allow for this the change has been implemented to support the passing of the data to secondary actions and be able to call a list of specified functions.