### PR TITLE
HOCS-3095 - Replace empty strings with 'undefined' for search

### DIFF
--- a/server/middleware/__tests__/searchHandler.spec.js
+++ b/server/middleware/__tests__/searchHandler.spec.js
@@ -36,7 +36,9 @@ describe('handleSearch', () => {
                     'caseStatus': 'active',
                     'CampaignType': 'Test Campaign 123',
                     'MinSignOffTeam': 'Test Min Sign Off Team',
-                    'OfficialEngagement': 'Yes'
+                    'OfficialEngagement': 'Yes',
+                    'ComplainantDOB': '',
+                    'ComplainantHORef': 'C2'
                 }
             },
             requestId: 'reqid',
@@ -104,11 +106,13 @@ describe('handleSearch', () => {
             data: {
                 FullName: 'test Name',
                 DateOfBirth: '12-11-1967',
+                ComplainantDOB: undefined,
                 NI: 'SJ0000000',
                 PrevHocsRef: 'PREV_HOCS_REF',
                 CampaignType: 'Test Campaign 123',
                 MinSignOffTeam: 'Test Min Sign Off Team',
-                OfficialEngagement: 'Yes'
+                OfficialEngagement: 'Yes',
+                ComplainantHORef: 'C2'
             },
             activeOnly: true
         };

--- a/server/middleware/searchHandler.js
+++ b/server/middleware/searchHandler.js
@@ -31,7 +31,7 @@ async function handleSearch(req, res, next) {
             data: {
                 FullName: formData['claimantName'],
                 DateOfBirth: formData['claimantDOB'],
-                ComplainantDOB: formData['ComplainantDOB'],
+                ComplainantDOB: replaceEmptyStringWithUndefined(formData['ComplainantDOB']),
                 NI: formData['niNumber'],
                 PrevHocsRef: formData['PrevHocsRef'],
                 RefType: formData['RefType'],
@@ -39,7 +39,7 @@ async function handleSearch(req, res, next) {
                 CampaignType: formData['CampaignType'],
                 MinSignOffTeam: formData['MinSignOffTeam'],
                 OfficialEngagement: formData['OfficialEngagement'],
-                ComplainantHORef: formData['ComplainantHORef']
+                ComplainantHORef: replaceEmptyStringWithUndefined(formData['ComplainantHORef'])
             },
             activeOnly: formData['caseStatus'] === 'active'
         };
@@ -75,6 +75,10 @@ async function handleSearch(req, res, next) {
 async function getMemberExternalKey(memberUuid) {
     const response = await infoService.get(`/member/${memberUuid}`);
     return response.data.externalKey;
+}
+
+function replaceEmptyStringWithUndefined(formDataItem) {
+    return formDataItem !== '' ? formDataItem : undefined;
 }
 
 module.exports = {


### PR DESCRIPTION
The search was failing if no DOB was set.

The two new fields ComplainantDOB and ComplainantHORef could have empty strings in them, which were being passed to as search params.

Changing them to 'undefined', if empty,  stops them from being used in the search.

Local testing proves the fix.