### PR TITLE
HOCS-3193 Sticky Cases

### DIFF
--- a/server/services/__tests__/action.spec.js
+++ b/server/services/__tests__/action.spec.js
@@ -26,6 +26,15 @@ jest.mock('../../clients', () => {
                     mockRequestClient(body);
                     return handleMockWorkflowCreateRequest(body);
                 }
+                if (url == '/case/1234/stage/5678') {
+                    mockRequestClient(body);
+                    return  Promise.resolve({
+                        data: {
+                            form: {},
+                            stageUUID: '123abc'
+                        }
+                    });
+                }
                 mockRequestClient(body);
             },
             delete: (url, body) => {
@@ -105,6 +114,25 @@ describe('Action service', () => {
     beforeEach(() => {
         mockRequestClient.mockReset();
     });
+
+    it('handleWorkflowSuccess - with form data returned from back end', async () => {
+
+        const FORM_DATA = { data: { 'a': 's' } };
+
+        const response = await actionService.performAction('WORKFLOW', {
+            workflow: 'CREATE',
+            action: 'WORKFLOW',
+            form: FORM_DATA,
+            user: mockUser,
+            caseId: '1234',
+            stageId: '5678'
+        });
+
+        expect(response).toBeDefined();
+        expect(mockRequestClient).toHaveBeenCalledWith(FORM_DATA);
+        expect(response).toHaveProperty('callbackUrl', '/case/1234/stage/123abc');
+    });
+
     it('should return a callback url when passed supported workflow and action', async () => {
         const response = await actionService.performAction('ACTION', {
             workflow: 'CREATE',

--- a/server/services/action.js
+++ b/server/services/action.js
@@ -66,9 +66,9 @@ async function handleActionSuccess(response, workflow, form) {
     }
 }
 
-function handleWorkflowSuccess(response, { caseId, stageId }) {
+function handleWorkflowSuccess(response, { caseId }) {
     if (response.data && response.data.form) {
-        return { callbackUrl: `/case/${caseId}/stage/${stageId}` };
+        return { callbackUrl: `/case/${caseId}/stage/${response.data.stageUUID}` };
     } else {
         return { callbackUrl: '/' };
     }


### PR DESCRIPTION
If at the end of a stage the user is a member of the team that handles the case at the next stage, then the case might want to be be allocated to them automatically and displayed on screen, instead of just going to the workstack.

When the workflow service - updateStageForward() - detects that the end of a stage is reached - in getStage() - it checks if the current user is on the team for the next stage. If they are the user is allocated to that case, and data relating to the new stage is returned to the front end.
The front end code detects if the stageId has changed, and uses that instead when it redirects.

The feature can be turned on by setting a process variable in the Camunda diagram. 

![sticky_cases001](https://user-images.githubusercontent.com/76998072/123073752-9d61e000-d40e-11eb-84bb-7b5a4d9d0cc8.png)
