### PR TITLE
HOCS 2709 add without mp

### DIFF
--- a/server/services/forms/index.js
+++ b/server/services/forms/index.js
@@ -182,6 +182,10 @@ const formDefinitions = {
                 builder: formRepository.addCorrespondent,
                 action: IS_MEMBER
             },
+            ADDNOMP: {
+                builder: formRepository.addCorrespondentDetails,
+                action: ADD_CORRESPONDENT
+            },
             DETAILS: {
                 builder: formRepository.addCorrespondentDetails,
                 action: ADD_CORRESPONDENT

--- a/server/services/forms/schemas/add-correspondent-details.js
+++ b/server/services/forms/schemas/add-correspondent-details.js
@@ -1,6 +1,14 @@
 const Form = require('../form-builder');
 const { Component, Choice } = require('../component-builder');
 
+function buildUrl(options) {
+    if (options.action === 'addNoMp') {
+        return `/case/${options.caseId}/stage/${options.stageId}`;
+    } else {
+        return `/case/${options.caseId}/stage/${options.stageId}/entity/correspondent/add`;
+    }
+}
+
 module.exports = options => Form()
     .withTitle('Record Correspondent Details')
     .withField(
@@ -64,7 +72,7 @@ module.exports = options => Form()
     .withSecondaryAction(
         Component('backlink')
             .withProp('label', 'Back')
-            .withProp('action', `/case/${options.caseId}/stage/${options.stageId}/entity/correspondent/add`)
+            .withProp('action', buildUrl(options))
             .build()
     )
     .build();

--- a/server/services/forms/schemas/add-correspondent-details.js
+++ b/server/services/forms/schemas/add-correspondent-details.js
@@ -2,11 +2,11 @@ const Form = require('../form-builder');
 const { Component, Choice } = require('../component-builder');
 
 function buildUrl(options) {
+    const url = `/case/${options.caseId}/stage/${options.stageId}`;
     if (options.action === 'addNoMp') {
-        return `/case/${options.caseId}/stage/${options.stageId}`;
-    } else {
-        return `/case/${options.caseId}/stage/${options.stageId}/entity/correspondent/add`;
+        return url;
     }
+    return url + '/entity/correspondent/add';
 }
 
 module.exports = options => Form()

--- a/src/shared/common/forms/composite/__tests__/__snapshots__/entity-list.spec.jsx.snap
+++ b/src/shared/common/forms/composite/__tests__/__snapshots__/entity-list.spec.jsx.snap
@@ -160,7 +160,7 @@ exports[`Entity list component should render with add link when passed in props 
 </div>
 `;
 
-exports[`Entity list component should render with addNoMp link when passed in props 1`] = `
+exports[`Entity list component should render with addUrl link when passed in props 1`] = `
 <div
   class="govuk-form-group"
 >

--- a/src/shared/common/forms/composite/__tests__/__snapshots__/entity-list.spec.jsx.snap
+++ b/src/shared/common/forms/composite/__tests__/__snapshots__/entity-list.spec.jsx.snap
@@ -160,40 +160,6 @@ exports[`Entity list component should render with add link when passed in props 
 </div>
 `;
 
-exports[`Entity list component should render with addUrl link when passed in props 1`] = `
-<div
-  class="govuk-form-group"
->
-  <fieldset
-    class="govuk-fieldset "
-    id="entity_list"
-  >
-    <legend
-      class="govuk-fieldset__legend"
-      id="entity_list-legend"
-    >
-      <span
-        class="govuk-fieldset__heading govuk-label--s"
-      />
-    </legend>
-    <br />
-    <a
-      class="govuk-body govuk-link"
-      href="/case/1234/stage/5678/entity/entity/addNoMp?hideSidebar=false"
-    >
-      Add a entity
-    </a>
-    <table
-      class="govuk-table"
-    >
-      <tbody
-        class="govuk-table__body"
-      />
-    </table>
-  </fieldset>
-</div>
-`;
-
 exports[`Entity list component should render with addUrlPath link when passed in props 1`] = `
 <div
   class="govuk-form-group"

--- a/src/shared/common/forms/composite/__tests__/__snapshots__/entity-list.spec.jsx.snap
+++ b/src/shared/common/forms/composite/__tests__/__snapshots__/entity-list.spec.jsx.snap
@@ -194,6 +194,40 @@ exports[`Entity list component should render with addUrl link when passed in pro
 </div>
 `;
 
+exports[`Entity list component should render with addUrlPath link when passed in props 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="entity_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="entity_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <br />
+    <a
+      class="govuk-body govuk-link"
+      href="/case/1234/stage/5678/entity/entity/addNoMp?hideSidebar=false"
+    >
+      Add a entity
+    </a>
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      />
+    </table>
+  </fieldset>
+</div>
+`;
+
 exports[`Entity list component should render with additional when passed in props 1`] = `
 <div
   class="govuk-form-group"

--- a/src/shared/common/forms/composite/__tests__/__snapshots__/entity-list.spec.jsx.snap
+++ b/src/shared/common/forms/composite/__tests__/__snapshots__/entity-list.spec.jsx.snap
@@ -160,6 +160,40 @@ exports[`Entity list component should render with add link when passed in props 
 </div>
 `;
 
+exports[`Entity list component should render with addNoMp link when passed in props 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="entity_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="entity_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <br />
+    <a
+      class="govuk-body govuk-link"
+      href="/case/1234/stage/5678/entity/entity/addNoMp?hideSidebar=false"
+    >
+      Add a entity
+    </a>
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      />
+    </table>
+  </fieldset>
+</div>
+`;
+
 exports[`Entity list component should render with additional when passed in props 1`] = `
 <div
   class="govuk-form-group"

--- a/src/shared/common/forms/composite/__tests__/entity-list.spec.jsx
+++ b/src/shared/common/forms/composite/__tests__/entity-list.spec.jsx
@@ -154,6 +154,21 @@ describe('Entity list component', () => {
         expect(WRAPPER).toMatchSnapshot();
     });
 
+    it('should render with addNoMp link when passed in props', () => {
+        const PROPS = {
+            ...DEFAULT_PROPS,
+            hasAddLinkNoMp: true
+        };
+        const OUTER = shallow(<WrappedEntityList {...PROPS} />);
+        const EntityList = OUTER.props().children;
+        const WRAPPER = render(
+            <MemoryRouter>
+                <EntityList page={PAGE} />
+            </MemoryRouter>);
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+    });
+
     it('should execute callback on initialization', () => {
         const PROPS = {
             ...DEFAULT_PROPS,

--- a/src/shared/common/forms/composite/__tests__/entity-list.spec.jsx
+++ b/src/shared/common/forms/composite/__tests__/entity-list.spec.jsx
@@ -154,11 +154,11 @@ describe('Entity list component', () => {
         expect(WRAPPER).toMatchSnapshot();
     });
 
-    it('should render with addUrl link when passed in props', () => {
+    it('should render with addUrlPath link when passed in props', () => {
         const PROPS = {
             ...DEFAULT_PROPS,
             hasAddLink: true,
-            addUrl: 'addNoMp'
+            addUrlPath: 'addNoMp'
         };
         const OUTER = shallow(<WrappedEntityList {...PROPS} />);
         const EntityList = OUTER.props().children;

--- a/src/shared/common/forms/composite/__tests__/entity-list.spec.jsx
+++ b/src/shared/common/forms/composite/__tests__/entity-list.spec.jsx
@@ -154,10 +154,11 @@ describe('Entity list component', () => {
         expect(WRAPPER).toMatchSnapshot();
     });
 
-    it('should render with addNoMp link when passed in props', () => {
+    it('should render with addUrl link when passed in props', () => {
         const PROPS = {
             ...DEFAULT_PROPS,
-            hasAddLinkNoMp: true
+            hasAddLink: true,
+            addUrl: 'addNoMp'
         };
         const OUTER = shallow(<WrappedEntityList {...PROPS} />);
         const EntityList = OUTER.props().children;

--- a/src/shared/common/forms/composite/entity-list.jsx
+++ b/src/shared/common/forms/composite/entity-list.jsx
@@ -41,7 +41,7 @@ class EntityList extends Component {
             entity,
             error,
             hasAddLink,
-            hasAddLinkNoMp,
+            addUrl,
             hasEditLink,
             hasRemoveLink,
             hideRemovePrimary,
@@ -96,8 +96,7 @@ class EntityList extends Component {
                                 );
                             })}
                             <br />
-                            {hasAddLink && <Link to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/${entity}/add?hideSidebar=${hideSidebar}`} className="govuk-body govuk-link">Add a {entity}</Link>}
-                            {hasAddLinkNoMp && <Link to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/${entity}/addNoMp?hideSidebar=${hideSidebar}`} className="govuk-body govuk-link">Add a {entity}</Link>}
+                            {hasAddLink && <Link to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/${entity}/${addUrl}?hideSidebar=${hideSidebar}`} className="govuk-body govuk-link">Add a {entity}</Link>}
                         </tbody>
                     </table>
                 </fieldset>
@@ -114,7 +113,7 @@ EntityList.propTypes = {
     disabled: PropTypes.bool,
     error: PropTypes.string,
     entity: PropTypes.string.isRequired,
-    hasAddLinkNoMp: PropTypes.bool,
+    addUrl: PropTypes.string,
     hasAddLink: PropTypes.bool,
     hasEditLink: PropTypes.bool,
     hasRemoveLink: PropTypes.bool,
@@ -135,7 +134,7 @@ EntityList.defaultProps = {
     choices: [],
     disabled: false,
     hideRemovePrimary: false,
-    hasAddLinkNoMp: false,
+    addUrl: 'add',
     type: 'radio',
     page: {},
     hideSidebar: false

--- a/src/shared/common/forms/composite/entity-list.jsx
+++ b/src/shared/common/forms/composite/entity-list.jsx
@@ -41,6 +41,7 @@ class EntityList extends Component {
             entity,
             error,
             hasAddLink,
+            hasAddLinkNoMp,
             hasEditLink,
             hasRemoveLink,
             hideRemovePrimary,
@@ -96,6 +97,7 @@ class EntityList extends Component {
                             })}
                             <br />
                             {hasAddLink && <Link to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/${entity}/add?hideSidebar=${hideSidebar}`} className="govuk-body govuk-link">Add a {entity}</Link>}
+                            {hasAddLinkNoMp && <Link to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/${entity}/addNoMp?hideSidebar=${hideSidebar}`} className="govuk-body govuk-link">Add a {entity}</Link>}
                         </tbody>
                     </table>
                 </fieldset>
@@ -112,6 +114,7 @@ EntityList.propTypes = {
     disabled: PropTypes.bool,
     error: PropTypes.string,
     entity: PropTypes.string.isRequired,
+    hasAddLinkNoMp: PropTypes.bool,
     hasAddLink: PropTypes.bool,
     hasEditLink: PropTypes.bool,
     hasRemoveLink: PropTypes.bool,
@@ -132,6 +135,7 @@ EntityList.defaultProps = {
     choices: [],
     disabled: false,
     hideRemovePrimary: false,
+    hasAddLinkNoMp: false,
     type: 'radio',
     page: {},
     hideSidebar: false

--- a/src/shared/common/forms/composite/entity-list.jsx
+++ b/src/shared/common/forms/composite/entity-list.jsx
@@ -41,7 +41,7 @@ class EntityList extends Component {
             entity,
             error,
             hasAddLink,
-            addUrl,
+            addUrlPath,
             hasEditLink,
             hasRemoveLink,
             hideRemovePrimary,
@@ -96,7 +96,7 @@ class EntityList extends Component {
                                 );
                             })}
                             <br />
-                            {hasAddLink && <Link to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/${entity}/${addUrl}?hideSidebar=${hideSidebar}`} className="govuk-body govuk-link">Add a {entity}</Link>}
+                            {hasAddLink && <Link to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/${entity}/${addUrlPath}?hideSidebar=${hideSidebar}`} className="govuk-body govuk-link">Add a {entity}</Link>}
                         </tbody>
                     </table>
                 </fieldset>
@@ -113,7 +113,7 @@ EntityList.propTypes = {
     disabled: PropTypes.bool,
     error: PropTypes.string,
     entity: PropTypes.string.isRequired,
-    addUrl: PropTypes.string,
+    addUrlPath: PropTypes.string,
     hasAddLink: PropTypes.bool,
     hasEditLink: PropTypes.bool,
     hasRemoveLink: PropTypes.bool,
@@ -134,7 +134,7 @@ EntityList.defaultProps = {
     choices: [],
     disabled: false,
     hideRemovePrimary: false,
-    addUrl: 'add',
+    addUrlPath: 'add',
     type: 'radio',
     page: {},
     hideSidebar: false


### PR DESCRIPTION
When creating a complaint, selecting wether the complaint is an MP is irrelevant.
This change modifies the correspondent creation to allow the skipping of the MP step.
This is achieved by passing 'addUrlPath' = 'addNoMp' when defining the entity-list field.