### PR TITLE
HOCS-2674: change teams type

### DIFF
--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -30,7 +30,6 @@ module.exports = {
         S_TEAMS: {
             client: 'INFO',
             endpoint: '/team',
-            type: listService.types.STATIC,
             adapter: statics.teamsAdapter
         },
         S_USERS: {

--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -30,6 +30,7 @@ module.exports = {
         S_TEAMS: {
             client: 'INFO',
             endpoint: '/team',
+            type: listService.types.DYNAMIC,
             adapter: statics.teamsAdapter
         },
         S_USERS: {
@@ -236,6 +237,7 @@ module.exports = {
         WCS_CASEWORK_TEAMS: {
             client: 'INFO',
             endpoint: '/teams?unit=WCS_CASEWORK_TEAMS',
+            type: listService.types.DYNAMIC,
             adapter: teamsAdapter
         },
         WORKFLOW_WORKSTACK: {
@@ -251,16 +253,19 @@ module.exports = {
         DRAFT_TEAMS: {
             client: 'INFO',
             endpoint: '/teams/drafters',
+            type: listService.types.DYNAMIC,
             adapter: teamsAdapter
         },
         PRIVATE_OFFICE_TEAMS: {
             client: 'INFO',
             endpoint: '/teams?unit=PRIVATE_OFFICE',
+            type: listService.types.DYNAMIC,
             adapter: teamsAdapter
         },
         MOVE_TEAM_OPTIONS: {
             client: 'INFO',
             endpoint: '/team/${teamId}/move_options',
+            type: listService.types.DYNAMIC,
             adapter: teamsAdapter
         },
         USERS_FOR_CASE: {


### PR DESCRIPTION
Currently, the teams endpoint is static and pulls the fresh list from
info on every pod start. As we now allow for dynamic teams to be
added through MUI this can cause discrepancies between data. This
change enforces that the team is pulled on every request.