### PR TITLE
HOCS-3730 add organisation field to correspondent

### DIFF
--- a/server/services/forms/schemas/decorators/__test__/form-decorations.spec.js
+++ b/server/services/forms/schemas/decorators/__test__/form-decorations.spec.js
@@ -201,6 +201,24 @@ describe('Form schema decorations', function () {
                     },
                     {
                         'component': 'text',
+                        'validation': [],
+                        'props': {
+                            'name': 'Organisation',
+                            'label': 'Organisation (Optional)',
+                            'visibilityConditions': [
+                                {
+                                    'conditionPropertyName': 'OriginalChannel',
+                                    'conditionPropertyValue': 'EMAIL'
+                                },
+                                {
+                                    'conditionPropertyName': 'OriginalChannel',
+                                    'conditionPropertyValue': 'POST'
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        'component': 'text',
                         'validation': [
                             {
                                 'type': 'required'

--- a/server/services/forms/schemas/decorators/form_decorations/schema-decorations.js
+++ b/server/services/forms/schemas/decorators/form_decorations/schema-decorations.js
@@ -65,8 +65,20 @@ module.exports = {
                                         'conditionPropertyValue': 'POST'
                                     }
                                 ])
-                                .build()
-                        )
+                                .build())
+                        .withField(
+                            Component('text', 'Organisation')
+                                .withProp('label', 'Organisation (Optional)')
+                                .withProp('visibilityConditions', [
+                                    {
+                                        'conditionPropertyName': 'OriginalChannel',
+                                        'conditionPropertyValue': 'EMAIL'
+                                    },{
+                                        'conditionPropertyName': 'OriginalChannel',
+                                        'conditionPropertyValue': 'POST'
+                                    }
+                                ])
+                                .build())
                         .withField(
                             Component('text', 'Address1')
                                 .withValidator('required')

--- a/server/services/forms/schemas/update-correspondent-details-foi.js
+++ b/server/services/forms/schemas/update-correspondent-details-foi.js
@@ -14,6 +14,11 @@ module.exports = async ({ caseId, stageId, context, user, requestId }) => {
                 .build()
         )
         .withField(
+            Component('text', 'organisation')
+                .withProp('label', 'Organisation')
+                .build()
+        )
+        .withField(
             Component('text', 'address1')
                 .withProp('label', 'Building')
                 .build()


### PR DESCRIPTION
Adds an Organisation field used in FOI requests, this field is stored in the Correspondent table.