### PR TITLE
HOCS-3814: add visible prop to radio group

### DIFF
--- a/src/shared/common/forms/__tests__/__snapshots__/radio-group.spec.js.snap
+++ b/src/shared/common/forms/__tests__/__snapshots__/radio-group.spec.js.snap
@@ -1,5 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Form radio group component should not render choices if visible is set to false 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="radio-group"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="radio-group-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <div
+      class="govuk-radios govuk-radios--conditional"
+      data-module="govuk-radios"
+      id="radio-group-radios"
+    >
+      <div
+        class="govuk-radios__item"
+      >
+        <input
+          class="govuk-radios__input"
+          data-aria-controls="conditional-radio-group-0"
+          id="radio-group-0"
+          name="radio-group"
+          type="radio"
+          value="ValueA"
+        />
+        <label
+          class="govuk-label govuk-radios__label"
+          for="radio-group-0"
+        >
+          labelA
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</div>
+`;
+
 exports[`Form radio group component should render disabled when passed 1`] = `
 <div
   class="govuk-form-group"
@@ -151,6 +195,86 @@ exports[`Form radio group component should render error message for textarea if 
             rows="4"
           />
         </div>
+      </div>
+      <div
+        class="govuk-radios__item"
+      >
+        <input
+          class="govuk-radios__input"
+          data-aria-controls="conditional-radio-group-1"
+          id="radio-group-1"
+          name="radio-group"
+          type="radio"
+          value="ValueB"
+        />
+        <label
+          class="govuk-label govuk-radios__label"
+          for="radio-group-1"
+        >
+          labelB
+        </label>
+      </div>
+      <div
+        class="govuk-radios__item"
+      >
+        <input
+          class="govuk-radios__input"
+          data-aria-controls="conditional-radio-group-2"
+          id="radio-group-2"
+          name="radio-group"
+          type="radio"
+          value="ValueC"
+        />
+        <label
+          class="govuk-label govuk-radios__label"
+          for="radio-group-2"
+        >
+          labelC
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</div>
+`;
+
+exports[`Form radio group component should render if visible is set to true 1`] = `
+<div
+  class="govuk-form-group"
+>
+  <fieldset
+    class="govuk-fieldset "
+    id="radio-group"
+  >
+    <legend
+      class="govuk-fieldset__legend"
+      id="radio-group-legend"
+    >
+      <span
+        class="govuk-fieldset__heading govuk-label--s"
+      />
+    </legend>
+    <div
+      class="govuk-radios govuk-radios--conditional"
+      data-module="govuk-radios"
+      id="radio-group-radios"
+    >
+      <div
+        class="govuk-radios__item"
+      >
+        <input
+          class="govuk-radios__input"
+          data-aria-controls="conditional-radio-group-0"
+          id="radio-group-0"
+          name="radio-group"
+          type="radio"
+          value="ValueA"
+        />
+        <label
+          class="govuk-label govuk-radios__label"
+          for="radio-group-0"
+        >
+          labelA
+        </label>
       </div>
       <div
         class="govuk-radios__item"

--- a/src/shared/common/forms/__tests__/radio-group.spec.js
+++ b/src/shared/common/forms/__tests__/radio-group.spec.js
@@ -4,7 +4,7 @@ import RadioGroup from '../radio-group.jsx';
 const choices = [
     { label: 'isA', value: 'A' },
     { label: 'isB', value: 'B' },
-    { label: 'isC', value: 'C' }
+    { label: 'isC', value: 'C' },
 ];
 
 describe('Form radio group component', () => {
@@ -82,6 +82,26 @@ describe('Form radio group component', () => {
         ];
         expect(
             render(<RadioGroup name="radio-group" choices={choices} errors={{ ValueAText: 'Some error message' }} updateState={() => null} />)
+        ).toMatchSnapshot();
+    });
+    it('should render if visible is set to true', () => {
+        const choices = [
+            { label: 'labelA', value: 'ValueA' },
+            { label: 'labelB', value: 'ValueB', visible: true },
+            { label: 'labelC', value: 'ValueC', visible: 'true' },
+        ];
+        expect(
+            render(<RadioGroup name="radio-group" choices={choices} updateState={() => null} />)
+        ).toMatchSnapshot();
+    });
+    it('should not render choices if visible is set to false', () => {
+        const choices = [
+            { label: 'labelA', value: 'ValueA' },
+            { label: 'labelB', value: 'ValueB', visible: false },
+            { label: 'labelC', value: 'ValueC', visible: 'false' },
+        ];
+        expect(
+            render(<RadioGroup name="radio-group" choices={choices} updateState={() => null} />)
         ).toMatchSnapshot();
     });
 });

--- a/src/shared/common/forms/radio-group.jsx
+++ b/src/shared/common/forms/radio-group.jsx
@@ -107,6 +107,11 @@ class Radio extends Component {
         return `${nameOfField}-${key}`;
     }
 
+    isChoiceVisible(choice) {
+        return choice.visible === undefined
+            || (Boolean(choice.visible) && choice.visible.toString().toLowerCase() !== 'false');
+    }
+
     render() {
         const {
             className,
@@ -133,53 +138,51 @@ class Radio extends Component {
                     {error && <span id={`${name}-error`} className="govuk-error-message">{error}</span>}
 
                     <div id={`${name}-radios`} className={'govuk-radios govuk-radios--conditional'} data-module="govuk-radios">
-                        {choicesToUse && choicesToUse.map((choice, i) => {
-                            const idName = this.getIdName(name, i);
-
-                            return (
-                                <Fragment key={i}>
-                                    <div className="govuk-radios__item">
-                                        <input id={idName}
-                                            type={type}
-                                            name={name}
-                                            value={choice.value}
-                                            checked={(value === choice.value)}
-                                            onChange={e => this.handleChange(e, choice)}
-                                            data-aria-controls={`conditional-${idName}`}
-                                            className={'govuk-radios__input'}
-                                        />
-                                        <label className="govuk-label govuk-radios__label" htmlFor={`${idName}`}>{choice.label}</label>
-                                    </div>
-
-                                    {choice.conditionalContent &&
-                                        <div className="govuk-radios__conditional govuk-radios__conditional--hidden"
-                                            id={`conditional-${idName}`}>
-                                            <div className={`govuk-form-group ${this.isConditionalContentError(errors, `${choice.value}Text`) ? ' govuk-form-group--error' : ''}`}>
-                                                <label className="govuk-label" htmlFor={`${choice.value}Text`}>
-                                                    {choice.conditionalContent.label}
-                                                </label>
-                                                {this.isConditionalContentError(errors, `${choice.value}Text`) &&
-                                                    <span id={`${choice.value}Text-error`} className="govuk-error-message">
-                                                        <span className="govuk-visually-hidden">Error:</span>{errors[`${choice.value}Text`]}
-                                                    </span>
-                                                }
-                                                <textarea
-                                                    className={`govuk-textarea ${this.isConditionalContentError(errors, `${choice.value}Text`) ? ' govuk-textarea--error' : ''}`}
-                                                    id={`${choice.value}Text`}
-                                                    name={`${choice.value}Text`}
-                                                    disabled={disabled}
-                                                    rows="4"
-                                                    onChange={e => this.handleChangeForTextArea(e)}
-                                                    value={this.returnConditionalContentValue(`${value}Text`)}
-                                                />
-                                            </div>
-
+                        {choicesToUse && choicesToUse
+                            .filter((choice) => this.isChoiceVisible(choice))
+                            .map((choice, i) => {
+                                const idName = this.getIdName(name, i);
+                                return (
+                                    <Fragment key={i}>
+                                        <div className="govuk-radios__item">
+                                            <input id={idName}
+                                                type={type}
+                                                name={name}
+                                                value={choice.value}
+                                                checked={(value === choice.value)}
+                                                onChange={e => this.handleChange(e, choice)}
+                                                data-aria-controls={`conditional-${idName}`}
+                                                className={'govuk-radios__input'}
+                                            />
+                                            <label className="govuk-label govuk-radios__label" htmlFor={`${idName}`}>{choice.label}</label>
                                         </div>
-                                    }
-
-                                </Fragment>
-                            );
-                        })}
+                                        {choice.conditionalContent &&
+                                            <div className="govuk-radios__conditional govuk-radios__conditional--hidden"
+                                                id={`conditional-${idName}`}>
+                                                <div className={`govuk-form-group ${this.isConditionalContentError(errors, `${choice.value}Text`) ? ' govuk-form-group--error' : ''}`}>
+                                                    <label className="govuk-label" htmlFor={`${choice.value}Text`}>
+                                                        {choice.conditionalContent.label}
+                                                    </label>
+                                                    {this.isConditionalContentError(errors, `${choice.value}Text`) &&
+                                                        <span id={`${choice.value}Text-error`} className="govuk-error-message">
+                                                            <span className="govuk-visually-hidden">Error:</span>{errors[`${choice.value}Text`]}
+                                                        </span>
+                                                    }
+                                                    <textarea
+                                                        className={`govuk-textarea ${this.isConditionalContentError(errors, `${choice.value}Text`) ? ' govuk-textarea--error' : ''}`}
+                                                        id={`${choice.value}Text`}
+                                                        name={`${choice.value}Text`}
+                                                        disabled={disabled}
+                                                        rows="4"
+                                                        onChange={e => this.handleChangeForTextArea(e)}
+                                                        value={this.returnConditionalContentValue(`${value}Text`)}
+                                                    />
+                                                </div>
+                                            </div>
+                                        }
+                                    </Fragment>
+                                );
+                            })}
 
                         {choicesToUse.length === 0 && <p className="govuk-body">No options available</p>}
                     </div>


### PR DESCRIPTION
Add the visible property option to the radio group component. This will
assist with feature flagging options without having the whole field
reverted.