### PR TITLE
HOCS-3474 Sorting on Requester/Reference column is broken in all work…

### DIFF
--- a/src/shared/common/components/__tests__/__snapshots__/workstack.spec.jsx.snap
+++ b/src/shared/common/components/__tests__/__snapshots__/workstack.spec.jsx.snap
@@ -225,6 +225,22 @@ exports[`Workstack component should not add link to headers with sortStrategy no
               "stageTypeDisplay": "Stage F",
               "uuid": "stage_uuid-447",
             },
+            Object {
+              "assignedTeamDisplay": "team6",
+              "assignedUserDisplay": "User5",
+              "caseReference": "case6",
+              "caseUUID": "case_uuid-klm",
+              "created": null,
+              "data": Object {
+                "CaseContributions": "[{\\"data\\":{\\"contributionDueDate\\":\\"2020-12-12\\", \\"contributionStatus\\": \\"TEST\\"}}]",
+                "DueDate": "2021-01-01",
+              },
+              "fullName": "My Name",
+              "isActive": "YES",
+              "stageType": "MPAM_DRAFT",
+              "stageTypeDisplay": "Stage F",
+              "uuid": "stage_uuid-448",
+            },
           ]
         }
         selectable={true}
@@ -291,7 +307,7 @@ exports[`Workstack component should not add link to headers with sortStrategy no
                         aria-live="polite"
                         className="govuk-hint"
                       >
-                        6
+                        7
                          Items
                       </span>
                       <table
@@ -1072,13 +1088,125 @@ exports[`Workstack component should not add link to headers with sortStrategy no
                               <span />
                             </td>
                           </tr>
+                          <tr
+                            className="govuk-radios govuk-table__row"
+                            key="stage_uuid-448"
+                          >
+                            <td
+                              className="govuk-table__cell"
+                            >
+                              <div
+                                className="govuk-checkboxes"
+                              >
+                                <div
+                                  className="govuk-checkboxes__item"
+                                  key="case_uuid-klmstage_uuid-448"
+                                >
+                                  <input
+                                    checked={false}
+                                    className="govuk-checkboxes__input"
+                                    id="selected_cases_case_uuid-klm"
+                                    name="selected_cases[]"
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                    value="case_uuid-klm:stage_uuid-448"
+                                  />
+                                  <label
+                                    className="govuk-label govuk-checkboxes__label"
+                                    htmlFor="selected_cases_case_uuid-klm"
+                                  >
+                                    <span
+                                      className="govuk-visually-hidden"
+                                    >
+                                      case6
+                                    </span>
+                                  </label>
+                                </div>
+                              </div>
+                            </td>
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448caseReference"
+                            >
+                              <Link
+                                className="govuk-link govuk-!-margin-right-3"
+                                to="/case/case_uuid-klm/stage/stage_uuid-448"
+                              >
+                                <LinkAnchor
+                                  className="govuk-link govuk-!-margin-right-3"
+                                  href="/case/case_uuid-klm/stage/stage_uuid-448"
+                                  navigate={[Function]}
+                                >
+                                  <a
+                                    className="govuk-link govuk-!-margin-right-3"
+                                    href="/case/case_uuid-klm/stage/stage_uuid-448"
+                                    onClick={[Function]}
+                                  >
+                                    case6
+                                  </a>
+                                </LinkAnchor>
+                              </Link>
+                            </td>
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448fullName"
+                            >
+                              My Name
+                            </td>
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448fullname"
+                            />
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448postcode"
+                            />
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448stageTypeDisplay"
+                            >
+                              Stage F
+                            </td>
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448assignedUserDisplay"
+                            >
+                              User5
+                            </td>
+                            <td
+                              className="govuk-table__cell govuk-table__cell--truncated"
+                              key="stage_uuid-448assignedTopicDisplay"
+                            />
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448TEST,created"
+                            />
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448isActive,TEST"
+                            >
+                              is Active
+                            </td>
+                            <td
+                              className="govuk-table__cell date-warning"
+                              key="stage_uuid-448data.CaseContributions"
+                            >
+                              <span />
+                            </td>
+                            <td
+                              className="govuk-table__cell date-warning"
+                              key="stage_uuid-448DueDate"
+                            >
+                              <span />
+                            </td>
+                          </tr>
                         </tbody>
                       </table>
                       <span
                         aria-live="polite"
                         className="govuk-hint"
                       >
-                        6
+                        7
                          Items
                       </span>
                     </div>
@@ -1161,7 +1289,7 @@ Array [
                   aria-live="polite"
                   class="govuk-hint"
                 >
-                  6 Items
+                  7 Items
                 </span>
                 <table
                   class="govuk-table"
@@ -1758,13 +1886,98 @@ Array [
                         <span />
                       </td>
                     </tr>
+                    <tr
+                      class="govuk-radios govuk-table__row"
+                    >
+                      <td
+                        class="govuk-table__cell"
+                      >
+                        <div
+                          class="govuk-checkboxes"
+                        >
+                          <div
+                            class="govuk-checkboxes__item"
+                          >
+                            <input
+                              class="govuk-checkboxes__input"
+                              id="selected_cases_case_uuid-klm"
+                              name="selected_cases[]"
+                              type="checkbox"
+                              value="case_uuid-klm:stage_uuid-448"
+                            />
+                            <label
+                              class="govuk-label govuk-checkboxes__label"
+                              for="selected_cases_case_uuid-klm"
+                            >
+                              <span
+                                class="govuk-visually-hidden"
+                              >
+                                case6
+                              </span>
+                            </label>
+                          </div>
+                        </div>
+                      </td>
+                      <td
+                        class="govuk-table__cell"
+                      >
+                        <a
+                          class="govuk-link govuk-!-margin-right-3"
+                          href="/case/case_uuid-klm/stage/stage_uuid-448"
+                        >
+                          case6
+                        </a>
+                      </td>
+                      <td
+                        class="govuk-table__cell"
+                      >
+                        My Name
+                      </td>
+                      <td
+                        class="govuk-table__cell"
+                      />
+                      <td
+                        class="govuk-table__cell"
+                      />
+                      <td
+                        class="govuk-table__cell"
+                      >
+                        Stage F
+                      </td>
+                      <td
+                        class="govuk-table__cell"
+                      >
+                        User5
+                      </td>
+                      <td
+                        class="govuk-table__cell govuk-table__cell--truncated"
+                      />
+                      <td
+                        class="govuk-table__cell"
+                      />
+                      <td
+                        class="govuk-table__cell"
+                      >
+                        is Active
+                      </td>
+                      <td
+                        class="govuk-table__cell date-warning"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        class="govuk-table__cell date-warning"
+                      >
+                        <span />
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
                 <span
                   aria-live="polite"
                   class="govuk-hint"
                 >
-                  6 Items
+                  7 Items
                 </span>
               </div>
             </div>
@@ -1887,7 +2100,7 @@ Array [
                   aria-live="polite"
                   class="govuk-hint"
                 >
-                  6 Items
+                  7 Items
                 </span>
                 <table
                   class="govuk-table"
@@ -2484,13 +2697,98 @@ Array [
                         <span />
                       </td>
                     </tr>
+                    <tr
+                      class="govuk-radios govuk-table__row"
+                    >
+                      <td
+                        class="govuk-table__cell"
+                      >
+                        <div
+                          class="govuk-checkboxes"
+                        >
+                          <div
+                            class="govuk-checkboxes__item"
+                          >
+                            <input
+                              class="govuk-checkboxes__input"
+                              id="selected_cases_case_uuid-klm"
+                              name="selected_cases[]"
+                              type="checkbox"
+                              value="case_uuid-klm:stage_uuid-448"
+                            />
+                            <label
+                              class="govuk-label govuk-checkboxes__label"
+                              for="selected_cases_case_uuid-klm"
+                            >
+                              <span
+                                class="govuk-visually-hidden"
+                              >
+                                case6
+                              </span>
+                            </label>
+                          </div>
+                        </div>
+                      </td>
+                      <td
+                        class="govuk-table__cell"
+                      >
+                        <a
+                          class="govuk-link govuk-!-margin-right-3"
+                          href="/case/case_uuid-klm/stage/stage_uuid-448"
+                        >
+                          case6
+                        </a>
+                      </td>
+                      <td
+                        class="govuk-table__cell"
+                      >
+                        My Name
+                      </td>
+                      <td
+                        class="govuk-table__cell"
+                      />
+                      <td
+                        class="govuk-table__cell"
+                      />
+                      <td
+                        class="govuk-table__cell"
+                      >
+                        Stage F
+                      </td>
+                      <td
+                        class="govuk-table__cell"
+                      >
+                        User5
+                      </td>
+                      <td
+                        class="govuk-table__cell govuk-table__cell--truncated"
+                      />
+                      <td
+                        class="govuk-table__cell"
+                      />
+                      <td
+                        class="govuk-table__cell"
+                      >
+                        is Active
+                      </td>
+                      <td
+                        class="govuk-table__cell date-warning"
+                      >
+                        <span />
+                      </td>
+                      <td
+                        class="govuk-table__cell date-warning"
+                      >
+                        <span />
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
                 <span
                   aria-live="polite"
                   class="govuk-hint"
                 >
-                  6 Items
+                  7 Items
                 </span>
               </div>
             </div>
@@ -2760,6 +3058,22 @@ exports[`Workstack component should render with filtering 1`] = `
               "stageType": "MPAM_DRAFT",
               "stageTypeDisplay": "Stage F",
               "uuid": "stage_uuid-447",
+            },
+            Object {
+              "assignedTeamDisplay": "team6",
+              "assignedUserDisplay": "User5",
+              "caseReference": "case6",
+              "caseUUID": "case_uuid-klm",
+              "created": null,
+              "data": Object {
+                "CaseContributions": "[{\\"data\\":{\\"contributionDueDate\\":\\"2020-12-12\\", \\"contributionStatus\\": \\"TEST\\"}}]",
+                "DueDate": "2021-01-01",
+              },
+              "fullName": "My Name",
+              "isActive": "YES",
+              "stageType": "MPAM_DRAFT",
+              "stageTypeDisplay": "Stage F",
+              "uuid": "stage_uuid-448",
             },
           ]
         }
