### PR TITLE
HOCS-3848: change workflow display logic

### DIFF
--- a/server/lists/adapters/__tests__/__snapshots__/workstacks.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/workstacks.spec.js.snap
@@ -1274,6 +1274,7 @@ Object {
       "caseReference": "A/1234568/19",
       "caseType": "WCS",
       "caseTypeDisplayFull": "MOCK_CASETYPE",
+      "contributions": "Due",
       "deadline": "2200-01-03",
       "deadlineDisplay": "03/01/2200",
       "dueContribution": "2020-12-12",
@@ -1296,7 +1297,7 @@ Object {
 }
 `;
 
-exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_DRAFT_REQUESTED_CONTRIBUTION with contributionStatus 1`] = `
+exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_DRAFT with contributions as Received 1`] = `
 Object {
   "allocateToTeamEndpoint": "/allocate/team",
   "allocateToUserEndpoint": "/allocate/user",
@@ -1310,6 +1311,79 @@ Object {
       "caseReference": "A/1234568/19",
       "caseType": "WCS",
       "caseTypeDisplayFull": "MOCK_CASETYPE",
+      "contributions": "Received",
+      "deadline": "2200-01-03",
+      "deadlineDisplay": "03/01/2200",
+      "mpWithOwnerDisplay": Object {
+        "mp": "",
+        "owner": "MOCK_USER",
+      },
+      "primaryCorrespondentAndRefDisplay": Object {
+        "caseReference": "A/1234568/19",
+      },
+      "stageType": "MPAM_DRAFT",
+      "stageTypeDisplay": "MOCK_STAGETYPE",
+      "stageTypeWithDueDateDisplay": "MOCK_STAGETYPE (Contributions Received)",
+      "teamUUID": 2,
+      "userUUID": 2,
+    },
+  ],
+  "label": "MOCK_STAGETYPE",
+  "teamMembers": Array [],
+}
+`;
+
+exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_DRAFT with contributions as null 1`] = `
+Object {
+  "allocateToTeamEndpoint": "/allocate/team",
+  "allocateToUserEndpoint": "/allocate/user",
+  "allocateToWorkstackEndpoint": "/unallocate/",
+  "columns": Array [],
+  "items": Array [
+    Object {
+      "active": true,
+      "assignedTeamDisplay": "MOCK_TEAM",
+      "assignedUserDisplay": "MOCK_USER",
+      "caseReference": "A/1234568/19",
+      "caseType": "WCS",
+      "caseTypeDisplayFull": "MOCK_CASETYPE",
+      "contributions": null,
+      "deadline": "2200-01-03",
+      "deadlineDisplay": "03/01/2200",
+      "mpWithOwnerDisplay": Object {
+        "mp": "",
+        "owner": "MOCK_USER",
+      },
+      "primaryCorrespondentAndRefDisplay": Object {
+        "caseReference": "A/1234568/19",
+      },
+      "stageType": "MPAM_DRAFT",
+      "stageTypeDisplay": "MOCK_STAGETYPE",
+      "stageTypeWithDueDateDisplay": "MOCK_STAGETYPE",
+      "teamUUID": 2,
+      "userUUID": 2,
+    },
+  ],
+  "label": "MOCK_STAGETYPE",
+  "teamMembers": Array [],
+}
+`;
+
+exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_DRAFT_REQUESTED_CONTRIBUTION with dueContribution 1`] = `
+Object {
+  "allocateToTeamEndpoint": "/allocate/team",
+  "allocateToUserEndpoint": "/allocate/user",
+  "allocateToWorkstackEndpoint": "/unallocate/",
+  "columns": Array [],
+  "items": Array [
+    Object {
+      "active": true,
+      "assignedTeamDisplay": "MOCK_TEAM",
+      "assignedUserDisplay": "MOCK_USER",
+      "caseReference": "A/1234568/19",
+      "caseType": "WCS",
+      "caseTypeDisplayFull": "MOCK_CASETYPE",
+      "contributions": "Due",
       "deadline": "2200-01-03",
       "deadlineDisplay": "03/01/2200",
       "dueContribution": "2020-12-12",
@@ -1332,7 +1406,7 @@ Object {
 }
 `;
 
-exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_DRAFT_REQUESTED_CONTRIBUTION with contributionStatus and contributionStatus 1`] = `
+exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_DRAFT_REQUESTED_CONTRIBUTION with dueContribution as null 1`] = `
 Object {
   "allocateToTeamEndpoint": "/allocate/team",
   "allocateToUserEndpoint": "/allocate/user",
@@ -1348,6 +1422,7 @@ Object {
       "caseTypeDisplayFull": "MOCK_CASETYPE",
       "deadline": "2200-01-03",
       "deadlineDisplay": "03/01/2200",
+      "dueContribution": null,
       "mpWithOwnerDisplay": Object {
         "mp": "",
         "owner": "MOCK_USER",
@@ -1367,7 +1442,7 @@ Object {
 }
 `;
 
-exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_TRIAGE with contributionStatus 1`] = `
+exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_TRIAGE with contributions as Received 1`] = `
 Object {
   "allocateToTeamEndpoint": "/allocate/team",
   "allocateToUserEndpoint": "/allocate/user",
@@ -1381,6 +1456,7 @@ Object {
       "caseReference": "A/1234568/19",
       "caseType": "WCS",
       "caseTypeDisplayFull": "MOCK_CASETYPE",
+      "contributions": "Received",
       "deadline": "2200-01-03",
       "deadlineDisplay": "03/01/2200",
       "mpWithOwnerDisplay": Object {
@@ -1402,7 +1478,7 @@ Object {
 }
 `;
 
-exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_TRIAGE_REQUESTED_CONTRIBUTION with contributionDueDate 1`] = `
+exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_TRIAGE with contributions as null 1`] = `
 Object {
   "allocateToTeamEndpoint": "/allocate/team",
   "allocateToUserEndpoint": "/allocate/user",
@@ -1416,6 +1492,43 @@ Object {
       "caseReference": "A/1234568/19",
       "caseType": "WCS",
       "caseTypeDisplayFull": "MOCK_CASETYPE",
+      "contributions": null,
+      "deadline": "2200-01-03",
+      "deadlineDisplay": "03/01/2200",
+      "mpWithOwnerDisplay": Object {
+        "mp": "",
+        "owner": "MOCK_USER",
+      },
+      "primaryCorrespondentAndRefDisplay": Object {
+        "caseReference": "A/1234568/19",
+      },
+      "stageType": "MPAM_TRIAGE",
+      "stageTypeDisplay": "MOCK_STAGETYPE",
+      "stageTypeWithDueDateDisplay": "MOCK_STAGETYPE",
+      "teamUUID": 2,
+      "userUUID": 2,
+    },
+  ],
+  "label": "MOCK_STAGETYPE",
+  "teamMembers": Array [],
+}
+`;
+
+exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_TRIAGE_REQUESTED_CONTRIBUTION with dueContribution 1`] = `
+Object {
+  "allocateToTeamEndpoint": "/allocate/team",
+  "allocateToUserEndpoint": "/allocate/user",
+  "allocateToWorkstackEndpoint": "/unallocate/",
+  "columns": Array [],
+  "items": Array [
+    Object {
+      "active": true,
+      "assignedTeamDisplay": "MOCK_TEAM",
+      "assignedUserDisplay": "MOCK_USER",
+      "caseReference": "A/1234568/19",
+      "caseType": "WCS",
+      "caseTypeDisplayFull": "MOCK_CASETYPE",
+      "contributions": "Due",
       "deadline": "2200-01-03",
       "deadlineDisplay": "03/01/2200",
       "dueContribution": "2020-12-12",
@@ -1438,7 +1551,7 @@ Object {
 }
 `;
 
-exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_TRIAGE_REQUESTED_CONTRIBUTION with contributionStatus and contributionStatus 1`] = `
+exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_TRIAGE_REQUESTED_CONTRIBUTION with dueContribution as null 1`] = `
 Object {
   "allocateToTeamEndpoint": "/allocate/team",
   "allocateToUserEndpoint": "/allocate/user",
@@ -1454,6 +1567,7 @@ Object {
       "caseTypeDisplayFull": "MOCK_CASETYPE",
       "deadline": "2200-01-03",
       "deadlineDisplay": "03/01/2200",
+      "dueContribution": null,
       "mpWithOwnerDisplay": Object {
         "mp": "",
         "owner": "MOCK_USER",
@@ -1533,7 +1647,7 @@ Object {
       },
       "stageType": "MPAM_TRIAGE",
       "stageTypeDisplay": "MOCK_STAGETYPE",
-      "stageTypeWithDueDateDisplay": "MOCK_STAGETYPE (Contributions Received)",
+      "stageTypeWithDueDateDisplay": "MOCK_STAGETYPE",
       "teamUUID": 2,
       "userUUID": 2,
     },

--- a/server/lists/adapters/__tests__/workstacks.spec.js
+++ b/server/lists/adapters/__tests__/workstacks.spec.js
@@ -902,7 +902,8 @@ describe('Workflow Workstack Adapter', () => {
                         deadline: '2200-01-03',
                         caseReference: 'A/1234568/19',
                         active: true,
-                        dueContribution: '2020-12-12'
+                        dueContribution: '2020-12-12',
+                        contributions: 'Due'
                     }
                 ]
             };
@@ -1036,7 +1037,7 @@ describe('Workflow Workstack Adapter', () => {
         expect(result).toMatchSnapshot();
     });
 
-    it('should transform a stage array to a workflow workstack with at MPAM_TRIAGE with contributionStatus',
+    it('should transform a stage array to a workflow workstack with at MPAM_TRIAGE with contributions as null',
         async () => {
             const mockData = {
                 stages: [
@@ -1047,7 +1048,8 @@ describe('Workflow Workstack Adapter', () => {
                         userUUID: 2,
                         deadline: '2200-01-03',
                         caseReference: 'A/1234568/19',
-                        active: true
+                        active: true,
+                        contributions: null
                     }
                 ]
             };
@@ -1065,7 +1067,37 @@ describe('Workflow Workstack Adapter', () => {
             expect(result).toMatchSnapshot();
         });
 
-    it('should transform a stage array to a workflow workstack with at MPAM_TRIAGE_REQUESTED_CONTRIBUTION with contributionDueDate',
+    it('should transform a stage array to a workflow workstack with at MPAM_TRIAGE with contributions as Received',
+        async () => {
+            const mockData = {
+                stages: [
+                    {
+                        teamUUID: 2,
+                        caseType: 'WCS',
+                        stageType: 'MPAM_TRIAGE',
+                        userUUID: 2,
+                        deadline: '2200-01-03',
+                        caseReference: 'A/1234568/19',
+                        active: true,
+                        contributions: 'Received'
+                    }
+                ]
+            };
+
+            const result = await stageAdapter(mockData, {
+                user: mockUser,
+                fromStaticList: mockFromStaticList,
+                logger: mockLogger,
+                teamId: 2,
+                workflowId: 'WCS',
+                stageId: 'MPAM_TRIAGE',
+                configuration: mockConfiguration
+            });
+
+            expect(result).toMatchSnapshot();
+        });
+
+    it('should transform a stage array to a workflow workstack with at MPAM_TRIAGE_REQUESTED_CONTRIBUTION with dueContribution',
         async () => {
             const mockData = {
                 stages: [
@@ -1077,7 +1109,8 @@ describe('Workflow Workstack Adapter', () => {
                         deadline: '2200-01-03',
                         caseReference: 'A/1234568/19',
                         active: true,
-                        dueContribution: '2020-12-12'
+                        dueContribution: '2020-12-12',
+                        contributions: 'Due'
                     }
                 ]
             };
@@ -1095,7 +1128,7 @@ describe('Workflow Workstack Adapter', () => {
             expect(result).toMatchSnapshot();
         });
 
-    it('should transform a stage array to a workflow workstack with at MPAM_TRIAGE_REQUESTED_CONTRIBUTION with contributionStatus and contributionStatus',
+    it('should transform a stage array to a workflow workstack with at MPAM_TRIAGE_REQUESTED_CONTRIBUTION with dueContribution as null',
         async () => {
             const mockData = {
                 stages: [
@@ -1106,7 +1139,8 @@ describe('Workflow Workstack Adapter', () => {
                         userUUID: 2,
                         deadline: '2200-01-03',
                         caseReference: 'A/1234568/19',
-                        active: true
+                        active: true,
+                        dueContribution: null
                     }
                 ]
             };
@@ -1124,7 +1158,67 @@ describe('Workflow Workstack Adapter', () => {
             expect(result).toMatchSnapshot();
         });
 
-    it('should transform a stage array to a workflow workstack with at MPAM_DRAFT_REQUESTED_CONTRIBUTION with contributionStatus',
+    it('should transform a stage array to a workflow workstack with at MPAM_DRAFT with contributions as null',
+        async () => {
+            const mockData = {
+                stages: [
+                    {
+                        teamUUID: 2,
+                        caseType: 'WCS',
+                        stageType: 'MPAM_DRAFT',
+                        userUUID: 2,
+                        deadline: '2200-01-03',
+                        caseReference: 'A/1234568/19',
+                        active: true,
+                        contributions: null
+                    }
+                ]
+            };
+
+            const result = await stageAdapter(mockData, {
+                user: mockUser,
+                fromStaticList: mockFromStaticList,
+                logger: mockLogger,
+                teamId: 2,
+                workflowId: 'WCS',
+                stageId: 'MPAM_DRAFT',
+                configuration: mockConfiguration
+            });
+
+            expect(result).toMatchSnapshot();
+        });
+
+    it('should transform a stage array to a workflow workstack with at MPAM_DRAFT with contributions as Received',
+        async () => {
+            const mockData = {
+                stages: [
+                    {
+                        teamUUID: 2,
+                        caseType: 'WCS',
+                        stageType: 'MPAM_DRAFT',
+                        userUUID: 2,
+                        deadline: '2200-01-03',
+                        caseReference: 'A/1234568/19',
+                        active: true,
+                        contributions: 'Received'
+                    }
+                ]
+            };
+
+            const result = await stageAdapter(mockData, {
+                user: mockUser,
+                fromStaticList: mockFromStaticList,
+                logger: mockLogger,
+                teamId: 2,
+                workflowId: 'WCS',
+                stageId: 'MPAM_DRAFT',
+                configuration: mockConfiguration
+            });
+
+            expect(result).toMatchSnapshot();
+        });
+
+    it('should transform a stage array to a workflow workstack with at MPAM_DRAFT_REQUESTED_CONTRIBUTION with dueContribution',
         async () => {
             const mockData = {
                 stages: [
@@ -1136,7 +1230,8 @@ describe('Workflow Workstack Adapter', () => {
                         deadline: '2200-01-03',
                         caseReference: 'A/1234568/19',
                         active: true,
-                        dueContribution: '2020-12-12'
+                        dueContribution: '2020-12-12',
+                        contributions: 'Due'
                     }
                 ]
             };
@@ -1154,7 +1249,7 @@ describe('Workflow Workstack Adapter', () => {
             expect(result).toMatchSnapshot();
         });
 
-    it('should transform a stage array to a workflow workstack with at MPAM_DRAFT_REQUESTED_CONTRIBUTION with contributionStatus and contributionStatus',
+    it('should transform a stage array to a workflow workstack with at MPAM_DRAFT_REQUESTED_CONTRIBUTION with dueContribution as null',
         async () => {
             const mockData = {
                 stages: [
@@ -1165,7 +1260,8 @@ describe('Workflow Workstack Adapter', () => {
                         userUUID: 2,
                         deadline: '2200-01-03',
                         caseReference: 'A/1234568/19',
-                        active: true
+                        active: true,
+                        dueContribution: null
                     }
                 ]
             };

--- a/server/lists/adapters/workstacks.js
+++ b/server/lists/adapters/workstacks.js
@@ -191,16 +191,14 @@ const bindDisplayElements = fromStaticList => async (stage) => {
         'MPAM_DRAFT_ESCALATED_REQUESTED_CONTRIBUTION'
     ];
 
-    if ((contributionReceivedStages.includes(stage.stageType) || contributionRequestedStages.includes(stage.stageType))) {
-        if (contributionRequestedStages.includes(stage.stageType) && stage.dueContribution) {
-            stage.stageTypeWithDueDateDisplay = `${stage.stageTypeDisplay} due: ${formatDate(stage.dueContribution)}`;
-        } else if (contributionReceivedStages.includes(stage.stageType) && !stage.dueContribution) {
-            stage.stageTypeWithDueDateDisplay = `${stage.stageTypeDisplay} (Contributions Received)`;
-        } else {
-            stage.stageTypeWithDueDateDisplay = stage.stageTypeDisplay;
-        }
+    if (contributionRequestedStages.includes(stage.stageType) && stage.dueContribution) {
+        stage.stageTypeWithDueDateDisplay = `${stage.stageTypeDisplay} due: ${formatDate(stage.dueContribution)}`;
+    } else if (contributionReceivedStages.includes(stage.stageType) && stage.contributions === 'Received') {
+        stage.stageTypeWithDueDateDisplay = `${stage.stageTypeDisplay} (Contributions Received)`;
     } else if (stage.data && stage.data.DueDate) {
         stage.stageTypeWithDueDateDisplay = `${stage.stageTypeDisplay} due ${formatDate(stage.data.DueDate)}`;
+    } else {
+        stage.stageTypeWithDueDateDisplay = stage.stageTypeDisplay;
     }
 
     stage.primaryCorrespondentAndRefDisplay = {};


### PR DESCRIPTION
Currently, when a there is not a dueContribution we show all MPAM cases
at the contribution received stages as they have a requested
contribution. This change improves this logic to check the status that
is passed back to ensure that it is 'Received' before it sets it to
that.