### PR TITLE
HOCS-3328 - Search Page not loading criteria options

### DIFF
--- a/src/shared/common/components/workstack.jsx
+++ b/src/shared/common/components/workstack.jsx
@@ -139,6 +139,12 @@ class WorkstackAllocate extends Component {
             throw new Error('Data Adapter not implemented: ' + colDataAdapter);
         }
 
+        // if the result is an empty object and it hasn't been handled by an adapter
+        // turn it into an empty string to avoid an error
+        if (typeof value === 'object' && Object.keys(value).length === 0) {
+            return '';
+        }
+
         return value;
     }
 


### PR DESCRIPTION
Currently if only FOI is checked and a case with no correspondent exists, the frontend throws an error, this change adds a check to fix that.

* Check for empty objects passed to front end and turn them into empty strings