### PR TITLE
HOCS-2900  Hide the MP question when adding correspondents

### DIFF
--- a/server/services/forms/index.js
+++ b/server/services/forms/index.js
@@ -175,6 +175,10 @@ const formDefinitions = {
                 builder: formRepository.addCorrespondent,
                 action: IS_MEMBER
             },
+            ADDNOMP: {
+                builder: formRepository.addCorrespondentDetails,
+                action: ADD_CORRESPONDENT
+            },
             DETAILS: {
                 builder: formRepository.addCorrespondentDetails,
                 action: ADD_CORRESPONDENT

--- a/server/services/forms/schemas/add-correspondent-details.js
+++ b/server/services/forms/schemas/add-correspondent-details.js
@@ -1,6 +1,14 @@
 const Form = require('../form-builder');
 const { Component, Choice } = require('../component-builder');
 
+function buildUrl(options) {
+    const url = `/case/${options.caseId}/stage/${options.stageId}`;
+    if (options.action === 'addNoMp') {
+        return url;
+    }
+    return url + '/entity/correspondent/add';
+}
+
 module.exports = options => Form()
     .withTitle('Record Correspondent Details')
     .withField(
@@ -64,7 +72,7 @@ module.exports = options => Form()
     .withSecondaryAction(
         Component('backlink')
             .withProp('label', 'Back')
-            .withProp('action', `/case/${options.caseId}/stage/${options.stageId}/entity/correspondent/add`)
+            .withProp('action', buildUrl(options))
             .build()
     )
     .build();

--- a/src/shared/common/forms/composite/__tests__/__snapshots__/entity-list.spec.jsx.snap
+++ b/src/shared/common/forms/composite/__tests__/__snapshots__/entity-list.spec.jsx.snap
@@ -160,6 +160,40 @@ exports[`Entity list component should render with add link when passed in props 
 </div>
 `;
 
+exports[`Entity list component should render with addUrlPath link when passed in props 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="entity_list"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="entity_list-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <br />
+    <a
+      class="govuk-body govuk-link"
+      href="/case/1234/stage/5678/entity/entity/addNoMp?hideSidebar=false"
+    >
+      Add a entity
+    </a>
+    <table
+      class="govuk-table"
+    >
+      <tbody
+        class="govuk-table__body"
+      />
+    </table>
+  </fieldset>
+</div>
+`;
+
 exports[`Entity list component should render with additional when passed in props 1`] = `
 <div
   class="govuk-form-group"

--- a/src/shared/common/forms/composite/__tests__/entity-list.spec.jsx
+++ b/src/shared/common/forms/composite/__tests__/entity-list.spec.jsx
@@ -154,6 +154,22 @@ describe('Entity list component', () => {
         expect(WRAPPER).toMatchSnapshot();
     });
 
+    it('should render with addUrlPath link when passed in props', () => {
+        const PROPS = {
+            ...DEFAULT_PROPS,
+            hasAddLink: true,
+            addUrlPath: 'addNoMp'
+        };
+        const OUTER = shallow(<WrappedEntityList {...PROPS} />);
+        const EntityList = OUTER.props().children;
+        const WRAPPER = render(
+            <MemoryRouter>
+                <EntityList page={PAGE} />
+            </MemoryRouter>);
+        expect(WRAPPER).toBeDefined();
+        expect(WRAPPER).toMatchSnapshot();
+    });
+
     it('should execute callback on initialization', () => {
         const PROPS = {
             ...DEFAULT_PROPS,

--- a/src/shared/common/forms/composite/entity-list.jsx
+++ b/src/shared/common/forms/composite/entity-list.jsx
@@ -41,6 +41,7 @@ class EntityList extends Component {
             entity,
             error,
             hasAddLink,
+            addUrlPath,
             hasEditLink,
             hasRemoveLink,
             hideRemovePrimary,
@@ -95,7 +96,7 @@ class EntityList extends Component {
                                 );
                             })}
                             <br />
-                            {hasAddLink && <Link to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/${entity}/add?hideSidebar=${hideSidebar}`} className="govuk-body govuk-link">Add a {entity}</Link>}
+                            {hasAddLink && <Link to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/${entity}/${addUrlPath}?hideSidebar=${hideSidebar}`} className="govuk-body govuk-link">Add a {entity}</Link>}
                         </tbody>
                     </table>
                 </fieldset>
@@ -112,6 +113,7 @@ EntityList.propTypes = {
     disabled: PropTypes.bool,
     error: PropTypes.string,
     entity: PropTypes.string.isRequired,
+    addUrlPath: PropTypes.string,
     hasAddLink: PropTypes.bool,
     hasEditLink: PropTypes.bool,
     hasRemoveLink: PropTypes.bool,
@@ -132,6 +134,7 @@ EntityList.defaultProps = {
     choices: [],
     disabled: false,
     hideRemovePrimary: false,
+    addUrlPath: 'add',
     type: 'radio',
     page: {},
     hideSidebar: false


### PR DESCRIPTION
Allow for add correspondent without a MP
addUrlPath defaults to "add"
Alternative addUrlPath = "addNoMp", which doesn't render MP question.
Ref: HOCS-2709