### PR TITLE
HOCS-3848: change workflow display logic

### DIFF
--- a/server/lists/adapters/__tests__/__snapshots__/workstacks.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/workstacks.spec.js.snap
@@ -1297,6 +1297,42 @@ Object {
 }
 `;
 
+exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_DRAFT with contributions as Cancelled 1`] = `
+Object {
+  "allocateToTeamEndpoint": "/allocate/team",
+  "allocateToUserEndpoint": "/allocate/user",
+  "allocateToWorkstackEndpoint": "/unallocate/",
+  "columns": Array [],
+  "items": Array [
+    Object {
+      "active": true,
+      "assignedTeamDisplay": "MOCK_TEAM",
+      "assignedUserDisplay": "MOCK_USER",
+      "caseReference": "A/1234568/19",
+      "caseType": "WCS",
+      "caseTypeDisplayFull": "MOCK_CASETYPE",
+      "contributions": "Cancelled",
+      "deadline": "2200-01-03",
+      "deadlineDisplay": "03/01/2200",
+      "mpWithOwnerDisplay": Object {
+        "mp": "",
+        "owner": "MOCK_USER",
+      },
+      "primaryCorrespondentAndRefDisplay": Object {
+        "caseReference": "A/1234568/19",
+      },
+      "stageType": "MPAM_DRAFT",
+      "stageTypeDisplay": "MOCK_STAGETYPE",
+      "stageTypeWithDueDateDisplay": "MOCK_STAGETYPE (Contributions Received)",
+      "teamUUID": 2,
+      "userUUID": 2,
+    },
+  ],
+  "label": "MOCK_STAGETYPE",
+  "teamMembers": Array [],
+}
+`;
+
 exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_DRAFT with contributions as Received 1`] = `
 Object {
   "allocateToTeamEndpoint": "/allocate/team",
@@ -1433,6 +1469,42 @@ Object {
       "stageType": "MPAM_DRAFT_REQUESTED_CONTRIBUTION",
       "stageTypeDisplay": "MOCK_STAGETYPE",
       "stageTypeWithDueDateDisplay": "MOCK_STAGETYPE",
+      "teamUUID": 2,
+      "userUUID": 2,
+    },
+  ],
+  "label": "MOCK_STAGETYPE",
+  "teamMembers": Array [],
+}
+`;
+
+exports[`Workflow Workstack Adapter should transform a stage array to a workflow workstack with at MPAM_TRIAGE with contributions as Cancelled 1`] = `
+Object {
+  "allocateToTeamEndpoint": "/allocate/team",
+  "allocateToUserEndpoint": "/allocate/user",
+  "allocateToWorkstackEndpoint": "/unallocate/",
+  "columns": Array [],
+  "items": Array [
+    Object {
+      "active": true,
+      "assignedTeamDisplay": "MOCK_TEAM",
+      "assignedUserDisplay": "MOCK_USER",
+      "caseReference": "A/1234568/19",
+      "caseType": "WCS",
+      "caseTypeDisplayFull": "MOCK_CASETYPE",
+      "contributions": "Cancelled",
+      "deadline": "2200-01-03",
+      "deadlineDisplay": "03/01/2200",
+      "mpWithOwnerDisplay": Object {
+        "mp": "",
+        "owner": "MOCK_USER",
+      },
+      "primaryCorrespondentAndRefDisplay": Object {
+        "caseReference": "A/1234568/19",
+      },
+      "stageType": "MPAM_TRIAGE",
+      "stageTypeDisplay": "MOCK_STAGETYPE",
+      "stageTypeWithDueDateDisplay": "MOCK_STAGETYPE (Contributions Received)",
       "teamUUID": 2,
       "userUUID": 2,
     },

--- a/server/lists/adapters/__tests__/workstacks.spec.js
+++ b/server/lists/adapters/__tests__/workstacks.spec.js
@@ -1097,6 +1097,36 @@ describe('Workflow Workstack Adapter', () => {
             expect(result).toMatchSnapshot();
         });
 
+    it('should transform a stage array to a workflow workstack with at MPAM_TRIAGE with contributions as Cancelled',
+        async () => {
+            const mockData = {
+                stages: [
+                    {
+                        teamUUID: 2,
+                        caseType: 'WCS',
+                        stageType: 'MPAM_TRIAGE',
+                        userUUID: 2,
+                        deadline: '2200-01-03',
+                        caseReference: 'A/1234568/19',
+                        active: true,
+                        contributions: 'Cancelled'
+                    }
+                ]
+            };
+
+            const result = await stageAdapter(mockData, {
+                user: mockUser,
+                fromStaticList: mockFromStaticList,
+                logger: mockLogger,
+                teamId: 2,
+                workflowId: 'WCS',
+                stageId: 'MPAM_TRIAGE',
+                configuration: mockConfiguration
+            });
+
+            expect(result).toMatchSnapshot();
+        });
+
     it('should transform a stage array to a workflow workstack with at MPAM_TRIAGE_REQUESTED_CONTRIBUTION with dueContribution',
         async () => {
             const mockData = {
@@ -1171,6 +1201,36 @@ describe('Workflow Workstack Adapter', () => {
                         caseReference: 'A/1234568/19',
                         active: true,
                         contributions: null
+                    }
+                ]
+            };
+
+            const result = await stageAdapter(mockData, {
+                user: mockUser,
+                fromStaticList: mockFromStaticList,
+                logger: mockLogger,
+                teamId: 2,
+                workflowId: 'WCS',
+                stageId: 'MPAM_DRAFT',
+                configuration: mockConfiguration
+            });
+
+            expect(result).toMatchSnapshot();
+        });
+
+    it('should transform a stage array to a workflow workstack with at MPAM_DRAFT with contributions as Cancelled',
+        async () => {
+            const mockData = {
+                stages: [
+                    {
+                        teamUUID: 2,
+                        caseType: 'WCS',
+                        stageType: 'MPAM_DRAFT',
+                        userUUID: 2,
+                        deadline: '2200-01-03',
+                        caseReference: 'A/1234568/19',
+                        active: true,
+                        contributions: 'Cancelled'
                     }
                 ]
             };

--- a/server/lists/adapters/workstacks.js
+++ b/server/lists/adapters/workstacks.js
@@ -175,30 +175,13 @@ const bindDisplayElements = fromStaticList => async (stage) => {
     }
     stage.deadlineDisplay = formatDate(stage.deadline);
 
-    stage.stageTypeWithDueDateDisplay = stage.stageTypeDisplay;
-
-    const contributionReceivedStages = [
-        'MPAM_TRIAGE',
-        'MPAM_TRIAGE_ESCALATE',
-        'MPAM_DRAFT',
-        'MPAM_DRAFT_ESCALATE'
-    ];
-
-    const contributionRequestedStages = [
-        'MPAM_TRIAGE_REQUESTED_CONTRIBUTION',
-        'MPAM_TRIAGE_ESCALATED_REQUESTED_CONTRIBUTION',
-        'MPAM_DRAFT_REQUESTED_CONTRIBUTION',
-        'MPAM_DRAFT_ESCALATED_REQUESTED_CONTRIBUTION'
-    ];
-
-    if (contributionRequestedStages.includes(stage.stageType) && stage.dueContribution) {
-        stage.stageTypeWithDueDateDisplay = `${stage.stageTypeDisplay} due: ${formatDate(stage.dueContribution)}`;
-    } else if (contributionReceivedStages.includes(stage.stageType) && stage.contributions === 'Received') {
-        stage.stageTypeWithDueDateDisplay = `${stage.stageTypeDisplay} (Contributions Received)`;
-    } else if (stage.data && stage.data.DueDate) {
-        stage.stageTypeWithDueDateDisplay = `${stage.stageTypeDisplay} due ${formatDate(stage.data.DueDate)}`;
-    } else {
-        stage.stageTypeWithDueDateDisplay = stage.stageTypeDisplay;
+    stage.stageTypeWithDueDateDisplay = contributionDueDateDisplay(stage);
+    if (stage.stageTypeWithDueDateDisplay === undefined) {
+        if (stage.data && stage.data.DueDate) {
+            stage.stageTypeWithDueDateDisplay = `${stage.stageTypeDisplay} due ${formatDate(stage.data.DueDate)}`;
+        } else {
+            stage.stageTypeWithDueDateDisplay = stage.stageTypeDisplay;
+        }
     }
 
     stage.primaryCorrespondentAndRefDisplay = {};
@@ -224,6 +207,32 @@ const bindDisplayElements = fromStaticList => async (stage) => {
     stage.primaryCorrespondentAndRefDisplay.caseReference = stage.caseReference;
 
     return stage;
+};
+
+const contributionDueDateDisplay = ({ stageType, stageTypeDisplay, dueContribution, contributions }) => {
+    const contributionReceivedStages = [
+        'MPAM_TRIAGE',
+        'MPAM_TRIAGE_ESCALATE',
+        'MPAM_DRAFT',
+        'MPAM_DRAFT_ESCALATE'
+    ];
+
+    const contributionRequestedStages = [
+        'MPAM_TRIAGE_REQUESTED_CONTRIBUTION',
+        'MPAM_TRIAGE_ESCALATED_REQUESTED_CONTRIBUTION',
+        'MPAM_DRAFT_REQUESTED_CONTRIBUTION',
+        'MPAM_DRAFT_ESCALATED_REQUESTED_CONTRIBUTION'
+    ];
+
+    const receivedStatus = ['Received', 'Cancelled'];
+
+    if (contributionRequestedStages.includes(stageType) && dueContribution) {
+        return `${stageTypeDisplay} due: ${formatDate(dueContribution)}`;
+    } else if (contributionReceivedStages.includes(stageType) && receivedStatus.includes(contributions)) {
+        return `${stageTypeDisplay} (Contributions Received)`;
+    }
+
+    return undefined;
 };
 
 class Card {


### PR DESCRIPTION
Further fix to handle both received flags of `Cancelled` and
`Received` for the stage type name. This also extracts that
code out to its own function.