### PR TITLE
HOCS-3464: eu national enquiry reason

### DIFF
--- a/server/lists/adapters/__tests__/__snapshots__/case-notes.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/case-notes.spec.js.snap
@@ -117,6 +117,18 @@ Array [
       "date": "5 January 2019 at 12:00",
       "modifiedBy": "MOCK_USER",
       "modifiedDate": null,
+      "note": "A test case note",
+    },
+    "timelineItemUUID": "__timelineItemUUID__",
+    "title": "Compliance measures - Other",
+    "type": "ENQUIRY_REASON_EUNATIONAL_OTHERDETAILS",
+  },
+  Object {
+    "body": Object {
+      "author": "MOCK_USER",
+      "date": "5 January 2019 at 12:00",
+      "modifiedBy": "MOCK_USER",
+      "modifiedDate": null,
       "stage": "MOCK_STAGETYPE",
     },
     "timelineItemUUID": "__timelineItemUUID__",

--- a/server/lists/adapters/__tests__/__snapshots__/case-summary.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/case-summary.spec.js.snap
@@ -215,6 +215,11 @@ Object {
       "label": "Test additional field date",
       "value": "01/01/2020",
     },
+    Object {
+      "choices": undefined,
+      "label": "Test additional field checkbox",
+      "value": "this, is, a, test",
+    },
   ],
   "case": Object {
     "created": "03/02/2019",

--- a/server/lists/adapters/__tests__/case-notes.spec.js
+++ b/server/lists/adapters/__tests__/case-notes.spec.js
@@ -43,6 +43,7 @@ describe('Case Notes Adapter', () => {
             { eventTime: '2019-01-05 12:00:01', type: 'CLOSE', userName: 'User A', body: { caseNote: 'A test case note', userUUID: 1, teamUUID: 1, stage: 1 }, timelineItemUUID: '__timelineItemUUID__' },
             { eventTime: '2019-01-05 12:00:03', type: 'CHANGE', userName: 'User A', body: { caseNote: 'A test case note', userUUID: 1, teamUUID: 1, stage: 1 }, timelineItemUUID: '__timelineItemUUID__' },
             { eventTime: '2019-01-05 12:00:02', type: 'CASE_TRANSFER_REASON', userName: 'User A', body: { caseNote: 'A test transfer reason case note', userUUID: 1, teamUUID: 1, stage: 1 }, timelineItemUUID: '__timelineItemUUID__' },
+            { eventTime: '2019-01-05 12:00:05', type: 'ENQUIRY_REASON_EUNATIONAL_OTHERDETAILS', userName: 'User A', body: { caseNote: 'A test case note', userUUID: 1, teamUUID: 1, stage: 1 }, timelineItemUUID: '__timelineItemUUID__' },
             { eventTime: '2019-01-01 12:00:00', type: 'TEST_UNKNOWN_TYPE', userName: 'User A', timelineItemUUID: '__timelineItemUUID__' }
         ];
 

--- a/server/lists/adapters/__tests__/case-summary.spec.js
+++ b/server/lists/adapters/__tests__/case-summary.spec.js
@@ -67,7 +67,8 @@ describe('Case Summary Adapter', () => {
             caseDeadline: '2020-01-01',
             additionalFields: [
                 { label: 'Test field', value: 'TEST' },
-                { label: 'Test additional field date', value: '2020-01-01', type: 'date' }
+                { label: 'Test additional field date', value: '2020-01-01', type: 'date' },
+                { label: 'Test additional field checkbox', value: 'this,is,a,test', type: 'checkbox' },
             ],
             primaryTopic: { label: 'Topic A' },
             primaryCorrespondent: {

--- a/server/lists/adapters/case-notes.js
+++ b/server/lists/adapters/case-notes.js
@@ -131,6 +131,10 @@ const typeAdaptors = {
     CASE_TRANSFER_REASON: ({ note }) => ({
         note,
         title: 'Case transfer reason'
+    }),
+    ENQUIRY_REASON_EUNATIONAL_OTHERDETAILS: ({ note }) => ({
+        note,
+        title: 'Compliance measures - Other'
     })
 };
 

--- a/server/lists/adapters/case-summary.js
+++ b/server/lists/adapters/case-summary.js
@@ -3,7 +3,8 @@ const User = require('../../models/user');
 const { formatDate } = require('../../libs/dateHelpers');
 
 const createAdditionalFields = async (additionalFields = [], fetchList) => {
-    var results = additionalFields.map(({ label, value, type, choices }) => type === 'date' ? ({ label, value: formatDate(value), choices }) : ({ label, value, choices }));
+    var results = additionalFields
+        .map(field => formatValueOnType(field));
 
     for (var i = 0; i < results.length; i++) {
         var field = results[i];
@@ -21,6 +22,21 @@ const createAdditionalFields = async (additionalFields = [], fetchList) => {
         }
     }
     return results;
+};
+
+const formatValueOnType = ({ label, value, type, choices }) => {
+    switch (type) {
+        case 'date':
+            return { label, value: formatDate(value), choices };
+        case 'checkbox':
+            return { label, value: formatCheckboxValue(value), choices };
+        default:
+            return { label, value, choices };
+    }
+};
+
+const formatCheckboxValue = (value) => {
+    return value.replace(/,/g, ', ');
 };
 
 const createDeadlines = async (deadlines, fromStaticList) => await Promise.all(Object.entries(deadlines)

--- a/server/lists/adapters/case-summary.js
+++ b/server/lists/adapters/case-summary.js
@@ -3,7 +3,7 @@ const User = require('../../models/user');
 const { formatDate } = require('../../libs/dateHelpers');
 
 const createAdditionalFields = async (additionalFields = [], fetchList) => {
-    var results = additionalFields
+    const results = additionalFields
         .map(field => formatValueOnType(field));
 
     for (var i = 0; i < results.length; i++) {

--- a/server/middleware/__tests__/process.spec.js
+++ b/server/middleware/__tests__/process.spec.js
@@ -613,4 +613,242 @@ describe('Process middleware', () => {
         processMiddleware(req, res, next);
         expect(req.form.data).toEqual({ testField: 'SomeRadioValue' });
     });
+    describe('when show/hide visibility props are passed through', () => {
+        it('should not process fields that are not visible with visibility function', () => {
+            const req = {
+                body: {
+                    'TestField1': 'Test',
+                    'TestField2': 'Blah',
+                },
+                query: {},
+                form: {
+                    schema: {
+                        fields: [
+                            {
+                                component: 'checkbox',
+                                validation: ['required'],
+                                props: {
+                                    name: 'TestField1',
+                                    label: 'Test Field 1',
+                                    choices: [
+                                        { label: 'A', value: 'Test' }
+                                    ]
+                                }
+                            },
+                            {
+                                component: 'text-area',
+                                validation: ['required'],
+                                props: {
+                                    name: 'TestField2',
+                                    label: 'Test Field 2',
+                                    visibilityConditions: [{
+                                        function: 'hasCommaSeparatedValue',
+                                        conditionPropertyName: 'TestField1',
+                                        conditionPropertyValue: 'Other'
+                                    }]
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+            const res = {};
+            processMiddleware(req, res, next);
+            expect(req.form.data).toEqual({ TestField1: 'Test' });
+        });
+        it('should process fields that are visible with visibility function', () => {
+            const req = {
+                body: {
+                    'TestField1': 'Test,Other',
+                    'TestField2': 'Blah',
+                },
+                query: {},
+                form: {
+                    schema: {
+                        fields: [
+                            {
+                                component: 'checkbox',
+                                validation: ['required'],
+                                props: {
+                                    name: 'TestField1',
+                                    label: 'Test Field 1',
+                                    choices: [
+                                        { label: 'A', value: 'Test' }
+                                    ]
+                                }
+                            },
+                            {
+                                component: 'text-area',
+                                validation: ['required'],
+                                props: {
+                                    name: 'TestField2',
+                                    label: 'Test Field 2',
+                                    visibilityConditions: [{
+                                        function: 'hasCommaSeparatedValue',
+                                        conditionPropertyName: 'TestField1',
+                                        conditionPropertyValue: 'Other'
+                                    }]
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+            const res = {};
+            processMiddleware(req, res, next);
+            expect(req.form.data).toEqual({ TestField1: 'Test,Other', TestField2: 'Blah' });
+        });
+        it('should process fields that are visible with visibility property condition', () => {
+            const req = {
+                body: {
+                    'TestField1': 'Other',
+                    'TestField2': 'Blah',
+                },
+                query: {},
+                form: {
+                    schema: {
+                        fields: [
+                            {
+                                component: 'text-area',
+                                validation: ['required'],
+                                props: {
+                                    name: 'TestField1',
+                                    label: 'Test Field 1'
+                                }
+                            },
+                            {
+                                component: 'text-area',
+                                validation: ['required'],
+                                props: {
+                                    name: 'TestField2',
+                                    label: 'Test Field 2',
+                                    visibilityConditions: [{
+                                        conditionPropertyName: 'TestField1',
+                                        conditionPropertyValue: 'Other'
+                                    }]
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+            const res = {};
+            processMiddleware(req, res, next);
+            expect(req.form.data).toEqual({ TestField1: 'Other', TestField2: 'Blah' });
+        });
+        it('should not process fields that are not visible with visibility property condition', () => {
+            const req = {
+                body: {
+                    'TestField1': 'OtherTEST',
+                    'TestField2': 'Blah',
+                },
+                query: {},
+                form: {
+                    schema: {
+                        fields: [
+                            {
+                                component: 'text-area',
+                                validation: ['required'],
+                                props: {
+                                    name: 'TestField1',
+                                    label: 'Test Field 1'
+                                }
+                            },
+                            {
+                                component: 'text-area',
+                                validation: ['required'],
+                                props: {
+                                    name: 'TestField2',
+                                    label: 'Test Field 2',
+                                    visibilityConditions: [{
+                                        conditionPropertyName: 'TestField1',
+                                        conditionPropertyValue: 'Other'
+                                    }]
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+            const res = {};
+            processMiddleware(req, res, next);
+            expect(req.form.data).toEqual({ TestField1: 'OtherTEST' });
+        });
+        it('should not process fields that are not visible with hide property condition', () => {
+            const req = {
+                body: {
+                    'TestField1': 'Other',
+                    'TestField2': 'Blah',
+                },
+                query: {},
+                form: {
+                    schema: {
+                        fields: [
+                            {
+                                component: 'text-area',
+                                validation: ['required'],
+                                props: {
+                                    name: 'TestField1',
+                                    label: 'Test Field 1'
+                                }
+                            },
+                            {
+                                component: 'text-area',
+                                validation: ['required'],
+                                props: {
+                                    name: 'TestField2',
+                                    label: 'Test Field 2',
+                                    hideConditions: [{
+                                        conditionPropertyName: 'TestField1',
+                                        conditionPropertyValue: 'Other'
+                                    }]
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+            const res = {};
+            processMiddleware(req, res, next);
+            expect(req.form.data).toEqual({ TestField1: 'Other' });
+        });
+        it('should not process fields that are visible with hide property condition', () => {
+            const req = {
+                body: {
+                    'TestField1': 'Other',
+                    'TestField2': 'Blah',
+                },
+                query: {},
+                form: {
+                    schema: {
+                        fields: [
+                            {
+                                component: 'text-area',
+                                validation: ['required'],
+                                props: {
+                                    name: 'TestField1',
+                                    label: 'Test Field 1'
+                                }
+                            },
+                            {
+                                component: 'text-area',
+                                validation: ['required'],
+                                props: {
+                                    name: 'TestField2',
+                                    label: 'Test Field 2',
+                                    hideConditions: [{
+                                        conditionPropertyName: 'TestField1',
+                                        conditionPropertyValue: 'OtherTest'
+                                    }]
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+            const res = {};
+            processMiddleware(req, res, next);
+            expect(req.form.data).toEqual({ TestField1: 'Other', TestField2: 'Blah' });
+        });
+    });
 });

--- a/server/middleware/__tests__/validation.spec.js
+++ b/server/middleware/__tests__/validation.spec.js
@@ -599,6 +599,123 @@ describe('Validation middleware', () => {
         expect(next.mock.calls[0][0]).not.toBeInstanceOf(Error);
         expect(next.mock.calls[0][0]).not.toBeInstanceOf(ValidationError);
     });
+    it('should validate when visibilityConditions function has been specified', () => {
+        const req = {
+            form: {
+                data: {
+                    TestCheckbox: 'Test,Other'
+                },
+                schema: {
+                    title: 'Some title',
+                    defaultActionLabel: 'Continue',
+                    fields: [
+                        {
+                            validation: ['required'],
+                            props: {
+                                visibilityConditions: [
+                                    {
+                                        function: 'hasCommaSeparatedValue',
+                                        conditionPropertyName: 'TestCheckbox',
+                                        conditionPropertyValue: 'Other'
+                                    },
+                                ],
+                                name: 'OtherFieldText',
+                                label: 'Value',
+                                sections: {},
+                                items: {},
+                            },
+                            validationSuppressor: {}
+                        },
+                    ]
+                }
+            },
+        };
+
+        validationMiddleware(req, res, next);
+
+        expect(req.form).toBeDefined();
+        expect(next).toHaveBeenCalled();
+        expect(next.mock.calls[0][0]).toBeInstanceOf(ValidationError);
+        expect(next.mock.calls[0][0].fields).toEqual({ OtherFieldText: 'Value is required' });
+    });
+    it('should not validate when visibilityConditions function has been specified but not satisfied', () => {
+        const req = {
+            form: {
+                data: {
+                    TestCheckbox: 'Test,Anything'
+                },
+                schema: {
+                    title: 'Some title',
+                    defaultActionLabel: 'Continue',
+                    fields: [
+                        {
+                            validation: ['required'],
+                            props: {
+                                visibilityConditions: [
+                                    {
+                                        function: 'hasCommaSeparatedValue',
+                                        conditionPropertyName: 'TestCheckbox',
+                                        conditionPropertyValue: 'Other'
+                                    },
+                                ],
+                                name: 'OtherFieldText',
+                                label: 'Value',
+                                sections: {},
+                                items: {},
+                            },
+                            validationSuppressor: {}
+                        },
+                    ]
+                }
+            },
+        };
+
+        validationMiddleware(req, res, next);
+
+        expect(req.form).toBeDefined();
+        expect(next).toHaveBeenCalled();
+        expect(next.mock.calls[0][0]).not.toBeInstanceOf(Error);
+        expect(next.mock.calls[0][0]).not.toBeInstanceOf(ValidationError);
+    });
+    it('should not validate when visibilityConditions function has been specified does not exist', () => {
+        const req = {
+            form: {
+                data: {
+                    TestCheckbox: 'Test,Other'
+                },
+                schema: {
+                    title: 'Some title',
+                    defaultActionLabel: 'Continue',
+                    fields: [
+                        {
+                            validation: ['required'],
+                            props: {
+                                visibilityConditions: [
+                                    {
+                                        function: 'testFunctionNotExist',
+                                        conditionPropertyName: 'TestCheckbox',
+                                        conditionPropertyValue: 'Other'
+                                    },
+                                ],
+                                name: 'OtherFieldText',
+                                label: 'Value',
+                                sections: {},
+                                items: {},
+                            },
+                            validationSuppressor: {}
+                        },
+                    ]
+                }
+            },
+        };
+
+        validationMiddleware(req, res, next);
+
+        expect(req.form).toBeDefined();
+        expect(next).toHaveBeenCalled();
+        expect(next.mock.calls[0][0]).not.toBeInstanceOf(Error);
+        expect(next.mock.calls[0][0]).not.toBeInstanceOf(ValidationError);
+    });
     it('should validate if radio button has conditionalContent', () => {
         const req = {
             form: {

--- a/server/middleware/process.js
+++ b/server/middleware/process.js
@@ -1,4 +1,6 @@
 const { FormSubmissionError } = require('../models/error');
+const showConditionFunctions = require('../../src/shared/helpers/show-condition-functions');
+const hideConditionFunctions = require('../../src/shared/helpers/hide-condition-functions');
 
 const customAdapters = {
     'radio': (reducer, field, data) => {
@@ -80,11 +82,50 @@ function processMiddleware(req, res, next) {
         const { schema } = req.form;
         req.form.data = schema.fields
             .filter(field => field.type !== 'display')
+            .filter(field => isFieldVisible(field.props, data))
             .reduce(createReducer(data, req), {});
     } catch (error) {
         return next(new FormSubmissionError('Unable to process form data'));
     }
     next();
+}
+
+function isFieldVisible({ visibilityConditions, hideConditions }, data) {
+    let isVisible = true;
+
+    // show component based on visibilityConditions
+    if (visibilityConditions) {
+        isVisible = false;
+
+        for (const condition of visibilityConditions) {
+            if (condition.function && Object.prototype.hasOwnProperty.call(showConditionFunctions, condition.function)) {
+                if (condition.conditionPropertyName && condition.conditionPropertyValue) {
+                    isVisible = showConditionFunctions[condition.function](data, condition.conditionPropertyName, condition.conditionPropertyValue);
+                } else {
+                    isVisible = hideConditionFunctions[condition.function](data);
+                }
+            } else if (data[condition.conditionPropertyName] && data[condition.conditionPropertyName] === condition.conditionPropertyValue) {
+                isVisible = true;
+            }
+        }
+    }
+
+    // hide component based on hideConditions
+    if (hideConditions) {
+        for (const condition of hideConditions) {
+            if (condition.function && Object.prototype.hasOwnProperty.call(hideConditions, condition.function)) {
+                if (condition.conditionPropertyName && condition.conditionPropertyValue) {
+                    isVisible = hideConditionFunctions[condition.function](data, condition.conditionPropertyName, condition.conditionPropertyValue);
+                } else {
+                    isVisible = hideConditionFunctions[condition.function](data);
+                }
+            } else if (data[condition.conditionPropertyName] && data[condition.conditionPropertyName] === condition.conditionPropertyValue) {
+                isVisible = false;
+            }
+        }
+    }
+
+    return isVisible;
 }
 
 /**

--- a/server/middleware/process.js
+++ b/server/middleware/process.js
@@ -9,7 +9,7 @@ const customAdapters = {
 
         if (Object.prototype.hasOwnProperty.call(data, name)) {
             reducer[name] = data[name];
-            if(conditionalRadioButtonTextFieldId in data) {
+            if (conditionalRadioButtonTextFieldId in data) {
                 reducer[conditionalRadioButtonTextFieldId] = data[conditionalRadioButtonTextFieldId];
             }
         }
@@ -68,7 +68,7 @@ function defaultAdapter(reducer, field, data) {
 const createReducer = (data, req) => (reducer, field) => {
     const component = field.component;
 
-    if(Object.prototype.hasOwnProperty.call(customAdapters, component)) {
+    if (Object.prototype.hasOwnProperty.call(customAdapters, component)) {
         customAdapters[component].call(this, reducer, field, data, req);
     } else {
         defaultAdapter(reducer, field, data);
@@ -79,7 +79,9 @@ const createReducer = (data, req) => (reducer, field) => {
 function processMiddleware(req, res, next) {
     try {
         const data = req.body;
+
         const { schema } = req.form;
+
         req.form.data = schema.fields
             .filter(field => field.type !== 'display')
             .filter(field => isFieldVisible(field.props, data))

--- a/server/middleware/validation.js
+++ b/server/middleware/validation.js
@@ -1,6 +1,7 @@
 const { FormSubmissionError, ValidationError } = require('../models/error');
 const { DOCUMENT_WHITELIST, DOCUMENT_BULK_LIMIT, VALID_DAYS_RANGE } = require('../config').forContext('server');
 const { MIN_ALLOWABLE_YEAR, MAX_ALLOWABLE_YEAR } = require('../libs/dateHelpers');
+const showConditionFunctions = require('../../src/shared/helpers/show-condition-functions');
 
 const validationErrors = {
     required: label => `${label} is required`,
@@ -292,8 +293,13 @@ function validationMiddleware(req, res, next) {
         let isVisible = true;
         if (visibilityConditions) {
             isVisible = false;
+
             for (let condition of visibilityConditions) {
-                if (data[condition.conditionPropertyName] && data[condition.conditionPropertyName] === condition.conditionPropertyValue) {
+                if (condition.function && Object.prototype.hasOwnProperty.call(showConditionFunctions, condition.function)) {
+                    if (condition.conditionPropertyName && condition.conditionPropertyValue) {
+                        isVisible = showConditionFunctions[condition.function](data, condition.conditionPropertyName, condition.conditionPropertyValue);
+                    }
+                } else if (data[condition.conditionPropertyName] && data[condition.conditionPropertyName] === condition.conditionPropertyValue) {
                     isVisible = true;
                 }
             }

--- a/src/shared/common/components/case-notes.jsx
+++ b/src/shared/common/components/case-notes.jsx
@@ -44,7 +44,7 @@ const TimelineItem = (refreshNotes) => ({ type, body, title, timelineItemUUID })
     const isCaseNote = [
         'MANUAL', 'CLOSE_CASE_TELEPHONE', 'CONVERTED_CASE_TO_MINISTERIAL', 'CONVERTED_CASE_TO_OFFICIAL', 'ALLOCATE',
         'CHANGE', 'CLOSE', 'REJECT', 'PHONECALL', 'REQUEST_CONTRIBUTION', 'SEND_TO_WORKFLOW_MANAGER', 'FOLLOW_UP',
-        'FOLLOW_UP_NOT_COMPLETED', 'WITHDRAW', 'CASE_TRANSFER_REASON'
+        'FOLLOW_UP_NOT_COMPLETED', 'WITHDRAW', 'CASE_TRANSFER_REASON', 'ENQUIRY_REASON_EUNATIONAL_OTHERDETAILS'
     ].includes(type);
     return (
         body && <li key={timelineItemUUID} className={classnames({ 'case-note': isCaseNote })}>

--- a/src/shared/helpers/__tests__/show-condition-functions.spec.js
+++ b/src/shared/helpers/__tests__/show-condition-functions.spec.js
@@ -1,0 +1,49 @@
+import showConditionFunctions from '../show-condition-functions';
+
+describe('ShowConditionFunctions', () => {
+    describe('hasCommaSeparatedValue', () => {
+        const mockData = [
+            {},
+            {
+                TestField: ''
+            },
+            {
+                TestField: ['Test1', 'Test2']
+            },
+            {
+                TestField: 'Test1'
+            },
+            {
+                TestField: 'Test1,Test2'
+            }
+        ];
+
+        it('returns false if the data does not exist', () => {
+            expect(showConditionFunctions.hasCommaSeparatedValue(mockData[0], 'TestField', 'TestValue')).toBe(false);
+        });
+        it('returns false if the data does not contain the requested value', () => {
+            expect(showConditionFunctions.hasCommaSeparatedValue(mockData[1], 'TestField', 'TestValue')).toBe(false);
+        });
+        it('returns false if the data array does not contain the requested value', () => {
+            expect(showConditionFunctions.hasCommaSeparatedValue(mockData[2], 'TestField', 'Test3')).toBe(false);
+        });
+        it('returns true if the data array does contain the requested value', () => {
+            expect(showConditionFunctions.hasCommaSeparatedValue(mockData[2], 'TestField', 'Test1')).toBe(true);
+        });
+        it('returns false if the data value does not match the requested value', () => {
+            expect(showConditionFunctions.hasCommaSeparatedValue(mockData[3], 'TestField', 'Test2')).toBe(false);
+        });
+        it('returns false if the data value does not match exactly the requested value', () => {
+            expect(showConditionFunctions.hasCommaSeparatedValue(mockData[3], 'TestField', 'Test2111')).toBe(false);
+        });
+        it('returns true if the data value does match the requested value', () => {
+            expect(showConditionFunctions.hasCommaSeparatedValue(mockData[3], 'TestField', 'Test1')).toBe(true);
+        });
+        it('returns false if the data comma-separated value does not match exactly the requested value', () => {
+            expect(showConditionFunctions.hasCommaSeparatedValue(mockData[4], 'TestField', 'Test')).toBe(false);
+        });
+        it('returns true if the data comma-separated value does match the requested value', () => {
+            expect(showConditionFunctions.hasCommaSeparatedValue(mockData[4], 'TestField', 'Test1')).toBe(true);
+        });
+    });
+});

--- a/src/shared/helpers/hide-condition-functions.js
+++ b/src/shared/helpers/hide-condition-functions.js
@@ -1,22 +1,22 @@
-const hideConditionFunctions = {
-    hasNoContributionsOrFulfilled: function (data) {
-        if (!data.CaseContributions) {
-            return true;
-        }
-
-        try {
-            const contributions = JSON.parse(data.CaseContributions);
-
-            if (!Array.isArray(contributions)) {
-                return true;
-            }
-
-            return contributions.filter(contribution => !contribution.data.contributionStatus).length === 0;
-        } catch (_) {
-            // If the CaseContributions is not a valid JSON we return true
-            return true;
-        }
+function hasNoContributionsOrFulfilled(data) {
+    if (!data.CaseContributions) {
+        return true;
     }
-};
 
-export default hideConditionFunctions;
+    try {
+        const contributions = JSON.parse(data.CaseContributions);
+
+        if (!Array.isArray(contributions)) {
+            return true;
+        }
+
+        return contributions.filter(contribution => !contribution.data.contributionStatus).length === 0;
+    } catch (_) {
+        // If the CaseContributions is not a valid JSON we return true
+        return true;
+    }
+}
+
+module.exports = {
+    hasNoContributionsOrFulfilled
+};

--- a/src/shared/helpers/show-condition-functions.js
+++ b/src/shared/helpers/show-condition-functions.js
@@ -1,0 +1,17 @@
+function hasCommaSeparatedValue(data, propertyName, propertyValue) {
+    if (!data || !data[propertyName]) {
+        return false;
+    }
+
+    const dataPropertyValue = data[propertyName];
+
+    if (Array.isArray(dataPropertyValue)) {
+        return dataPropertyValue.includes(propertyValue);
+    }
+
+    return dataPropertyValue.split(',').includes(propertyValue);
+}
+
+module.exports = {
+    hasCommaSeparatedValue
+};


### PR DESCRIPTION
To support the addition of a new Enquiry Reason the following changes have been applied:
- Case note titles have been added for case notes of type:  `ENQUIRY_REASON_EUNATIONAL_OTHERDETAILS`

Additional quality of life improvements have been made whilst working on this:
- Checkbox components that have multiple values now have a space after the comma to improve readability. This has involved a new reducer-esque functionality that can be easily expanded for other component types.
- Forms that have hidden fields (based on visibilityConditions and hideConditions) no longer have there value sent to be added to a cases case data.
- Visibility conditions now support functional checks that are specified in the `show-condition-functions.js` file.
- `show-condition-functions` and `hide-condition-functions` now use pre-ES6 exporting for code reuse within the node server and the frontend.