### PR TITLE
HOCS-3720: Add Complaints Stage 2 to search

### DIFF
--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -262,6 +262,11 @@ module.exports = {
             endpoint: '/caseType?bulkOnly=false',
             adapter: caseTypeCommaSeparatedAdapter
         },
+        CASE_TYPES_FOR_SEARCH: {
+            client: 'INFO',
+            endpoint: '/caseType?bulkOnly=false&addCasesWithPreviousType=true',
+            adapter: caseTypeAdapter
+        },
         COUNTRIES_CURRENT: {
             client: 'INFO',
             endpoint: '/country',

--- a/server/services/forms/schemas/search.js
+++ b/server/services/forms/schemas/search.js
@@ -15,6 +15,7 @@ const search = async (options = {}) => {
 
     let fields = [];
     const systemConfiguration = await listService.fetch('S_SYSTEM_CONFIGURATION');
+    await listService.fetch('CASE_TYPES_FOR_SEARCH');
     systemConfiguration.profiles.map(profile => {
         if (userProfileNames.includes(profile.profileName)) {
             profile.searchFields.map(searchField => {


### PR DESCRIPTION
- Add `CASE_TYPES_FOR_SEARCH' as a separate list for case types to be shown on search page. (Existing case types list is used on the 'Create Case' page which needs to remain as-is).
- Fetches this list as part of loading the search screen.