### PR TITLE
Hocs 3077 fix frontend user issue

### DIFF
--- a/server/lists/adapters/users.js
+++ b/server/lists/adapters/users.js
@@ -3,10 +3,11 @@ const byLabel = (a, b) => a.label.toUpperCase().localeCompare(b.label.toUpperCas
 module.exports = async (data, { user, logger }) => {
     logger.debug('REQUEST_USERS', { users: data.length });
     return data
-        .filter(u => u.id !== user.id)
+        .filter(u => user && (u.id !== user.id))
         .map(({ id, firstName, lastName, email }) => ({
             label: `${firstName} ${lastName} (${email})`,
             value: id
         }))
         .sort(byLabel);
+
 };


### PR DESCRIPTION
 HOCS-3077 fix frontend user issue
    
Currently the frontend pulls a list of users for each approal team at startup.
When this list is pulled, there is a comparison operator to check if each user
is the requesting user. At startup, however, there is no user, as it's not
triggered by a requested. This crashes the frontend.
   
* Only check the user matches the pulled user if one exists