@@ -3342,6 +3656,22 @@ exports[`Workstack component should sort descending when the column heading is c
               "stageTypeDisplay": "Stage F",
               "uuid": "stage_uuid-447",
             },
+            Object {
+              "assignedTeamDisplay": "team6",
+              "assignedUserDisplay": "User5",
+              "caseReference": "case6",
+              "caseUUID": "case_uuid-klm",
+              "created": null,
+              "data": Object {
+                "CaseContributions": "[{\\"data\\":{\\"contributionDueDate\\":\\"2020-12-12\\", \\"contributionStatus\\": \\"TEST\\"}}]",
+                "DueDate": "2021-01-01",
+              },
+              "fullName": "My Name",
+              "isActive": "YES",
+              "stageType": "MPAM_DRAFT",
+              "stageTypeDisplay": "Stage F",
+              "uuid": "stage_uuid-448",
+            },
           ]
         }
         selectable={true}
@@ -3408,7 +3738,7 @@ exports[`Workstack component should sort descending when the column heading is c
                         aria-live="polite"
                         className="govuk-hint"
                       >
-                        6
+                        7
                          Items
                       </span>
                       <table
@@ -3617,6 +3947,118 @@ exports[`Workstack component should sort descending when the column heading is c
                             <td
                               className="govuk-table__cell date-warning"
                               key="stage_uuid-447DueDate"
+                            >
+                              <span />
+                            </td>
+                          </tr>
+                          <tr
+                            className="govuk-radios govuk-table__row"
+                            key="stage_uuid-448"
+                          >
+                            <td
+                              className="govuk-table__cell"
+                            >
+                              <div
+                                className="govuk-checkboxes"
+                              >
+                                <div
+                                  className="govuk-checkboxes__item"
+                                  key="case_uuid-klmstage_uuid-448"
+                                >
+                                  <input
+                                    checked={false}
+                                    className="govuk-checkboxes__input"
+                                    id="selected_cases_case_uuid-klm"
+                                    name="selected_cases[]"
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                    value="case_uuid-klm:stage_uuid-448"
+                                  />
+                                  <label
+                                    className="govuk-label govuk-checkboxes__label"
+                                    htmlFor="selected_cases_case_uuid-klm"
+                                  >
+                                    <span
+                                      className="govuk-visually-hidden"
+                                    >
+                                      case6
+                                    </span>
+                                  </label>
+                                </div>
+                              </div>
+                            </td>
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448caseReference"
+                            >
+                              <Link
+                                className="govuk-link govuk-!-margin-right-3"
+                                to="/case/case_uuid-klm/stage/stage_uuid-448"
+                              >
+                                <LinkAnchor
+                                  className="govuk-link govuk-!-margin-right-3"
+                                  href="/case/case_uuid-klm/stage/stage_uuid-448"
+                                  navigate={[Function]}
+                                >
+                                  <a
+                                    className="govuk-link govuk-!-margin-right-3"
+                                    href="/case/case_uuid-klm/stage/stage_uuid-448"
+                                    onClick={[Function]}
+                                  >
+                                    case6
+                                  </a>
+                                </LinkAnchor>
+                              </Link>
+                            </td>
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448fullName"
+                            >
+                              My Name
+                            </td>
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448fullname"
+                            />
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448postcode"
+                            />
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448stageTypeDisplay"
+                            >
+                              Stage F
+                            </td>
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448assignedUserDisplay"
+                            >
+                              User5
+                            </td>
+                            <td
+                              className="govuk-table__cell govuk-table__cell--truncated"
+                              key="stage_uuid-448assignedTopicDisplay"
+                            />
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448TEST,created"
+                            />
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448isActive,TEST"
+                            >
+                              is Active
+                            </td>
+                            <td
+                              className="govuk-table__cell date-warning"
+                              key="stage_uuid-448data.CaseContributions"
+                            >
+                              <span />
+                            </td>
+                            <td
+                              className="govuk-table__cell date-warning"
+                              key="stage_uuid-448DueDate"
                             >
                               <span />
                             </td>
@@ -4196,7 +4638,7 @@ exports[`Workstack component should sort descending when the column heading is c
                         aria-live="polite"
                         className="govuk-hint"
                       >
-                        6
+                        7
                          Items
                       </span>
                     </div>
@@ -4473,6 +4915,22 @@ exports[`Workstack component should sort when the column heading is clicked 1`] 
               "stageTypeDisplay": "Stage F",
               "uuid": "stage_uuid-447",
             },
+            Object {
+              "assignedTeamDisplay": "team6",
+              "assignedUserDisplay": "User5",
+              "caseReference": "case6",
+              "caseUUID": "case_uuid-klm",
+              "created": null,
+              "data": Object {
+                "CaseContributions": "[{\\"data\\":{\\"contributionDueDate\\":\\"2020-12-12\\", \\"contributionStatus\\": \\"TEST\\"}}]",
+                "DueDate": "2021-01-01",
+              },
+              "fullName": "My Name",
+              "isActive": "YES",
+              "stageType": "MPAM_DRAFT",
+              "stageTypeDisplay": "Stage F",
+              "uuid": "stage_uuid-448",
+            },
           ]
         }
         selectable={true}
