### PR TITLE
HOCS-3013: change dashboard endpoint call

### DIFF
--- a/server/lists/adapters/__tests__/__snapshots__/workstacks.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/workstacks.spec.js.snap
@@ -44,24 +44,34 @@ exports[`Dashboard Adapter should transform a stage array to a dashboard schema 
 Object {
   "teams": Array [
     Card {
-      "count": 3,
+      "count": 0,
       "label": "MOCK_TEAM",
       "tags": Object {
-        "allocated": 1,
-        "overdue": 2,
+        "allocated": 0,
+        "overdue": 0,
       },
       "type": "team",
       "value": 1,
     },
     Card {
-      "count": 3,
+      "count": 2,
       "label": "MOCK_TEAM",
       "tags": Object {
-        "allocated": 3,
+        "allocated": 1,
         "overdue": 1,
       },
       "type": "team",
       "value": 2,
+    },
+    Card {
+      "count": 0,
+      "label": "MOCK_TEAM",
+      "tags": Object {
+        "allocated": 0,
+        "overdue": 0,
+      },
+      "type": "team",
+      "value": 3,
     },
   ],
   "user": Array [
@@ -69,7 +79,7 @@ Object {
       "count": 1,
       "label": "Cases",
       "tags": Object {
-        "allocated": undefined,
+        "allocated": 0,
         "overdue": 1,
       },
       "type": undefined,
@@ -83,17 +93,17 @@ exports[`Dashboard Adapter should transform a stage array to a dashboard schema 
 Object {
   "teams": Array [
     Card {
-      "count": 3,
+      "count": 0,
       "label": "MOCK_TEAM",
       "tags": Object {
-        "allocated": 1,
+        "allocated": 0,
         "overdue": 0,
       },
       "type": "team",
       "value": 1,
     },
     Card {
-      "count": 1,
+      "count": 2,
       "label": "MOCK_TEAM",
       "tags": Object {
         "allocated": 1,
@@ -102,14 +112,24 @@ Object {
       "type": "team",
       "value": 2,
     },
+    Card {
+      "count": 0,
+      "label": "MOCK_TEAM",
+      "tags": Object {
+        "allocated": 0,
+        "overdue": 0,
+      },
+      "type": "team",
+      "value": 3,
+    },
   ],
   "user": Array [
     Card {
       "count": 1,
       "label": "Cases",
       "tags": Object {
-        "allocated": undefined,
-        "overdue": false,
+        "allocated": 0,
+        "overdue": 0,
       },
       "type": undefined,
       "value": undefined,

--- a/server/lists/adapters/__tests__/__snapshots__/workstacks.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/workstacks.spec.js.snap
@@ -1,45 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dashboard Adapter should hide unworkable
- 1`] = `
-Object {
-  "teams": Array [
-    Card {
-      "count": 2,
-      "label": "MOCK_TEAM",
-      "tags": Object {
-        "allocated": 0,
-        "overdue": 1,
-      },
-      "type": "team",
-      "value": 1,
-    },
-    Card {
-      "count": 3,
-      "label": "MOCK_TEAM",
-      "tags": Object {
-        "allocated": 3,
-        "overdue": 1,
-      },
-      "type": "team",
-      "value": 2,
-    },
-  ],
-  "user": Array [
-    Card {
-      "count": 1,
-      "label": "Cases",
-      "tags": Object {
-        "allocated": undefined,
-        "overdue": 1,
-      },
-      "type": undefined,
-      "value": undefined,
-    },
-  ],
-}
-`;
-
 exports[`Dashboard Adapter should transform a stage array to a dashboard schema 1`] = `
 Object {
   "teams": Array [

--- a/server/lists/adapters/__tests__/workstacks.spec.js
+++ b/server/lists/adapters/__tests__/workstacks.spec.js
@@ -50,46 +50,34 @@ describe('Dashboard Adapter', () => {
         const mockData = {
             stages: [
                 {
-                    teamUUID: 1,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: 1,
-                    deadline: '1900-01-01'
+                    teamUuid: 1,
+                    statistics: {
+                        usersCases: 0,
+                        usersOverdueCases: 0,
+                        cases: 0,
+                        overdueCases: 0,
+                        unallocatedCases: 0
+                    }
                 },
                 {
-                    teamUUID: 1,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: null,
-                    deadline: '1900-01-02'
+                    teamUuid: 2,
+                    statistics: {
+                        usersCases: 1,
+                        usersOverdueCases: 1,
+                        cases: 2,
+                        overdueCases: 1,
+                        unallocatedCases: 1
+                    }
                 },
                 {
-                    teamUUID: 1,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: 2,
-                    deadline: '2200-01-03'
-                },
-                {
-                    teamUUID: 2,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: null,
-                    deadline: '2200-04-01'
-                },
-                {
-                    teamUUID: 2,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: null,
-                    deadline: todaysDate
-                },
-                {
-                    teamUUID: 2,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: null,
-                    deadline: '1900-01-01'
+                    teamUuid: 3,
+                    statistics: {
+                        usersCases: 0,
+                        usersOverdueCases: 0,
+                        cases: 0,
+                        overdueCases: 0,
+                        unallocatedCases: 0
+                    }
                 }
             ]
         };
@@ -166,43 +154,42 @@ describe('Dashboard Adapter', () => {
         const mockData = {
             stages: [
                 {
-                    teamUUID: 1,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: 1,
-                    deadline: '1900-01-01'
+                    teamUuid: 1,
+                    statistics: {
+                        usersCases: 0,
+                        usersOverdueCases: 0,
+                        cases: 0,
+                        overdueCases: 0,
+                        unallocatedCases: 0
+                    }
                 },
                 {
-                    teamUUID: 1,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: null,
-                    deadline: '1900-01-02'
+                    teamUuid: 2,
+                    statistics: {
+                        usersCases: 1,
+                        usersOverdueCases: 1,
+                        cases: 2,
+                        overdueCases: 1,
+                        unallocatedCases: 1
+                    }
                 },
                 {
-                    teamUUID: 1,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: 2,
-                    deadline: '2200-01-03'
-                },
-                {
-                    teamUUID: 2,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: null,
-                    deadline: '2200-04-01'
+                    teamUuid: 3,
+                    statistics: {
+                        usersCases: 0,
+                        usersOverdueCases: 0,
+                        cases: 0,
+                        overdueCases: 0,
+                        unallocatedCases: 0
+                    }
                 }
             ]
         };
         const testConfiguration = {
-            workstackTypeColumns: [
-                { workstackType: 'DEFAULT', workstackColumns: [] },
-                { workstackType: 'WCS', workstackColumns: [] }
-            ],
+            ...mockConfiguration,
             deadlinesEnabled: false
-        }
-            ;
+        };
+
         const result = await dashboardAdapter(mockData, {
             user: mockUser,
             fromStaticList: mockFromStaticList,
@@ -1096,7 +1083,7 @@ describe('Workflow Workstack Adapter', () => {
             stages: [
                 {
                     correspondents: {
-                        correspondents: [ { fullname: 'testName', uuid: 'uuid123', is_primary: 'true' } ]
+                        correspondents: [{ fullname: 'testName', uuid: 'uuid123', is_primary: 'true' }]
                     },
                     teamUUID: 2,
                     caseType: 'WCS',

--- a/server/lists/adapters/__tests__/workstacks.spec.js
+++ b/server/lists/adapters/__tests__/workstacks.spec.js
@@ -90,65 +90,6 @@ describe('Dashboard Adapter', () => {
         });
         expect(result).toMatchSnapshot();
     });
-    it('should hide unworkable\n', async () => {
-        const mockData = {
-            stages: [
-                {
-                    teamUUID: 1,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: 1,
-                    deadline: '1900-01-01'
-                },
-                {
-                    teamUUID: 1,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: null,
-                    deadline: '1900-01-02',
-                    data: {
-                        Unworkable: 'True'
-                    }
-                },
-                {
-                    teamUUID: 1,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: 2,
-                    deadline: '2200-01-03'
-                },
-                {
-                    teamUUID: 2,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: null,
-                    deadline: '2200-04-01'
-                },
-                {
-                    teamUUID: 2,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: null,
-                    deadline: todaysDate
-                },
-                {
-                    teamUUID: 2,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: null,
-                    deadline: '1900-01-01'
-                }
-            ]
-        };
-
-        const result = await dashboardAdapter(mockData, {
-            user: mockUser,
-            fromStaticList: mockFromStaticList,
-            logger: mockLogger,
-            configuration: mockConfiguration
-        });
-        expect(result).toMatchSnapshot();
-    });
 
     it('should transform a stage array to a dashboard schema when deadlines are disabled', async () => {
         const mockData = {

--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -269,7 +269,7 @@ module.exports = {
         },
         DASHBOARD: {
             client: 'CASEWORK',
-            endpoint: '/stage',
+            endpoint: '/dashboard',
             adapter: workstack.dashboardAdapter
         },
         USER_WORKSTACK: {


### PR DESCRIPTION
To support the new result set provided by the `/dashboard`
endpoint in casework, this change parses the result that will 
be returned. As we no longer need computation (as this is 
done in the backend service), we can simply just populate 
each of the cards.

This change also changes the list that is used when hitting 
the dashboard to `/dashboard` of casework.