### PR TITLE
HOCS-3670: user workstack simplification

### DIFF
--- a/server/lists/adapters/__tests__/__snapshots__/workstacks.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/workstacks.spec.js.snap
@@ -658,15 +658,6 @@ Object {
 }
 `;
 
-exports[`User Workstack Adapter should hide unworkable 1`] = `
-Object {
-  "allocateToWorkstackEndpoint": "/unallocate/",
-  "columns": Array [],
-  "items": Array [],
-  "label": "My Cases",
-}
-`;
-
 exports[`User Workstack Adapter should transform a stage array to a user workstack schema 1`] = `
 Object {
   "allocateToWorkstackEndpoint": "/unallocate/",
@@ -680,6 +671,7 @@ Object {
       "assignedUserDisplay": "MOCK_USER",
       "caseType": "DEFAULT",
       "caseTypeDisplayFull": "MOCK_CASETYPE",
+      "data": Object {},
       "deadline": "2200-01-01",
       "deadlineDisplay": "01/01/2200",
       "mpWithOwnerDisplay": Object {
@@ -694,6 +686,49 @@ Object {
       "stageTypeWithDueDateDisplay": "MOCK_STAGETYPE",
       "teamUUID": 1,
       "userUUID": 1,
+    },
+    Object {
+      "active": true,
+      "assignedTeamDisplay": "MOCK_TEAM",
+      "assignedUserDisplay": "MOCK_USER",
+      "caseType": "WCS",
+      "caseTypeDisplayFull": "MOCK_CASETYPE",
+      "data": Object {},
+      "deadline": "2200-01-02",
+      "deadlineDisplay": "02/01/2200",
+      "mpWithOwnerDisplay": Object {
+        "mp": "",
+        "owner": "MOCK_USER",
+      },
+      "primaryCorrespondentAndRefDisplay": Object {
+        "caseReference": undefined,
+      },
+      "stageType": "A",
+      "stageTypeDisplay": "MOCK_STAGETYPE",
+      "stageTypeWithDueDateDisplay": "MOCK_STAGETYPE",
+      "teamUUID": 2,
+      "userUUID": 2,
+    },
+    Object {
+      "active": false,
+      "assignedTeamDisplay": "MOCK_TEAM",
+      "caseType": "WCS",
+      "caseTypeDisplayFull": "MOCK_CASETYPE",
+      "data": Object {},
+      "deadline": "2200-01-03",
+      "deadlineDisplay": "03/01/2200",
+      "mpWithOwnerDisplay": Object {
+        "mp": "",
+        "owner": undefined,
+      },
+      "primaryCorrespondentAndRefDisplay": Object {
+        "caseReference": undefined,
+      },
+      "stageType": "A",
+      "stageTypeDisplay": "Closed",
+      "stageTypeWithDueDateDisplay": "Closed",
+      "teamUUID": 2,
+      "userUUID": null,
     },
   ],
   "label": "My Cases",

--- a/server/lists/adapters/__tests__/workstacks.spec.js
+++ b/server/lists/adapters/__tests__/workstacks.spec.js
@@ -159,54 +159,8 @@ describe('User Workstack Adapter', () => {
                     userUUID: 1,
                     deadline: '2200-01-01',
                     active: true,
-                    assignedTopic: mockTopic
-                },
-                {
-                    teamUUID: 2,
-                    caseType: 'WCS',
-                    stageType: 'A',
-                    userUUID: 2,
-                    deadline: '2200-01-02',
-                    active: true
-                },
-                {
-                    teamUUID: 2,
-                    caseType: 'WCS',
-                    stageType: 'A',
-                    userUUID: null,
-                    deadline: '2200-01-03',
-                    active: false
-                }
-            ]
-        };
-
-        const result = await userAdapter(mockData, {
-            user: mockUser,
-            fromStaticList: mockFromStaticList,
-            logger: mockLogger,
-            configuration: {
-                workstackTypeColumns: [
-                    { workstackType: 'DEFAULT', workstackColumns: [] },
-                    { workstackType: 'WCS', workstackColumns: [] }
-                ],
-            }
-        });
-        expect(result).toMatchSnapshot();
-    });
-    it('should hide unworkable', async () => {
-        const mockData = {
-            stages: [
-                {
-                    teamUUID: 1,
-                    caseType: 'DEFAULT',
-                    stageType: 'A',
-                    userUUID: 1,
-                    deadline: '2200-01-01',
-                    active: true,
                     assignedTopic: mockTopic,
-                    data: {
-                        Unworkable: 'True'
-                    }
+                    data: {}
                 },
                 {
                     teamUUID: 2,
@@ -214,7 +168,8 @@ describe('User Workstack Adapter', () => {
                     stageType: 'A',
                     userUUID: 2,
                     deadline: '2200-01-02',
-                    active: true
+                    active: true,
+                    data: {}
                 },
                 {
                     teamUUID: 2,
@@ -222,13 +177,13 @@ describe('User Workstack Adapter', () => {
                     stageType: 'A',
                     userUUID: null,
                     deadline: '2200-01-03',
-                    active: false
+                    active: false,
+                    data: {}
                 }
             ]
         };
 
         const result = await userAdapter(mockData, {
-            user: mockUser,
             fromStaticList: mockFromStaticList,
             logger: mockLogger,
             configuration: {

--- a/server/lists/adapters/workstacks.js
+++ b/server/lists/adapters/workstacks.js
@@ -30,20 +30,15 @@ const byWorkable = (stage) => {
         if (stage.data.Unworkable) {
             if (stage.data.Unworkable === 'True') {
                 return 0;
-            } else {
-                return 1;
             }
-        } else {
-            return 1;
         }
-    } else {
-        return 1;
     }
+    return 1;
 };
 
 const defaultCaseSort = (a, b) => {
-    var sortResult = byPriority(a, b);
-    if (sortResult == 0) {
+    let sortResult = byPriority(a, b);
+    if (sortResult === 0) {
         sortResult = byCaseReference(a, b);
     }
     return sortResult;

--- a/server/lists/adapters/workstacks.js
+++ b/server/lists/adapters/workstacks.js
@@ -1,6 +1,12 @@
 const { addDays, formatDate } = require('../../libs/dateHelpers');
 
-const byCaseReference = (a, b) => a.caseReference.localeCompare(b.caseReference);
+const byCaseReference = (a, b) => {
+    if (a.caseReference == null || b.caseReference == null) {
+        return 0;
+    }
+
+    return a.caseReference.localeCompare(b.caseReference);
+};
 
 const byPriority = (a, b) => {
     if (a.data.systemCalculatedPriority == undefined || b.data.systemCalculatedPriority == undefined) {
@@ -278,14 +284,14 @@ const bindDashboardElements = fromStaticList => async (stage) => {
     return stage;
 };
 
-const userAdapter = async (data, { fromStaticList, logger, user, configuration }) => {
+const userAdapter = async (data, { fromStaticList, logger, configuration }) => {
     const workstackData = await Promise.all(data.stages
-        .filter(byWorkable)
-        .filter(stage => stage.userUUID === user.uuid)
         .sort(defaultCaseSort)
         .sort(tagSort)
         .map(bindDisplayElements(fromStaticList)));
+
     logger.debug('REQUEST_USER_WORKSTACK', { user_cases: workstackData.length });
+
     return {
         label: 'My Cases',
         items: workstackData,

--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -274,7 +274,7 @@ module.exports = {
         },
         USER_WORKSTACK: {
             client: 'CASEWORK',
-            endpoint: '/stage',
+            endpoint: '/stage/user/${userUuid}',
             adapter: workstack.userAdapter
         },
         TEAM_WORKSTACK: {

--- a/server/middleware/__tests__/workstack.spec.js
+++ b/server/middleware/__tests__/workstack.spec.js
@@ -39,7 +39,8 @@ describe('Workstack middleware', () => {
                         }
                         return Promise.reject();
                     })
-                }
+                },
+                user: { uuid: 'TEST' }
             };
             res = {
                 locals: {}
@@ -51,6 +52,16 @@ describe('Workstack middleware', () => {
             expect(res.locals.workstack).toBeDefined();
             expect(res.locals.workstack).toEqual('MOCK_WORKSTACK');
             expect(next).toHaveBeenCalled();
+        });
+
+        it('should call next with an error if user not present', async () => {
+            const reqWithoutUser = req;
+            delete reqWithoutUser.user;
+
+            await userWorkstackMiddleware(reqWithoutUser, res, next);
+            expect(res.locals.workstack).not.toBeDefined();
+            expect(next).toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith(TypeError('Cannot read property \'uuid\' of undefined'));
         });
 
         it('should call next with an error if unable to retrieve workstack data', async () => {

--- a/server/middleware/workstack.js
+++ b/server/middleware/workstack.js
@@ -4,7 +4,7 @@ const { caseworkService, workflowService } = require('../clients');
 
 async function userWorkstackMiddleware(req, res, next) {
     try {
-        const response = await req.listService.fetch('USER_WORKSTACK', req.params);
+        const response = await req.listService.fetch('USER_WORKSTACK', { userUuid: req.user.uuid });
         res.locals.workstack = response;
         next();
     } catch (error) {


### PR DESCRIPTION
Modify the USER_WORKSTACK list to point to the new endpoint in casework.
This endpoint passes through the user uuid.

To utilise the new endpoint result from casework, this change adapts the
 `userAdapter` to remove the unecessary filters. Alongside this an
 improvement to the byCaseReference comparator to check if the value is
 present.