@@ -4539,7 +4997,7 @@ exports[`Workstack component should sort when the column heading is clicked 1`] 
                         aria-live="polite"
                         className="govuk-hint"
                       >
-                        6
+                        7
                          Items
                       </span>
                       <table
@@ -5321,13 +5779,125 @@ exports[`Workstack component should sort when the column heading is clicked 1`] 
                               <span />
                             </td>
                           </tr>
+                          <tr
+                            className="govuk-radios govuk-table__row"
+                            key="stage_uuid-448"
+                          >
+                            <td
+                              className="govuk-table__cell"
+                            >
+                              <div
+                                className="govuk-checkboxes"
+                              >
+                                <div
+                                  className="govuk-checkboxes__item"
+                                  key="case_uuid-klmstage_uuid-448"
+                                >
+                                  <input
+                                    checked={false}
+                                    className="govuk-checkboxes__input"
+                                    id="selected_cases_case_uuid-klm"
+                                    name="selected_cases[]"
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                    value="case_uuid-klm:stage_uuid-448"
+                                  />
+                                  <label
+                                    className="govuk-label govuk-checkboxes__label"
+                                    htmlFor="selected_cases_case_uuid-klm"
+                                  >
+                                    <span
+                                      className="govuk-visually-hidden"
+                                    >
+                                      case6
+                                    </span>
+                                  </label>
+                                </div>
+                              </div>
+                            </td>
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448caseReference"
+                            >
+                              <Link
+                                className="govuk-link govuk-!-margin-right-3"
+                                to="/case/case_uuid-klm/stage/stage_uuid-448"
+                              >
+                                <LinkAnchor
+                                  className="govuk-link govuk-!-margin-right-3"
+                                  href="/case/case_uuid-klm/stage/stage_uuid-448"
+                                  navigate={[Function]}
+                                >
+                                  <a
+                                    className="govuk-link govuk-!-margin-right-3"
+                                    href="/case/case_uuid-klm/stage/stage_uuid-448"
+                                    onClick={[Function]}
+                                  >
+                                    case6
+                                  </a>
+                                </LinkAnchor>
+                              </Link>
+                            </td>
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448fullName"
+                            >
+                              My Name
+                            </td>
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448fullname"
+                            />
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448postcode"
+                            />
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448stageTypeDisplay"
+                            >
+                              Stage F
+                            </td>
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448assignedUserDisplay"
+                            >
+                              User5
+                            </td>
+                            <td
+                              className="govuk-table__cell govuk-table__cell--truncated"
+                              key="stage_uuid-448assignedTopicDisplay"
+                            />
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448TEST,created"
+                            />
+                            <td
+                              className="govuk-table__cell"
+                              key="stage_uuid-448isActive,TEST"
+                            >
+                              is Active
+                            </td>
+                            <td
+                              className="govuk-table__cell date-warning"
+                              key="stage_uuid-448data.CaseContributions"
+                            >
+                              <span />
+                            </td>
+                            <td
+                              className="govuk-table__cell date-warning"
+                              key="stage_uuid-448DueDate"
+                            >
+                              <span />
+                            </td>
+                          </tr>
                         </tbody>
                       </table>
                       <span
                         aria-live="polite"
                         className="govuk-hint"
                       >
