### PR TITLE
HOCS-2762: allow override for case data usage

### DIFF
--- a/src/shared/common/forms/__tests__/form-repository.spec.js
+++ b/src/shared/common/forms/__tests__/form-repository.spec.js
@@ -23,7 +23,7 @@ const supportedFormComponents = [
     { component: 'panel', props: { name: 'panel' } },
     { component: 'inset', props: { name: 'inset' } },
     { component: 'paragraph', props: { name: 'paragraph' } },
-    { component: 'hidden', props: { name: 'hidden' } },
+    { component: 'hidden', props: { name: 'hidden', defaultValue: 'TEST_VALUE', populateFromCaseData: false } },
     { component: 'expandable-checkbox', props: { choice: { label: '__label__', value: '__value__' }, name: 'expandable' } },
 ];
 
@@ -36,7 +36,8 @@ const supportedSecondaryActions = [
 const testData = {
     'text-component': 'TEST',
     'checkbox-component-A': true,
-    'checkbox-component-B': false
+    'checkbox-component-B': false,
+    'hidden': 'TEST'
 };
 
 const testValidationErrors = {
@@ -103,6 +104,22 @@ describe('Form repository', () => {
         expect(wrapper).toBeDefined();
         expect(wrapper.find('Text').length).toEqual(1);
         expect(wrapper.props().value).toEqual(testData[componentConfiguration.props.name]);
+    });
+
+    it('should pass defaultValue when populateFromCaseData is false', () => {
+        const componentConfiguration = supportedFormComponents
+            .filter(field => field.component === 'hidden')
+            .reduce((reducer, field) => reducer = field, null);
+        const Component = formComponentFactory(componentConfiguration.component, {
+            key: 1,
+            config: componentConfiguration.props,
+            data: testData,
+            callback: mockCallback
+        });
+        const wrapper = mount(Component);
+        expect(wrapper).toBeDefined();
+        expect(wrapper.find('hidden').length).toEqual(1);
+        expect(wrapper.props().value).toEqual('TEST_VALUE');
     });
 
     it('should support components in the supportedSecondaryActions list', () => {

--- a/src/shared/common/forms/form-repository.jsx
+++ b/src/shared/common/forms/form-repository.jsx
@@ -30,21 +30,26 @@ function defaultDataAdapter(name, data, currentValue) {
     return data[name] || currentValue;
 }
 
+const retrieveValue = ({ defaultValue, populateFromCaseData = true, name }, dataAdapter, data) => {
+    let value = defaultValue || '';
+
+    if (populateFromCaseData && data) {
+        value = dataAdapter ? dataAdapter(name, data) : defaultDataAdapter(name, data, value);
+    }
+
+    return value;
+};
+
 function renderFormComponent(Component, options) {
     const { key, config, data, errors, callback, dataAdapter, page } = options;
 
     if (isComponentVisible(config, data)) {
-        let value = config.defaultValue || '';
-
-        if (data) {
-            value = dataAdapter ? dataAdapter(config.name, data) : defaultDataAdapter(config.name, data, value);
-        }
         return <Component key={key}
             {...config}
             data={data}
             error={errors && errors[config.name]}
             errors={errors}
-            value={value}
+            value={retrieveValue(config, dataAdapter, data)}
             updateState={callback ? data => callback(data) : null}
             page={page} />;
     }


### PR DESCRIPTION
At present we always check to see if the component 'name' is within
the data and replace the value with that if it exists. In some
circumstances we don't want that to happen, this allows for a
`populateFromCaseData` prop type to be specified that bypasses
this and uses the defaultValue if specified or empty.
Restructuring this code into its own function to improve code
readability.