### PR TITLE
HOCS 3417 Allocate a case

### DIFF
--- a/server/services/action.js
+++ b/server/services/action.js
@@ -94,7 +94,6 @@ const actions = {
                     case actionTypes.CREATE_CASE: {
                         const { data: documentTags } = await getDocumentTags(context);
                         response = await createCase('/case', { caseType: context, form }, documentTags[0], headers);
-                        console.log('responseData', response.data);
                         clientResponse = { summary: 'Case Created ', link: `${response.data.reference}` };
                         return handleActionSuccess(clientResponse, workflow, form);
                     }

--- a/server/services/action.js
+++ b/server/services/action.js
@@ -94,6 +94,7 @@ const actions = {
                     case actionTypes.CREATE_CASE: {
                         const { data: documentTags } = await getDocumentTags(context);
                         response = await createCase('/case', { caseType: context, form }, documentTags[0], headers);
+                        console.log('responseData', response.data);
                         clientResponse = { summary: 'Case Created ', link: `${response.data.reference}` };
                         return handleActionSuccess(clientResponse, workflow, form);
                     }

--- a/src/shared/common/forms/__tests__/__snapshots__/confirmation-with-team-name-and-case-ref.spec.js.snap
+++ b/src/shared/common/forms/__tests__/__snapshots__/confirmation-with-team-name-and-case-ref.spec.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Panel component should render with default props 1`] = `
+<div>
+  <div
+    class="govuk-panel govuk-panel--confirmation"
+  >
+    <div
+      class="govuk-panel__body"
+    >
+      Case : 
+    </div>
+  </div>
+  <h2
+    class="govuk-heading-m"
+  >
+    Case   
+  </h2>
+</div>
+`;
+
+exports[`Panel component should render with title and team name when passed 1`] = `
+<div>
+  <div
+    class="govuk-panel govuk-panel--confirmation"
+  >
+    <div
+      class="govuk-panel__body"
+    >
+      Case completed: FOI BICSPI Acceptance Team
+    </div>
+  </div>
+  <h2
+    class="govuk-heading-m"
+  >
+    Case test-case-ref completed FOI BICSPI Acceptance Team
+  </h2>
+</div>
+`;

--- a/src/shared/common/forms/__tests__/confirmation-with-team-name-and-case-ref.spec.js
+++ b/src/shared/common/forms/__tests__/confirmation-with-team-name-and-case-ref.spec.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import ConfirmationWithTeamNameAndCaseRef from '../confirmation-with-team-name-and-case-ref.jsx';
+import { ApplicationProvider } from '../../../contexts/application.jsx';
+
+describe('Panel component', () => {
+    const config = {
+        csrf: '__token__'
+    };
+
+    const choices = [
+        {
+            key: '4ef92480-922f-11eb-a8b3-0242ac130003',
+            value: 'FOI BICSPI Acceptance Team'
+        }
+    ];
+
+    const data = {
+        AcceptanceTeam: '4ef92480-922f-11eb-a8b3-0242ac130003'
+    };
+
+    xit('should render with default props', () => {
+        expect(
+            render(<ApplicationProvider>
+                <ConfirmationWithTeamNameAndCaseRef />
+            </ApplicationProvider>)
+        ).toMatchSnapshot();
+    });
+
+
+    it('should render with title and team name when passed', () => {
+        expect(
+            render(<ApplicationProvider config={config} data={data}>
+                <ConfirmationWithTeamNameAndCaseRef data={data} choices={choices} label="completed" caseRef={'test-case-ref'} />
+            </ApplicationProvider>)
+        ).toMatchSnapshot();
+    });
+
+});

--- a/src/shared/common/forms/__tests__/confirmation-with-team-name-and-case-ref.spec.js
+++ b/src/shared/common/forms/__tests__/confirmation-with-team-name-and-case-ref.spec.js
@@ -14,14 +14,19 @@ describe('Panel component', () => {
         }
     ];
 
+    const defaultData = {
+
+    };
+
     const data = {
+        CurrentStage: 'FOI_ALLOCATION',
         AcceptanceTeam: '4ef92480-922f-11eb-a8b3-0242ac130003'
     };
 
-    xit('should render with default props', () => {
+    it('should render with default props', () => {
         expect(
-            render(<ApplicationProvider>
-                <ConfirmationWithTeamNameAndCaseRef />
+            render(<ApplicationProvider config={config}>
+                <ConfirmationWithTeamNameAndCaseRef data={defaultData}/>
             </ApplicationProvider>)
         ).toMatchSnapshot();
     });
@@ -29,7 +34,7 @@ describe('Panel component', () => {
 
     it('should render with title and team name when passed', () => {
         expect(
-            render(<ApplicationProvider config={config} data={data}>
+            render(<ApplicationProvider config={config} >
                 <ConfirmationWithTeamNameAndCaseRef data={data} choices={choices} label="completed" caseRef={'test-case-ref'} />
             </ApplicationProvider>)
         ).toMatchSnapshot();

--- a/src/shared/common/forms/confirmation-with-team-name-and-case-ref.jsx
+++ b/src/shared/common/forms/confirmation-with-team-name-and-case-ref.jsx
@@ -3,11 +3,9 @@ import PropTypes from 'prop-types';
 
 export default class ConfirmationWithTeamNameAndCaseRef extends Component {
 
-    getTeamName(teams, data){
-        if (data.AcceptanceTeam){
-            return teams.find(team => team.key === data.AcceptanceTeam).value;
-        }
-        return '';
+    extractRequiredTeam(data, CurrentStage, choices) {
+        const requiredTeamType = StageTeamTypes[CurrentStage];
+        return requiredTeamType ? choices.find(choice => choice.key === data[requiredTeamType]).value : '';
     }
 
     render() {
@@ -19,7 +17,7 @@ export default class ConfirmationWithTeamNameAndCaseRef extends Component {
             data
         } = this.props;
 
-        const teamName = this.getTeamName(choices, data);
+        const teamName = this.extractRequiredTeam(data, data.CurrentStage, choices);
 
         return (
             <div>
@@ -36,8 +34,12 @@ export default class ConfirmationWithTeamNameAndCaseRef extends Component {
 }
 
 ConfirmationWithTeamNameAndCaseRef.propTypes = {
-    data: PropTypes.object,
     label: PropTypes.string,
     caseRef: PropTypes.string,
-    choices: PropTypes.array
+    choices: PropTypes.array,
+    data: PropTypes.object
+};
+
+const StageTeamTypes = {
+    FOI_ALLOCATION: 'AcceptanceTeam'
 };

--- a/src/shared/common/forms/confirmation-with-team-name-and-case-ref.jsx
+++ b/src/shared/common/forms/confirmation-with-team-name-and-case-ref.jsx
@@ -1,16 +1,25 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-export default class ConfirmationWithCaseRef extends Component {
+export default class ConfirmationWithTeamNameAndCaseRef extends Component {
+
+    getTeamName(teams, data){
+        if (data.AcceptanceTeam){
+            return teams.find(team => team.key === data.AcceptanceTeam).value;
+        }
+        return '';
+    }
 
     render() {
 
         const {
             label,
             caseRef,
-            nextActions,
-            teamName
+            choices,
+            data
         } = this.props;
+
+        const teamName = this.getTeamName(choices, data);
 
         return (
             <div>
@@ -21,27 +30,14 @@ export default class ConfirmationWithCaseRef extends Component {
                 <h2 className="govuk-heading-m">
                     Case {caseRef} {label} {teamName}
                 </h2>
-                <div>
-                    {nextActions &&
-                        nextActions.map((action, i) => {
-                            return (
-                                <Fragment key={i}>
-                                    <div className='govuk-table__cell'>
-                                        <a href={`${action.url}`} className="govuk-link govuk-heading-m">{action.label} </a>
-                                    </div>
-                                </Fragment>
-                            );
-                        })
-                    }
-                </div>
             </div>
         );
     }
 }
 
-ConfirmationWithCaseRef.propTypes = {
+ConfirmationWithTeamNameAndCaseRef.propTypes = {
+    data: PropTypes.object,
     label: PropTypes.string,
     caseRef: PropTypes.string,
-    nextActions: PropTypes.array,
-    teamName: PropTypes.string
+    choices: PropTypes.array
 };

--- a/src/shared/common/forms/confirmation-with-team-name-and-case-ref.jsx
+++ b/src/shared/common/forms/confirmation-with-team-name-and-case-ref.jsx
@@ -1,0 +1,51 @@
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+
+export default class ConfirmationWithCaseRef extends Component {
+
+    render() {
+
+        const {
+            label,
+            caseRef,
+            nextActions,
+            teamName,
+            name,
+            callback
+        } = this.props;
+
+        return (
+            <div>
+                <div className="govuk-panel govuk-panel--confirmation">
+                    <div className="govuk-panel__body">Case {label}: {teamName}
+                    </div>
+                </div>
+                <h2 className="govuk-heading-m">
+                    Case {caseRef} {label} {teamName}
+                </h2>
+                <div>
+                    {nextActions &&
+                        nextActions.map((action, i) => {
+                            return (
+                                <Fragment key={i}>
+                                    <div className='govuk-table__cell'>
+                                        <a href={`${action.url}`} onClick={() => callback( { submitAction: name } )} className="govuk-link govuk-heading-m">{action.label} </a>
+                                    </div>
+                                </Fragment>
+                            );
+                        })
+                    }
+                </div>
+            </div>
+        );
+    }
+}
+
+ConfirmationWithCaseRef.propTypes = {
+    label: PropTypes.string,
+    caseRef: PropTypes.string,
+    nextActions: PropTypes.array,
+    name: PropTypes.string,
+    teamName: PropTypes.string,
+    callback: PropTypes.func
+};

--- a/src/shared/common/forms/confirmation-with-team-name-and-case-ref.jsx
+++ b/src/shared/common/forms/confirmation-with-team-name-and-case-ref.jsx
@@ -9,9 +9,7 @@ export default class ConfirmationWithCaseRef extends Component {
             label,
             caseRef,
             nextActions,
-            teamName,
-            name,
-            callback
+            teamName
         } = this.props;
 
         return (
@@ -29,7 +27,7 @@ export default class ConfirmationWithCaseRef extends Component {
                             return (
                                 <Fragment key={i}>
                                     <div className='govuk-table__cell'>
-                                        <a href={`${action.url}`} onClick={() => callback( { submitAction: name } )} className="govuk-link govuk-heading-m">{action.label} </a>
+                                        <a href={`${action.url}`} className="govuk-link govuk-heading-m">{action.label} </a>
                                     </div>
                                 </Fragment>
                             );
@@ -45,7 +43,5 @@ ConfirmationWithCaseRef.propTypes = {
     label: PropTypes.string,
     caseRef: PropTypes.string,
     nextActions: PropTypes.array,
-    name: PropTypes.string,
-    teamName: PropTypes.string,
-    callback: PropTypes.func
+    teamName: PropTypes.string
 };

--- a/src/shared/common/forms/form-repository.jsx
+++ b/src/shared/common/forms/form-repository.jsx
@@ -161,7 +161,11 @@ export function formComponentFactory(field, options) {
         case 'confirmation-with-case-ref':
             return renderFormComponent(ConfirmationWithCaseRef, { key, data, config, caseRef });
         case 'confirmation-with-team-name-and-case-ref':
-            return renderFormComponent(ConfirmationWithTeamNameAndCaseRef, { key, data, config: { ...config, baseUrl: options.baseUrl, teamName: data.Directorate }, caseRef, callback });
+            var teamName;
+            if (data.AcceptanceTeam){
+                teamName = config.choices.find(choice => choice.key === data.AcceptanceTeam).value;
+            }
+            return renderFormComponent(ConfirmationWithTeamNameAndCaseRef, { key, data, config: { ...config, baseUrl: options.baseUrl, teamName: teamName }, caseRef, callback });
         case 'paragraph':
             return renderFormComponent(Paragraph, { key, config });
         case 'entity-manager':

--- a/src/shared/common/forms/form-repository.jsx
+++ b/src/shared/common/forms/form-repository.jsx
@@ -28,6 +28,7 @@ import HideConditionFunctions from './../../helpers/hide-condition-functions';
 import ConfirmationWithCaseRef from './confirmation-with-case-ref.jsx';
 import ReviewField from './composite/review-field.jsx';
 import Heading from './heading.jsx';
+import ConfirmationWithTeamNameAndCaseRef from './confirmation-with-team-name-and-case-ref.jsx';
 
 function defaultDataAdapter(name, data, currentValue) {
     return data[name] || currentValue;
@@ -159,6 +160,8 @@ export function formComponentFactory(field, options) {
             return renderFormComponent(Inset, { key, data, config });
         case 'confirmation-with-case-ref':
             return renderFormComponent(ConfirmationWithCaseRef, { key, data, config, caseRef });
+        case 'confirmation-with-team-name-and-case-ref':
+            return renderFormComponent(ConfirmationWithTeamNameAndCaseRef, { key, data, config: { ...config, baseUrl: options.baseUrl, teamName: data.Directorate }, caseRef, callback });
         case 'paragraph':
             return renderFormComponent(Paragraph, { key, config });
         case 'entity-manager':

--- a/src/shared/common/forms/form-repository.jsx
+++ b/src/shared/common/forms/form-repository.jsx
@@ -161,11 +161,7 @@ export function formComponentFactory(field, options) {
         case 'confirmation-with-case-ref':
             return renderFormComponent(ConfirmationWithCaseRef, { key, data, config, caseRef });
         case 'confirmation-with-team-name-and-case-ref':
-            var teamName;
-            if (data.AcceptanceTeam){
-                teamName = config.choices.find(choice => choice.key === data.AcceptanceTeam).value;
-            }
-            return renderFormComponent(ConfirmationWithTeamNameAndCaseRef, { key, data, config: { ...config, baseUrl: options.baseUrl, teamName: teamName }, caseRef, callback });
+            return renderFormComponent(ConfirmationWithTeamNameAndCaseRef, { key, data, config, caseRef });
         case 'paragraph':
             return renderFormComponent(Paragraph, { key, config });
         case 'entity-manager':


### PR DESCRIPTION
Updates the allocation stage, removing the Request Type Selection screen, removing the Allocation Case Note entry field and adding in a confirmation screen displaying the team name and case number.