### PR TITLE
HOCS-3412: sanitise date year part

### DIFF
--- a/server/middleware/__tests__/process.spec.js
+++ b/server/middleware/__tests__/process.spec.js
@@ -264,6 +264,60 @@ describe('Process middleware', () => {
         expect(next).toHaveBeenCalledTimes(1);
     });
 
+    it('should return sanitised year on change', () => {
+        const req = {
+            body: {
+                ['test-field-1']: '0000-01-01',
+                ['test-field-2']: '00002021-01-01',
+                ['test-field-3']: '002000-01-01',
+            },
+            query: {},
+            form: {
+                schema: {
+                    fields: [
+                        {
+                            component: 'date',
+                            validation: [
+                                'required'
+                            ],
+                            props: {
+                                name: 'test-field-1',
+                            }
+                        },
+                        {
+                            component: 'date',
+                            validation: [
+                                'required'
+                            ],
+                            props: {
+                                name: 'test-field-2',
+                            }
+                        },
+                        {
+                            component: 'date',
+                            validation: [
+                                'required'
+                            ],
+                            props: {
+                                name: 'test-field-3',
+                            }
+                        }
+                    ]
+                }
+            }
+        };
+        const res = {};
+
+        processMiddleware(req, res, next);
+        expect(req.form).toBeDefined();
+        expect(req.form.data).toBeDefined();
+        expect(req.form.data['test-field-1']).toEqual('-01-01');
+        expect(req.form.data['test-field-2']).toEqual('2021-01-01');
+        expect(req.form.data['test-field-3']).toEqual('2000-01-01');
+        expect(next).toHaveBeenCalled();
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
     it('should process checkbox data passed as an array', () => {
         const req = {
             body: {

--- a/server/middleware/process.js
+++ b/server/middleware/process.js
@@ -20,7 +20,7 @@ const customAdapters = {
         const [year = '', month = '', day = ''] = (value || '').split('-');
 
         if (year && month && day) {
-            reducer[name] = `${year}-${sanitiseDayMonthPart(month)}-${sanitiseDayMonthPart(day)}`;
+            reducer[name] = `${sanitiseYearPart(year)}-${sanitiseDayMonthPart(month)}-${sanitiseDayMonthPart(day)}`;
         }
         else if (year + month + day === '') {
             reducer[name] = '';
@@ -29,8 +29,7 @@ const customAdapters = {
     'checkbox': (reducer, field, data) => {
         const { name } = field.props;
         if (Object.prototype.hasOwnProperty.call(data, name)) {
-            const value = data[name];
-            reducer[name] = value;
+            reducer[name] = data[name];
         }
     },
     'add-document': (reducer, field, data, req) => {
@@ -159,6 +158,22 @@ function sanitiseDayMonthPart(value, paddingZeros = 2) {
         return value.substring(value.length - 2);
     }
     return value.padStart(paddingZeros, '0');
+}
+
+/**
+ * Dates that have a year part that contains leading zeroes are currentyly saved to the system
+ * with these leading zeroes. These zeroes add nothing to a year and can be safely stripped
+ * without the year losing it's meaning.
+ *
+ * @param {String} value the date year to sanitise
+ * @returns the sanitised date year part.
+ */
+function sanitiseYearPart(value) {
+    if (value === '') {
+        return value;
+    }
+
+    return value.replace(/^0+/, '');
 }
 
 module.exports = {


### PR DESCRIPTION
Currently, leading zeroes are accepted on date year parts. These leading
 zeroes don't add anything important to the date so should be stripped.