### PR TITLE
HOCS-3092 : "Add business contribution" link, fix

### DIFF
--- a/server/services/forms/index.js
+++ b/server/services/forms/index.js
@@ -251,7 +251,7 @@ const formDefinitions = {
                 }
             }
         },
-        CCT_CASE_CONTRIB: {
+        CCT_BUS_CONTRIB: {
             COMP: {
                 ADDREQUEST: {
                     builder: formRepository.contributionRequest,


### PR DESCRIPTION
"Case contributions" have been renamed to "Business contributions".
Merge to epic.