### PR TITLE
HOCS-2763: remove OfficialEngagement from search

### DIFF
--- a/server/middleware/__tests__/searchHandler.spec.js
+++ b/server/middleware/__tests__/searchHandler.spec.js
@@ -32,8 +32,7 @@ describe('handleSearch', () => {
                     'PrevHocsRef': 'PREV_HOCS_REF',
                     'caseStatus': 'active',
                     'CampaignType': 'Test Campaign 123',
-                    'MinSignOffTeam': 'Test Min Sign Off Team',
-                    'OfficialEngagement': 'Yes'
+                    'MinSignOffTeam': 'Test Min Sign Off Team'
                 }
             },
             requestId: 'reqid',
@@ -101,8 +100,7 @@ describe('handleSearch', () => {
                 NI: 'SJ0000000',
                 PrevHocsRef: 'PREV_HOCS_REF',
                 CampaignType: 'Test Campaign 123',
-                MinSignOffTeam: 'Test Min Sign Off Team',
-                OfficialEngagement: 'Yes'
+                MinSignOffTeam: 'Test Min Sign Off Team'
             },
             activeOnly: true
         };

--- a/server/middleware/searchHandler.js
+++ b/server/middleware/searchHandler.js
@@ -33,8 +33,7 @@ async function handleSearch(req, res, next) {
                 RefType: formData['RefType'],
                 HomeSecInterest: formData['HomeSecInterest'] === 'true' ? true : undefined,
                 CampaignType: formData['CampaignType'],
-                MinSignOffTeam: formData['MinSignOffTeam'],
-                OfficialEngagement: formData['OfficialEngagement']
+                MinSignOffTeam: formData['MinSignOffTeam']
             },
             activeOnly: formData['caseStatus'] === 'active'
         };

--- a/server/services/forms/schemas/search.js
+++ b/server/services/forms/schemas/search.js
@@ -16,7 +16,6 @@ const search = async (options = {}) => {
     let fields = [];
     const systemConfiguration = await listService.fetch('S_SYSTEM_CONFIGURATION');
     systemConfiguration.profiles.map(profile => {
-        console.log(profile);
         if (userProfileNames.includes(profile.profileName)) {
             profile.searchFields.map(searchField => {
                 if (!fields.some(field => field.name === searchField.name && field.component === searchField.component)) {

--- a/server/services/forms/schemas/search.js
+++ b/server/services/forms/schemas/search.js
@@ -16,6 +16,7 @@ const search = async (options = {}) => {
     let fields = [];
     const systemConfiguration = await listService.fetch('S_SYSTEM_CONFIGURATION');
     systemConfiguration.profiles.map(profile => {
+        console.log(profile);
         if (userProfileNames.includes(profile.profileName)) {
             profile.searchFields.map(searchField => {
                 if (!fields.some(field => field.name === searchField.name && field.component === searchField.component)) {


### PR DESCRIPTION
We have removed the OfficialEngagement from the search for MTS
cases and MTS cases going forward. As a result the business no
longer need to be able to search based off this and this can be
removed from passed data.