### PR TITLE
HOCS-2769 Autodeploy delta branch to delta env

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -151,6 +151,27 @@ steps:
     depends_on:
       - clone kube repo
 
+  # deploy epic branches to specific namespaces
+  - name: deploy to delta
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    environment:
+      ENVIRONMENT: hocs-delta
+      VERSION: build_${DRONE_BUILD_NUMBER}
+      KUBE_TOKEN:
+        from_secret: hocs_frontend_hocs_delta
+      POISE_WHITELIST:
+        from_secret: POISE_WHITELIST
+    commands:
+      - cd kube-hocs-frontend
+      - ./deploy.sh
+    when:
+      branch:
+        - epic/HOCS-COMP
+      event:
+        - push
+    depends_on:
+      - clone kube repo
+
   - name: wait for docker
     image: docker
     commands:


### PR DESCRIPTION
This adds a step to Drone that fires on push to the COMP epic branch,
which triggers a deployment to the hocs-delta environment.

Previously we were deploying manually to hocs-delta, and using a fixed
branch-based tag, which was causing inconsistencies and confusion. Here
we deploy a tag based on the Drone build number, which is easier to
track. If we wanted, we could deploy using the SHA hash for a similar
effect.