### PR TITLE
HOCS-3316 Only flushing old static lists if retrieval of new ones is …

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -151,27 +151,6 @@ steps:
     depends_on:
       - clone kube repo
 
-  # deploy epic branches to specific namespaces
-  - name: deploy to delta
-    image: quay.io/ukhomeofficedigital/kd:v1.16.0
-    environment:
-      ENVIRONMENT: hocs-delta
-      VERSION: build_${DRONE_BUILD_NUMBER}
-      KUBE_TOKEN:
-        from_secret: hocs_frontend_hocs_delta
-      POISE_WHITELIST:
-        from_secret: POISE_WHITELIST
-    commands:
-      - cd kube-hocs-frontend
-      - ./deploy.sh
-    when:
-      branch:
-        - epic/HOCS-COMP
-      event:
-        - push
-    depends_on:
-      - clone kube repo
-
   - name: wait for docker
     image: docker
     commands:

--- a/server/services/list/__tests__/service.spec.js
+++ b/server/services/list/__tests__/service.spec.js
@@ -502,16 +502,53 @@ describe('List Service', () => {
         });
     });
 
-    describe('when the flush method is called', () => {
-        it('should call the flush on the instance', async () => {
+    describe('when the flush method is called but retreival of new data fails', () => {
+        it('should call not call flush or store on the respository', async () => {
             const listKey = '__listKey__';
+
             const mockRepositoryFlush = jest.fn();
+            const mockRepositoryStore = jest.fn();
+            const mockRepositoryFetch = jest.fn();
+            const mockClientInstance = jest.fn();
+            mockClientInstance.get = mockGet;
+            mockRepositoryFetch.mockReturnValue(mockClientInstance);
+            const mockGet = jest.fn();
+            mockGet.mockImplementation(() => {
+                throw new Error('400');
+            });
 
-            await listService.initialise({}, {}, { listRepository: { flush: mockRepositoryFlush } });
+            await listService.initialise({}, {}, { listRepository: { flush: mockRepositoryFlush, fetch: mockRepositoryFetch, store: mockRepositoryStore } });
 
-            listService.flush(listKey);
+            await listService.flush(listKey);
 
             expect(getLogger).toHaveBeenCalled();
+            expect(mockRepositoryFlush).not.toHaveBeenCalled();
+            expect(mockRepositoryStore).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('when the flush method is called and retreival of new data is successful', () => {
+        it('should call call flush and store on the repository', async () => {
+            const listKey = '__listKey__';
+
+            const mockRepositoryFlush = jest.fn();
+            const mockRepositoryStore = jest.fn();
+            const mockRepositoryFetch = jest.fn();
+            const mockGet = jest.fn();
+            mockGet.mockReturnValue(JSON.parse('{"client": "newclient"}'));
+
+            const mockClientInstance = jest.fn();
+            mockClientInstance.get = mockGet;
+            mockRepositoryFetch.mockReturnValue(mockClientInstance);
+
+            await listService.initialise({}, {}, { listRepository: { flush: mockRepositoryFlush, fetch: mockRepositoryFetch, store: mockRepositoryStore } });
+            const mockAdapter = jest.fn();
+            listService.applyAdapter = mockAdapter;
+
+            await listService.flush(listKey);
+
+            expect(getLogger).toHaveBeenCalled();
+            expect(mockRepositoryStore).toHaveBeenCalled();
             expect(mockRepositoryFlush).toHaveBeenCalledWith(listKey);
         });
     });

--- a/server/services/list/__tests__/service.spec.js
+++ b/server/services/list/__tests__/service.spec.js
@@ -517,7 +517,11 @@ describe('List Service', () => {
                 throw new Error('400');
             });
 
-            await listService.initialise({}, {}, { listRepository: { flush: mockRepositoryFlush, fetch: mockRepositoryFetch, store: mockRepositoryStore } });
+            await listService.initialise({}, {}, { listRepository: { 
+                flush: mockRepositoryFlush, 
+                fetch: mockRepositoryFetch, 
+                store: mockRepositoryStore 
+            }});
 
             await listService.flush(listKey);
 
@@ -541,7 +545,11 @@ describe('List Service', () => {
             mockClientInstance.get = mockGet;
             mockRepositoryFetch.mockReturnValue(mockClientInstance);
 
-            await listService.initialise({}, {}, { listRepository: { flush: mockRepositoryFlush, fetch: mockRepositoryFetch, store: mockRepositoryStore } });
+            await listService.initialise({}, {}, { listRepository: { 
+                flush: mockRepositoryFlush, 
+                fetch: mockRepositoryFetch, 
+                store: mockRepositoryStore 
+            } });
             const mockAdapter = jest.fn();
             listService.applyAdapter = mockAdapter;
 

--- a/server/services/list/__tests__/service.spec.js
+++ b/server/services/list/__tests__/service.spec.js
@@ -517,11 +517,11 @@ describe('List Service', () => {
                 throw new Error('400');
             });
 
-            await listService.initialise({}, {}, { listRepository: { 
-                flush: mockRepositoryFlush, 
-                fetch: mockRepositoryFetch, 
-                store: mockRepositoryStore 
-            }});
+            await listService.initialise({}, {}, { listRepository: {
+                flush: mockRepositoryFlush,
+                fetch: mockRepositoryFetch,
+                store: mockRepositoryStore
+            } });
 
             await listService.flush(listKey);
 
@@ -545,10 +545,10 @@ describe('List Service', () => {
             mockClientInstance.get = mockGet;
             mockRepositoryFetch.mockReturnValue(mockClientInstance);
 
-            await listService.initialise({}, {}, { listRepository: { 
-                flush: mockRepositoryFlush, 
-                fetch: mockRepositoryFetch, 
-                store: mockRepositoryStore 
+            await listService.initialise({}, {}, { listRepository: {
+                flush: mockRepositoryFlush,
+                fetch: mockRepositoryFetch,
+                store: mockRepositoryStore
             } });
             const mockAdapter = jest.fn();
             listService.applyAdapter = mockAdapter;

--- a/server/services/list/service.js
+++ b/server/services/list/service.js
@@ -183,8 +183,8 @@ const cacheStaticList = async (listId) => {
     const logger = getLogger();
     try {
         const response = await clientInstance.get(endpoint);
-        listCache.flush(listId);
         const listData = await applyAdapter(response.data, adapter, { logger });
+        listCache.flush(listId);
         listCache.store(listId, listData);
         logger.info('CACHE_STATIC_LIST_SUCCESS', { list: listId, client: client, endpoint: endpoint });
     } catch (error) {

--- a/server/services/list/service.js
+++ b/server/services/list/service.js
@@ -173,8 +173,7 @@ const getInstance = (requestId, user) => {
 };
 
 const flush = async (key) => {
-    listCache.flush(key);
-    getLogger().info('Flushing Cache ' + key);
+    getLogger().info('Flushing and retrieving new Cache ' + key);
     await cacheStaticList(key);
 };
 
@@ -182,15 +181,15 @@ const cacheStaticList = async (listId) => {
     const { endpoint, client, adapter } = listRepository.fetch(listId);
     const clientInstance = clientRepository.fetch(client);
     const logger = getLogger();
-    let response;
     try {
-        response = await clientInstance.get(endpoint);
+        const response = await clientInstance.get(endpoint);
+        listCache.flush(listId);
+        const listData = await applyAdapter(response.data, adapter, { logger });
+        listCache.store(listId, listData);
+        logger.info('CACHE_STATIC_LIST_SUCCESS', { list: listId, client: client, endpoint: endpoint });
     } catch (error) {
         logger.error('CACHE_STATIC_LIST_REQUEST_FAILURE', { list: listId, status: error.response ? error.response.status : error.code });
     }
-    const listData = await applyAdapter(response.data, adapter, { logger });
-    listCache.store(listId, listData);
-    logger.info('CACHE_STATIC_LIST_SUCCESS', { list: listId, client: client, endpoint: endpoint });
 };
 
 module.exports = {


### PR DESCRIPTION
…successful

This fixes a bug where occasionally team names would not appear on the dashboard.

Team names are stored in static lists which are refreshed every 15 minutes. This bug occurred when the refresh failed due to the info or casework services not being available as the old behaviour was to delete the static lists, request new ones and repopulate when they arrived, so failure to retrieve new ones left us with nothing. The new behaviour waits to see if new lists are successfully retrieved before deleting and replacing the old data. In the event of failure the preexisting static lists are maintained and the user won't know anything is amiss. 