### PR TITLE
HOCS-3148 Draft Document validation error

### DIFF
--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -773,6 +773,11 @@ module.exports = {
             endpoint: '/case/document/reference/${caseId}/?type=DRAFT',
             adapter: documentListAdapter
         },
+        CASE_DOCUMENT_LIST_FOI_DRAFT: {
+            client: 'CASEWORK',
+            endpoint: '/case/document/reference/${caseId}/?type=Draft%20response',
+            adapter: documentListAdapter
+        },
         CASE_DOCUMENT_TAGS: {
             client: 'CASEWORK',
             endpoint: '/case/${caseId}/documentTags',


### PR DESCRIPTION
The draft upload stage is looking for the wrong document tag.
This PR updates the screen to look for the correct one.