### PR TITLE
HOCS-3645: add correspondent type display name

### DIFF
--- a/src/shared/common/components/__tests__/people.spec.jsx
+++ b/src/shared/common/components/__tests__/people.spec.jsx
@@ -59,6 +59,46 @@ const correspondents = [
         'reference': 'a reference',
         'externalKey': null,
         'isPrimary': false
+    },
+    {
+        'uuid': 'UUID_4',
+        'created': '2020-05-28T11:28:36.342184',
+        'type': 'APPLICANT',
+        'typeDisplayName': 'Applicant Test Case',
+        'caseUUID': 'CASE_UUID_4',
+        'fullname': 'my name',
+        'address': {
+            'postcode': 'ZR1 3PL',
+            'address1': 'some house',
+            'address2': 'some street',
+            'address3': 'some_city',
+            'country': 'United Kingdom'
+        },
+        'telephone': '01987876882342',
+        'email': 'test@test.com',
+        'reference': 'a reference',
+        'externalKey': null,
+        'isPrimary': false
+    },
+    {
+        'uuid': 'UUID_5',
+        'created': '2020-05-28T11:28:36.342184',
+        'type': 'APPLICANT',
+        'typeDisplayName': 'Applicant Test Case',
+        'caseUUID': 'CASE_UUID_5',
+        'fullname': 'my name',
+        'address': {
+            'postcode': 'ZR1 3PL',
+            'address1': 'some house',
+            'address2': 'some street',
+            'address3': 'some_city',
+            'country': 'United Kingdom'
+        },
+        'telephone': '01987876882342',
+        'email': 'test@test.com',
+        'reference': 'a reference',
+        'externalKey': null,
+        'isPrimary': true
     }
 ];
 
@@ -73,12 +113,12 @@ const page = {
 
 describe('The people component', () => {
 
-    it('should render successfully with 3 correspondent\'s', () => {
-        const outer = shallow(<WrappedPeople />);
+    it('should render successfully with 5 correspondent\'s', () => {
+        const outer = shallow(<WrappedPeople/>);
         const People = outer.props().children;
         const wrapper = mount(
             <MemoryRouter>
-                <People dispatch={jest.fn(() => Promise.resolve())} correspondents={correspondents} page={page} />
+                <People dispatch={jest.fn(() => Promise.resolve())} correspondents={correspondents} page={page}/>
             </MemoryRouter>
         );
         expect(wrapper).toBeDefined();

--- a/src/shared/common/components/people.jsx
+++ b/src/shared/common/components/people.jsx
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import axios from 'axios';
 import { ApplicationConsumer } from '../../contexts/application.jsx';
-import { clearApiStatus, unsetCorrespondents, updateApiStatus } from '../../contexts/actions/index';
+import { clearApiStatus, unsetCorrespondents, updateApiStatus } from '../../contexts/actions/index.jsx';
 import status from '../../helpers/api-status.js';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';

--- a/src/shared/common/components/people.jsx
+++ b/src/shared/common/components/people.jsx
@@ -1,11 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import axios from 'axios';
 import { ApplicationConsumer } from '../../contexts/application.jsx';
-import {
-    updateApiStatus,
-    unsetCorrespondents,
-    clearApiStatus
-} from '../../contexts/actions/index.jsx';
+import { clearApiStatus, unsetCorrespondents, updateApiStatus } from '../../contexts/actions/index';
 import status from '../../helpers/api-status.js';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
@@ -52,7 +48,7 @@ class People extends Component {
         return (
             <Fragment key={person.uuid}>
                 <h2 className='govuk-heading-m'>
-                    {this.toTitleCase(person.type) + (person.isPrimary ? ' (primary)' : '')}
+                    {this.getTitle(person)}
                 </h2>
                 <table className='govuk-table margin-left--small'>
                     <tbody className='govuk-table__body'>
@@ -105,21 +101,29 @@ class People extends Component {
         const { page } = this.props;
         return (
             <Fragment>
-                <Link className='govuk-body govuk-link' to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/people/manage`} >Manage People</Link>
-                {correspondents &&  correspondents[0] !== null &&
+                <Link className='govuk-body govuk-link'
+                    to={`/case/${page.params.caseId}/stage/${page.params.stageId}/entity/people/manage`}>Manage
+                    People</Link>
+                {correspondents && correspondents[0] !== null &&
                 correspondents.map(person => this.renderPerson(person))
                 }
             </Fragment>
         );
     }
 
-    toTitleCase(str) {
-        return str.replace(
-            /\w\S*/g,
-            function (txt) {
-                return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-            }
-        );
+    getTitle({ type, typeDisplayName, isPrimary }) {
+        let title;
+
+        if (typeDisplayName) {
+            title = typeDisplayName;
+        } else {
+            title = type.replace(/\w\S*/g,
+                (txt) => {
+                    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+                });
+        }
+
+        return title + (isPrimary ? ' (primary)' : '');
     }
 }
 


### PR DESCRIPTION
As a result of now returning the correspondent display name as part of
the request. If it is present we should use it, otherwise just the type
should be shown. This change also moves the whole title 'generator' to
within a function.