### PR TITLE
HOCS-3397 Issues caused by team deactivation through Management UI

### DIFF
--- a/server/lists/adapters/__tests__/workstacks.spec.js
+++ b/server/lists/adapters/__tests__/workstacks.spec.js
@@ -7,6 +7,8 @@ const mockTopic = 'MOCK_TOPIC';
 
 const mockFromStaticList = jest.fn((list) => {
     switch (list) {
+        case 'S_ALL_TEAMS':
+            return 'MOCK_TEAM';
         case 'S_TEAMS':
             return 'MOCK_TEAM';
         case 'S_CASETYPES':

--- a/server/lists/adapters/workstacks.js
+++ b/server/lists/adapters/workstacks.js
@@ -147,7 +147,7 @@ const decorateContributionsWithStatus = (contributions, currentDate) => {
 };
 
 const bindDisplayElements = fromStaticList => async (stage) => {
-    stage.assignedTeamDisplay = await fromStaticList('S_TEAMS', stage.teamUUID);
+    stage.assignedTeamDisplay = await fromStaticList('S_ALL_TEAMS', stage.teamUUID);
     stage.caseTypeDisplayFull = await fromStaticList('S_CASETYPES', stage.caseType);
 
     if (stage.assignedTopic) {
@@ -334,7 +334,7 @@ const teamAdapter = async (data, { fromStaticList, logger, teamId, configuration
             return cards;
         }, [])
         .sort(byLabel);
-    const teamDisplayName = await fromStaticList('S_TEAMS', teamId);
+    const teamDisplayName = await fromStaticList('S_ALL_TEAMS', teamId);
 
     logger.debug('REQUEST_TEAM_WORKSTACK', { team: teamDisplayName, workflows: workflowCards.length, rows: workstackData.length });
     return {

--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -33,6 +33,12 @@ module.exports = {
             type: listService.types.STATIC,
             adapter: statics.teamsAdapter
         },
+        S_ALL_TEAMS: {
+            client: 'INFO',
+            endpoint: '/team/all',
+            type: listService.types.STATIC,
+            adapter: statics.teamsAdapter
+        },
         S_USERS: {
             client: 'INFO',
             endpoint: '/users',

--- a/server/middleware/__tests__/searchHandler.spec.js
+++ b/server/middleware/__tests__/searchHandler.spec.js
@@ -42,7 +42,7 @@ describe('handleSearch', () => {
             user: mockUser,
             listService: {
                 getFromStaticList: jest.fn(async (listId, key) => {
-                    if (listId === 'S_TEAMS' && key === 'T1') {
+                    if (listId === 'S_ALL_TEAMS' && key === 'T1') {
                         return Promise.resolve('TEAM1');
                     }
                     if (listId === 'S_CASETYPES' && key === 'CT1') {


### PR DESCRIPTION
Deactivated team workstacks are appearing on the dashboard with blank labels. These labels are populated by the frontend from a list of teams from the info-service. Currently only the list of active teams is used, causing the issue.

* Use the full team list in the list service, including deactivated teams