-                        6
+                        7
                          Items
                       </span>
                     </div>

--- a/src/shared/common/components/__tests__/workstack.spec.jsx
+++ b/src/shared/common/components/__tests__/workstack.spec.jsx
@@ -64,6 +64,15 @@ describe('Workstack component', () => {
                     CaseContributions: '[{"data":{"contributionDueDate":"2020-12-12", "contributionStatus": "TEST"}}]',
                     DueDate: '2021-01-01'
                 }
+            },
+            {
+                caseReference: 'case6', caseUUID: 'case_uuid-klm', uuid: 'stage_uuid-448', fullName: 'My Name',
+                stageTypeDisplay: 'Stage F', assignedUserDisplay: 'User5', assignedTeamDisplay: 'team6',
+                created: null, isActive: 'YES', stageType: 'MPAM_DRAFT',
+                data: {
+                    CaseContributions: '[{"data":{"contributionDueDate":"2020-12-12", "contributionStatus": "TEST"}}]',
+                    DueDate: '2021-01-01'
+                }
             }
         ],
         columns: [
@@ -125,7 +134,7 @@ describe('Workstack component', () => {
         const links = WRAPPER.find('th.govuk-link');
         expect(links).toHaveLength(11);
         links.first().simulate('click');
-        expect(arraySortSpy).toHaveBeenCalledTimes(21);
+        expect(arraySortSpy).toHaveBeenCalledTimes(27);
         expect(WRAPPER).toMatchSnapshot();
     });
 
@@ -138,7 +147,7 @@ describe('Workstack component', () => {
         expect(links).toHaveLength(11);
         links.first().simulate('click');
         links.first().simulate('click');
-        expect(arraySortSpy).toHaveBeenCalledTimes(28);
+        expect(arraySortSpy).toHaveBeenCalledTimes(36);
         expect(WRAPPER).toMatchSnapshot();
     });
 

--- a/src/shared/common/components/workstack.jsx
+++ b/src/shared/common/components/workstack.jsx
@@ -140,7 +140,7 @@ class WorkstackAllocate extends Component {
     }
 
     getPrimaryCorrespondentDataValue(row) {
-        return row.primaryCorrespondent.fullname;
+        return row.primaryCorrespondent ? row.primaryCorrespondent.fullname : '';
     }
 
     applyDataAdapter(value, colDataAdapter, dataValueKey, row) {


### PR DESCRIPTION
…stacks

This issue is called by old cases which do not have correspondents. This
change adds a check to stop these throwing errors.

* Check primaryCorrespondent is defined before trying to access fullname