### PR TITLE
HOCS-3128: change radio control ids

### DIFF
--- a/src/shared/common/forms/__tests__/__snapshots__/radio-group.spec.js.snap
+++ b/src/shared/common/forms/__tests__/__snapshots__/radio-group.spec.js.snap
@@ -27,15 +27,15 @@ exports[`Form radio group component should render disabled when passed 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-A"
-          id="radio-group-A"
+          data-aria-controls="conditional-radio-group-0"
+          id="radio-group-0"
           name="radio-group"
           type="radio"
           value="A"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-A"
+          for="radio-group-0"
         >
           isA
         </label>
@@ -45,15 +45,15 @@ exports[`Form radio group component should render disabled when passed 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-B"
-          id="radio-group-B"
+          data-aria-controls="conditional-radio-group-1"
+          id="radio-group-1"
           name="radio-group"
           type="radio"
           value="B"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-B"
+          for="radio-group-1"
         >
           isB
         </label>
@@ -63,15 +63,15 @@ exports[`Form radio group component should render disabled when passed 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-C"
-          id="radio-group-C"
+          data-aria-controls="conditional-radio-group-2"
+          id="radio-group-2"
           name="radio-group"
           type="radio"
           value="C"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-C"
+          for="radio-group-2"
         >
           isC
         </label>
@@ -107,22 +107,22 @@ exports[`Form radio group component should render error message for textarea if 
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-ValueA"
-          id="radio-group-ValueA"
+          data-aria-controls="conditional-radio-group-0"
+          id="radio-group-0"
           name="radio-group"
           type="radio"
           value="ValueA"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-ValueA"
+          for="radio-group-0"
         >
           labelA
         </label>
       </div>
       <div
         class="govuk-radios__conditional govuk-radios__conditional--hidden"
-        id="conditional-radio-group-ValueA"
+        id="conditional-radio-group-0"
       >
         <div
           class="govuk-form-group  govuk-form-group--error"
@@ -157,15 +157,15 @@ exports[`Form radio group component should render error message for textarea if 
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-ValueB"
-          id="radio-group-ValueB"
+          data-aria-controls="conditional-radio-group-1"
+          id="radio-group-1"
           name="radio-group"
           type="radio"
           value="ValueB"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-ValueB"
+          for="radio-group-1"
         >
           labelB
         </label>
@@ -175,15 +175,15 @@ exports[`Form radio group component should render error message for textarea if 
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-ValueC"
-          id="radio-group-ValueC"
+          data-aria-controls="conditional-radio-group-2"
+          id="radio-group-2"
           name="radio-group"
           type="radio"
           value="ValueC"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-ValueC"
+          for="radio-group-2"
         >
           labelC
         </label>
@@ -219,15 +219,15 @@ exports[`Form radio group component should render with default props 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-A"
-          id="radio-group-A"
+          data-aria-controls="conditional-radio-group-0"
+          id="radio-group-0"
           name="radio-group"
           type="radio"
           value="A"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-A"
+          for="radio-group-0"
         >
           isA
         </label>
@@ -237,15 +237,15 @@ exports[`Form radio group component should render with default props 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-B"
-          id="radio-group-B"
+          data-aria-controls="conditional-radio-group-1"
+          id="radio-group-1"
           name="radio-group"
           type="radio"
           value="B"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-B"
+          for="radio-group-1"
         >
           isB
         </label>
@@ -255,15 +255,15 @@ exports[`Form radio group component should render with default props 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-C"
-          id="radio-group-C"
+          data-aria-controls="conditional-radio-group-2"
+          id="radio-group-2"
           name="radio-group"
           type="radio"
           value="C"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-C"
+          for="radio-group-2"
         >
           isC
         </label>
@@ -305,15 +305,15 @@ exports[`Form radio group component should render with error when passed 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-A"
-          id="radio-group-A"
+          data-aria-controls="conditional-radio-group-0"
+          id="radio-group-0"
           name="radio-group"
           type="radio"
           value="A"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-A"
+          for="radio-group-0"
         >
           isA
         </label>
@@ -323,15 +323,15 @@ exports[`Form radio group component should render with error when passed 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-B"
-          id="radio-group-B"
+          data-aria-controls="conditional-radio-group-1"
+          id="radio-group-1"
           name="radio-group"
           type="radio"
           value="B"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-B"
+          for="radio-group-1"
         >
           isB
         </label>
@@ -341,15 +341,15 @@ exports[`Form radio group component should render with error when passed 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-C"
-          id="radio-group-C"
+          data-aria-controls="conditional-radio-group-2"
+          id="radio-group-2"
           name="radio-group"
           type="radio"
           value="C"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-C"
+          for="radio-group-2"
         >
           isC
         </label>
@@ -390,15 +390,15 @@ exports[`Form radio group component should render with hint when passed 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-A"
-          id="radio-group-A"
+          data-aria-controls="conditional-radio-group-0"
+          id="radio-group-0"
           name="radio-group"
           type="radio"
           value="A"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-A"
+          for="radio-group-0"
         >
           isA
         </label>
@@ -408,15 +408,15 @@ exports[`Form radio group component should render with hint when passed 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-B"
-          id="radio-group-B"
+          data-aria-controls="conditional-radio-group-1"
+          id="radio-group-1"
           name="radio-group"
           type="radio"
           value="B"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-B"
+          for="radio-group-1"
         >
           isB
         </label>
@@ -426,15 +426,15 @@ exports[`Form radio group component should render with hint when passed 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-C"
-          id="radio-group-C"
+          data-aria-controls="conditional-radio-group-2"
+          id="radio-group-2"
           name="radio-group"
           type="radio"
           value="C"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-C"
+          for="radio-group-2"
         >
           isC
         </label>
@@ -472,15 +472,15 @@ exports[`Form radio group component should render with label when passed 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-A"
-          id="radio-group-A"
+          data-aria-controls="conditional-radio-group-0"
+          id="radio-group-0"
           name="radio-group"
           type="radio"
           value="A"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-A"
+          for="radio-group-0"
         >
           isA
         </label>
@@ -490,15 +490,15 @@ exports[`Form radio group component should render with label when passed 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-B"
-          id="radio-group-B"
+          data-aria-controls="conditional-radio-group-1"
+          id="radio-group-1"
           name="radio-group"
           type="radio"
           value="B"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-B"
+          for="radio-group-1"
         >
           isB
         </label>
@@ -508,15 +508,15 @@ exports[`Form radio group component should render with label when passed 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-C"
-          id="radio-group-C"
+          data-aria-controls="conditional-radio-group-2"
+          id="radio-group-2"
           name="radio-group"
           type="radio"
           value="C"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-C"
+          for="radio-group-2"
         >
           isC
         </label>
@@ -553,15 +553,15 @@ exports[`Form radio group component should render with value when passed 1`] = `
         <input
           checked=""
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-A"
-          id="radio-group-A"
+          data-aria-controls="conditional-radio-group-0"
+          id="radio-group-0"
           name="radio-group"
           type="radio"
           value="A"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-A"
+          for="radio-group-0"
         >
           isA
         </label>
@@ -571,15 +571,15 @@ exports[`Form radio group component should render with value when passed 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-B"
-          id="radio-group-B"
+          data-aria-controls="conditional-radio-group-1"
+          id="radio-group-1"
           name="radio-group"
           type="radio"
           value="B"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-B"
+          for="radio-group-1"
         >
           isB
         </label>
@@ -589,15 +589,15 @@ exports[`Form radio group component should render with value when passed 1`] = `
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-C"
-          id="radio-group-C"
+          data-aria-controls="conditional-radio-group-2"
+          id="radio-group-2"
           name="radio-group"
           type="radio"
           value="C"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-C"
+          for="radio-group-2"
         >
           isC
         </label>
@@ -633,22 +633,22 @@ exports[`Form radio group component should textarea if conditional content exist
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-ValueA"
-          id="radio-group-ValueA"
+          data-aria-controls="conditional-radio-group-0"
+          id="radio-group-0"
           name="radio-group"
           type="radio"
           value="ValueA"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-ValueA"
+          for="radio-group-0"
         >
           labelA
         </label>
       </div>
       <div
         class="govuk-radios__conditional govuk-radios__conditional--hidden"
-        id="conditional-radio-group-ValueA"
+        id="conditional-radio-group-0"
       >
         <div
           class="govuk-form-group "
@@ -672,15 +672,15 @@ exports[`Form radio group component should textarea if conditional content exist
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-ValueB"
-          id="radio-group-ValueB"
+          data-aria-controls="conditional-radio-group-1"
+          id="radio-group-1"
           name="radio-group"
           type="radio"
           value="ValueB"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-ValueB"
+          for="radio-group-1"
         >
           labelB
         </label>
@@ -690,15 +690,15 @@ exports[`Form radio group component should textarea if conditional content exist
       >
         <input
           class="govuk-radios__input"
-          data-aria-controls="conditional-radio-group-ValueC"
-          id="radio-group-ValueC"
+          data-aria-controls="conditional-radio-group-2"
+          id="radio-group-2"
           name="radio-group"
           type="radio"
           value="ValueC"
         />
         <label
           class="govuk-label govuk-radios__label"
-          for="radio-group-ValueC"
+          for="radio-group-2"
         >
           labelC
         </label>

--- a/src/shared/common/forms/__tests__/radio-group.spec.js
+++ b/src/shared/common/forms/__tests__/radio-group.spec.js
@@ -56,11 +56,11 @@ describe('Form radio group component', () => {
 
         mockCallback.mockReset();
 
-        wrapper.find(`#radio-group-${firstValue}`).simulate('change', { target: { value: firstValue } });
+        wrapper.find('#radio-group-0').simulate('change', { target: { value: firstValue } });
         expect(mockCallback).toHaveBeenCalledTimes(1);
         expect(mockCallback).toHaveBeenCalledWith({ 'radio-group': firstValue });
 
-        wrapper.find(`#radio-group-${secondValue}`).simulate('change', { target: { value: secondValue } });
+        wrapper.find('#radio-group-1').simulate('change', { target: { value: secondValue } });
         expect(mockCallback).toHaveBeenCalledTimes(2);
         expect(mockCallback).toHaveBeenCalledWith({ 'radio-group': secondValue });
     });
@@ -81,7 +81,7 @@ describe('Form radio group component', () => {
             { label: 'labelC', value: 'ValueC' }
         ];
         expect(
-            render(<RadioGroup name="radio-group" choices={choices} errors={ { ValueAText: 'Some error message' } } updateState={() => null} />)
+            render(<RadioGroup name="radio-group" choices={choices} errors={{ ValueAText: 'Some error message' }} updateState={() => null} />)
         ).toMatchSnapshot();
     });
 });

--- a/src/shared/common/forms/radio-group.jsx
+++ b/src/shared/common/forms/radio-group.jsx
@@ -103,6 +103,10 @@ class Radio extends Component {
         return choicesToUse;
     }
 
+    getIdName(nameOfField, key) {
+        return `${nameOfField}-${key}`;
+    }
+
     render() {
         const {
             className,
@@ -130,24 +134,26 @@ class Radio extends Component {
 
                     <div id={`${name}-radios`} className={'govuk-radios govuk-radios--conditional'} data-module="govuk-radios">
                         {choicesToUse && choicesToUse.map((choice, i) => {
+                            const idName = this.getIdName(name, i);
+
                             return (
                                 <Fragment key={i}>
                                     <div className="govuk-radios__item">
-                                        <input id={`${name}-${choice.value}`}
+                                        <input id={idName}
                                             type={type}
                                             name={name}
                                             value={choice.value}
                                             checked={(value === choice.value)}
                                             onChange={e => this.handleChange(e, choice)}
-                                            data-aria-controls={`conditional-${name}-${choice.value}`}
+                                            data-aria-controls={`conditional-${idName}`}
                                             className={'govuk-radios__input'}
                                         />
-                                        <label className="govuk-label govuk-radios__label" htmlFor={`${name}-${choice.value}`}>{choice.label}</label>
+                                        <label className="govuk-label govuk-radios__label" htmlFor={`${idName}`}>{choice.label}</label>
                                     </div>
 
                                     {choice.conditionalContent &&
                                         <div className="govuk-radios__conditional govuk-radios__conditional--hidden"
-                                            id={`conditional-${name}-${choice.value}`}>
+                                            id={`conditional-${idName}`}>
                                             <div className={`govuk-form-group ${this.isConditionalContentError(errors, `${choice.value}Text`) ? ' govuk-form-group--error' : ''}`}>
                                                 <label className="govuk-label" htmlFor={`${choice.value}Text`}>
                                                     {choice.conditionalContent.label}


### PR DESCRIPTION
At present there are instances whereby the choices have values that
contain characters that are not allowed in CSS selectors. This change
improves the id that the radio uses so that there is a reduced chance
of these characters being part of the selectors. We now use the
name of the character and the key index to identify each of the
options. Due to this change various tests need to be updated to use
this new id.