### PR TITLE
HOCS-3008 Prevent force flushing of cache

### DIFF
--- a/server/lists/adapters/case-notes.js
+++ b/server/lists/adapters/case-notes.js
@@ -29,7 +29,7 @@ const typeAdaptors = {
     }),
     STAGE_ALLOCATED_TO_TEAM: async ({ allocationId, stage }, fromStaticList) => ({
         stage,
-        title: `Allocated to the ${await fromStaticList('S_TEAMS', allocationId, true)}`
+        title: `Allocated to the ${await fromStaticList('S_TEAMS', allocationId)}`
     }),
     STAGE_CREATED: async ({ stage }) => ({
         title: `Stage: ${stage} Started`

--- a/server/lists/adapters/case-summary.js
+++ b/server/lists/adapters/case-summary.js
@@ -34,7 +34,7 @@ const getActiveStages = async (deadlines, fromStaticList) => await Promise.all(d
     .map(async ({ stage: stageId, assignedToUserUUID: userId, assignedToTeamUUID: teamId }) => ({
         stage: await fromStaticList('S_STAGETYPES', stageId),
         assignedUser: await fromStaticList('S_USERS', userId),
-        assignedTeam: await fromStaticList('S_TEAMS', teamId, true)
+        assignedTeam: await fromStaticList('S_TEAMS', teamId)
     })));
 
 const getPrimaryTopic = (topic) => topic ? topic.label : null;

--- a/server/lists/adapters/workstacks.js
+++ b/server/lists/adapters/workstacks.js
@@ -115,7 +115,7 @@ const getCorrespondentsNameByType = (correspondents, types) =>
         .join(', ');
 
 const bindDisplayElements = fromStaticList => async (stage) => {
-    stage.assignedTeamDisplay = await fromStaticList('S_TEAMS', stage.teamUUID, true);
+    stage.assignedTeamDisplay = await fromStaticList('S_TEAMS', stage.teamUUID);
     stage.caseTypeDisplayFull = await fromStaticList('S_CASETYPES', stage.caseType);
 
     if (stage.assignedTopic) {
@@ -292,7 +292,7 @@ const teamAdapter = async (data, { fromStaticList, logger, teamId, configuration
             return cards;
         }, [])
         .sort(byLabel);
-    const teamDisplayName = await fromStaticList('S_TEAMS', teamId, true);
+    const teamDisplayName = await fromStaticList('S_TEAMS', teamId);
 
     logger.debug('REQUEST_TEAM_WORKSTACK', { team: teamDisplayName, workflows: workflowCards.length, rows: workstackData.length });
     return {


### PR DESCRIPTION
Cache flushing was being triggered in various places and under
particular circumstances resulted in many flush requests being triggered unintentionally
in a very short space of time.

This change removes the force flush, so the cache clear will stick to the
cron schedule.