### PR TITLE
HOCS-2885 Push FOI MVP to hocs-gamma automatically

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -151,6 +151,26 @@ steps:
     depends_on:
       - clone kube repo
 
+  - name: deploy to gamma
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    environment:
+      ENVIRONMENT: hocs-gamma
+      VERSION: build_${DRONE_BUILD_NUMBER}
+      KUBE_TOKEN:
+        from_secret: hocs_frontend_hocs_gamma
+      POISE_WHITELIST:
+        from_secret: POISE_WHITELIST
+    commands:
+      - cd kube-hocs-frontend
+      - ./deploy.sh
+    when:
+      branch:
+        - epic/foi-mvp
+      event:
+        - push
+    depends_on:
+      - clone kube repo
+
   - name: wait for docker
     image: docker
     commands:


### PR DESCRIPTION
This adds a step to Drone that fires on push to the FOI epic branch,
which triggers a deployment to the hocs-gamma environment.

Previously we were deploying manually to hocs-gamma, and using a fixed
branch-based tag, which was causing inconsistencies and confusion. Here
we deploy a tag based on the Drone build number, which is easier to
track. If we wanted, we could deploy using the SHA hash for a similar
effect.