### PR TITLE
Revert "HOCS-2674: change teams type (#622)"

### DIFF
--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -30,7 +30,7 @@ module.exports = {
         S_TEAMS: {
             client: 'INFO',
             endpoint: '/team',
-            type: listService.types.DYNAMIC,
+            type: listService.types.STATIC,
             adapter: statics.teamsAdapter
         },
         S_USERS: {
@@ -237,7 +237,6 @@ module.exports = {
         WCS_CASEWORK_TEAMS: {
             client: 'INFO',
             endpoint: '/teams?unit=WCS_CASEWORK_TEAMS',
-            type: listService.types.DYNAMIC,
             adapter: teamsAdapter
         },
         WORKFLOW_WORKSTACK: {
@@ -253,19 +252,16 @@ module.exports = {
         DRAFT_TEAMS: {
             client: 'INFO',
             endpoint: '/teams/drafters',
-            type: listService.types.DYNAMIC,
             adapter: teamsAdapter
         },
         PRIVATE_OFFICE_TEAMS: {
             client: 'INFO',
             endpoint: '/teams?unit=PRIVATE_OFFICE',
-            type: listService.types.DYNAMIC,
             adapter: teamsAdapter
         },
         MOVE_TEAM_OPTIONS: {
             client: 'INFO',
             endpoint: '/team/${teamId}/move_options',
-            type: listService.types.DYNAMIC,
             adapter: teamsAdapter
         },
         USERS_FOR_CASE: {


### PR DESCRIPTION
Issue identified with this change - as we rely on static team names 
within workstacks, summary tab and other places we cannot just 
remove the cache as the frontend no longer will display the names. A 
more thorough investigation of this cache removal needs to take 
place about unintended consequences. 

This reverts commit a3a4e05f17b46895544a29b99d78f9a8829920c0.