### PR TITLE
HOCS-3315: utilise show stack trace environment var

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -1,6 +1,7 @@
 const isProduction = process.env.NODE_ENV === 'production';
 const workflowAuth = (process.env.WORKFLOW_BASIC_AUTH || 'UNSET:UNSET').split(':');
 const isNotProd = process.env.IS_NOTPROD === '1';
+const showStackTraceInErrorPage = process.env.SHOW_STACKTRACE_ON_ERROR_PAGE === '1';
 
 const config = {
     applications: {
@@ -42,5 +43,6 @@ module.exports = {
         }
     },
     isProduction,
-    isNotProd
+    isNotProd,
+    showStackTraceInErrorPage
 };

--- a/server/models/error.js
+++ b/server/models/error.js
@@ -1,4 +1,4 @@
-const { isProduction } = require('../config');
+const { showStackTraceInErrorPage: showStackTrace } = require('../config');
 
 class ErrorModel extends Error {
 
@@ -14,7 +14,7 @@ class ErrorModel extends Error {
             status: this.status,
             title: this.title,
             message: this.message,
-            stack: isProduction ? null : this.stack
+            stack: showStackTrace ? null : this.stack
         };
     }
 


### PR DESCRIPTION
At present to show stack traces within the error we rely on the
`isProduction` value in the config page. As turning this off in
non-local environments causes unintended consequences. To
mitigate this, a new `SHOW_STACKTRACE_ON_ERROR_PAGE` env
variable is being passed through. This is then used to signal whether
to pass through the stacktrace to the error model.