### PR TITLE
HOCS-3262 Changes to final allocation screen

### DIFF
--- a/src/shared/common/forms/__tests__/__snapshots__/confirmation-with-team-name-and-case-ref.spec.js.snap
+++ b/src/shared/common/forms/__tests__/__snapshots__/confirmation-with-team-name-and-case-ref.spec.js.snap
@@ -2,15 +2,6 @@
 
 exports[`Panel component should render with default props 1`] = `
 <div>
-  <div
-    class="govuk-panel govuk-panel--confirmation"
-  >
-    <div
-      class="govuk-panel__body"
-    >
-      Case : 
-    </div>
-  </div>
   <h2
     class="govuk-heading-m"
   >
@@ -20,6 +11,16 @@ exports[`Panel component should render with default props 1`] = `
 `;
 
 exports[`Panel component should render with title and team name when passed 1`] = `
+<div>
+  <h2
+    class="govuk-heading-m"
+  >
+    Case test-case-ref completed FOI BICSPI Acceptance Team
+  </h2>
+</div>
+`;
+
+exports[`Panel component should render with title, team name and header box when passed 1`] = `
 <div>
   <div
     class="govuk-panel govuk-panel--confirmation"

--- a/src/shared/common/forms/__tests__/confirmation-with-team-name-and-case-ref.spec.js
+++ b/src/shared/common/forms/__tests__/confirmation-with-team-name-and-case-ref.spec.js
@@ -14,6 +14,8 @@ describe('Panel component', () => {
         }
     ];
 
+    const hasHeader = true;
+
     const defaultData = {
 
     };
@@ -36,6 +38,14 @@ describe('Panel component', () => {
         expect(
             render(<ApplicationProvider config={config} >
                 <ConfirmationWithTeamNameAndCaseRef data={data} choices={choices} label="completed" caseRef={'test-case-ref'} />
+            </ApplicationProvider>)
+        ).toMatchSnapshot();
+    });
+
+    it('should render with title, team name and header box when passed', () => {
+        expect(
+            render(<ApplicationProvider config={config} >
+                <ConfirmationWithTeamNameAndCaseRef data={data} choices={choices} label="completed" caseRef={'test-case-ref'} hasHeader={hasHeader} />
             </ApplicationProvider>)
         ).toMatchSnapshot();
     });

--- a/src/shared/common/forms/confirmation-with-team-name-and-case-ref.jsx
+++ b/src/shared/common/forms/confirmation-with-team-name-and-case-ref.jsx
@@ -14,17 +14,20 @@ export default class ConfirmationWithTeamNameAndCaseRef extends Component {
             label,
             caseRef,
             choices,
-            data
+            data,
+            hasHeader
         } = this.props;
 
         const teamName = this.extractRequiredTeam(data, data.CurrentStage, choices);
 
         return (
             <div>
-                <div className="govuk-panel govuk-panel--confirmation">
-                    <div className="govuk-panel__body">Case {label}: {teamName}
+                {hasHeader &&
+                    <div className="govuk-panel govuk-panel--confirmation">
+                        <div className="govuk-panel__body">Case {label}: {teamName}
+                        </div>
                     </div>
-                </div>
+                }
                 <h2 className="govuk-heading-m">
                     Case {caseRef} {label} {teamName}
                 </h2>
@@ -37,7 +40,8 @@ ConfirmationWithTeamNameAndCaseRef.propTypes = {
     label: PropTypes.string,
     caseRef: PropTypes.string,
     choices: PropTypes.array,
-    data: PropTypes.object
+    data: PropTypes.object,
+    hasHeader: PropTypes.bool
 };
 
 const StageTeamTypes = {


### PR DESCRIPTION
1) Remove green "Case has been allocated to:..." panel from final screen in Allocation stage

2) Black text in screen shot to change from "Case FOI/xxxx... has been allocated to..." to "Case FOI/xxxx... will be allocated to..."

3) Green button to read "Confirm allocation"