### PR TITLE
HOCS-4008: bubble up forbidden service exceptions

### DIFF
--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto');
 const jwt = require('jsonwebtoken');
 const User = require('../models/user');
-const { AuthenticationError } = require('../models/error');
+const { ForbiddenError } = require('../models/error');
 const getLogger = require('../libs/logger');
 
 
@@ -21,7 +21,7 @@ function authMiddleware(req, res, next) {
         return next();
     }
     logger.error('AUTH_FAILURE');
-    next(new AuthenticationError('Unauthorised', 401));
+    next(new ForbiddenError('Unauthorised', 401));
 
 }
 
@@ -99,7 +99,7 @@ function protect(permission) {
             return next();
         }
         logger.error('AUTH_FAILURE', { expected: permission, user: req.user.username, roles: req.user.roles });
-        next(new AuthenticationError('Unauthorised'));
+        next(new ForbiddenError('Unauthorised'));
     };
 }
 

--- a/server/middleware/document.js
+++ b/server/middleware/document.js
@@ -1,6 +1,6 @@
 const { caseworkService } = require('../clients');
 const getLogger = require('../libs/logger');
-const { DocumentError, PermissionError } = require('../models/error');
+const { DocumentError, AuthenticationError } = require('../models/error');
 const User = require('../models/user');
 
 async function getOriginalDocument(req, res, next) {
@@ -20,7 +20,7 @@ async function getOriginalDocument(req, res, next) {
     } catch (error) {
         logger.error('REQUEST_DOCUMENT_ORIGINAL_FAILURE', { ...req.params });
         if (error.response !== undefined && error.response.status === 401) {
-            return next(new PermissionError('You are not authorised to work on this case'));
+            return next(new AuthenticationError('You are not authorised to work on this case'));
         }
         return next(new DocumentError('Unable to retrieve original document'));
     }
@@ -45,7 +45,7 @@ async function getPdfDocument(req, res, next) {
     } catch (error) {
         logger.error('REQUEST_DOCUMENT_PDF_FAILURE', { ...req.params });
         if (error.response !== undefined && error.response.status === 401) {
-            return next(new PermissionError('You are not authorised to work on this case'));
+            return next(new AuthenticationError('You are not authorised to work on this case'));
         }
         return next(new DocumentError('Unable to retrieve PDF document'));
     }
@@ -69,7 +69,7 @@ async function getPdfDocumentPreview(req, res, next) {
     } catch (error) {
         logger.error('REQUEST_DOCUMENT_PREVIEW_FAILURE', { ...req.params });
         if (error.response !== undefined && error.response.status === 401) {
-            return next(new PermissionError('You are not authorised to work on this case'));
+            return next(new AuthenticationError('You are not authorised to work on this case'));
         }
         return next(new DocumentError('Unable to retrieve document for PDF preview'));
     }
@@ -83,7 +83,7 @@ async function getDocumentList(req, res, next) {
     } catch (error) {
         res.locals.documents = [];
         if (error.response !== undefined && error.response.status === 401) {
-            return { error: new PermissionError('You are not authorised to work on this case') };
+            return { error: new AuthenticationError('You are not authorised to work on this case') };
         }
         logger.info('CASE_DOCUMENT_LIST_RETURN_EMPTY');
     } finally {

--- a/server/models/error.js
+++ b/server/models/error.js
@@ -20,9 +20,9 @@ class ErrorModel extends Error {
 
 }
 
-class AuthenticationError extends ErrorModel {
+class ForbiddenError extends ErrorModel {
     constructor(message, status = 403) {
-        super(message, status, 'Authentication error');
+        super(message, status, 'Forbidden');
     }
 }
 
@@ -69,7 +69,7 @@ class DocumentNotFoundError extends ErrorModel {
     }
 }
 
-class PermissionError extends ErrorModel {
+class AuthenticationError extends ErrorModel {
     constructor(message, status = 401) {
         super(message, status, 'Unauthorised');
     }
@@ -78,11 +78,11 @@ class PermissionError extends ErrorModel {
 module.exports = {
     ActionError,
     AllocationError,
-    AuthenticationError,
+    ForbiddenError,
     DocumentError,
     DocumentNotFoundError,
     FormSubmissionError,
     FormServiceError,
     ValidationError,
-    PermissionError
+    AuthenticationError
 };

--- a/server/services/__tests__/form.spec.js
+++ b/server/services/__tests__/form.spec.js
@@ -239,7 +239,7 @@ describe('getFormForStage', () => {
 
 describe('when the hydrate method is called', () => {
     const { hydrateFields } = require('../form');
-    const { FormServiceError, PermissionError } = require('../../models/error');
+    const { FormServiceError, AuthenticationError } = require('../../models/error');
     const items = ['item1', 'item2', 'item3'];
 
     describe('and the schema has a flat array of fields ', () => {
@@ -300,7 +300,7 @@ describe('when the hydrate method is called', () => {
         it('should call next with a permission error', async () => {
             await hydrateFields(req, null, next);
 
-            expect(next).toHaveBeenCalledWith(new PermissionError('You are not authorised to work on this case'));
+            expect(next).toHaveBeenCalledWith(new AuthenticationError('You are not authorised to work on this case'));
         });
     });
     describe('and the list fetch request fails with a PermissionError', () => {
@@ -319,7 +319,7 @@ describe('when the hydrate method is called', () => {
                 }
             },
             listService: {
-                fetch: () => Promise.reject(new PermissionError('PermissionError'))
+                fetch: () => Promise.reject(new AuthenticationError('PermissionError'))
             }
         };
         const next = jest.fn();
@@ -327,7 +327,7 @@ describe('when the hydrate method is called', () => {
         it('should call next with a permission error', async () => {
             await hydrateFields(req, null, next);
 
-            expect(next).toHaveBeenCalledWith(new PermissionError('PermissionError'));
+            expect(next).toHaveBeenCalledWith(new AuthenticationError('PermissionError'));
         });
     });
     describe('and the list fetch request fails with some other error', () => {

--- a/server/services/form.js
+++ b/server/services/form.js
@@ -2,7 +2,7 @@ const formRepository = require('./forms/index');
 const listService = require('./list/service');
 const { workflowService, caseworkService } = require('../clients');
 const getLogger = require('../libs/logger');
-const { FormServiceError, PermissionError } = require('../models/error');
+const { FormServiceError, AuthenticationError } = require('../models/error');
 const User = require('../models/user');
 const FormBuilder = require('./forms/form-builder');
 const { Component } = require('./forms/component-builder');
@@ -27,7 +27,7 @@ async function getFormSchemaFromWorkflowService(requestId, options, user) {
                 try {
                     return { form: await returnReadOnlyCaseViewForm(requestId, user, caseId) };
                 } catch (error) {
-                    return { error: new PermissionError('You are not authorised to work on this case') };
+                    return { error: new AuthenticationError('You are not authorised to work on this case') };
                 }
             case 403:
                 // handle not allocated
@@ -163,11 +163,11 @@ const hydrateFields = async (req, res, next) => {
         try {
             await Promise.all(requests);
         } catch (error) {
-            if (error instanceof PermissionError) {
+            if (error instanceof AuthenticationError) {
                 return next(error);
             }
             if (error.response !== undefined && error.response.status === 401) {
-                return next(new PermissionError('You are not authorised to work on this case'));
+                return next(new AuthenticationError('You are not authorised to work on this case'));
             }
             return next(new FormServiceError('Failed to fetch form'));
         }
@@ -237,7 +237,7 @@ const getFormForAction = async (req, res, next) => {
     } catch (error) {
         logger.error('ACTION_FORM_FAILURE', { message: error.message, stack: error.stack });
         if (error.response !== undefined && error.response.status === 401) {
-            return next(new PermissionError('You are not authorised to work on this case'));
+            return next(new AuthenticationError('You are not authorised to work on this case'));
         }
         return next(new FormServiceError('Failed to fetch form'));
     }
@@ -258,7 +258,7 @@ const getFormForCase = async (req, res, next) => {
     } catch (error) {
         logger.error('CASE_FORM_FAILURE', { message: error.message, stack: error.stack });
         if (error.response !== undefined && error.response.status === 401) {
-            return next(new PermissionError('You are not authorised to work on this case'));
+            return next(new AuthenticationError('You are not authorised to work on this case'));
         }
         return next(new FormServiceError('Failed to fetch form'));
     }
@@ -281,7 +281,7 @@ const getFormForStage = async (req, res, next) => {
     } catch (error) {
         logger.error('WORKFLOW_FORM_FAILURE', { message: error.message, stack: error.stack });
         if (error.response !== undefined && error.response.status === 401) {
-            return next(new PermissionError('You are not authorised to work on this case'));
+            return next(new AuthenticationError('You are not authorised to work on this case'));
         }
         return next(new FormServiceError('Failed to fetch form'));
     }

--- a/server/services/list/__tests__/service.spec.js
+++ b/server/services/list/__tests__/service.spec.js
@@ -502,6 +502,37 @@ describe('List Service', () => {
             expect(result).toEqual(mockResponse);
         });
 
+        it('should throw ForbiddenError on 403', async () => {
+            const lists = {
+                test: {
+                    client: 'test',
+                    endpoint: '/test/api'
+                }
+            };
+
+            const mockedFunction = jest.fn()
+                .mockImplementation(() => {
+                    const error = new Error();
+                    error.response = { status: 403 };
+                    throw error;
+                });
+
+            const clients = {
+                test: {
+                    get: mockedFunction
+                }
+            };
+
+            await listService.initialise(lists, clients);
+            const instance = listService.getInstance(mockUUID, mockUser);
+
+            try {
+                await instance.fetch('test');
+            } catch (error) {
+                expect(error).toBeInstanceOf(ForbiddenError);
+            }
+        });
+
         it('should throw AuthenticationError on 401', async () => {
             const lists = {
                 test: {

--- a/server/services/list/__tests__/service.spec.js
+++ b/server/services/list/__tests__/service.spec.js
@@ -1,6 +1,7 @@
 const listService = require('../service');
 const User = require('../../../models/user');
 const getLogger = require('../../../libs/logger');
+const { ForbiddenError, AuthenticationError } = require('../../../models/error');
 
 jest.mock('../../../libs/logger', () => jest.fn().mockReturnValue({
     debug: jest.fn(),
@@ -499,6 +500,37 @@ describe('List Service', () => {
 
             expect(result).toBeDefined();
             expect(result).toEqual(mockResponse);
+        });
+
+        it('should throw AuthenticationError on 401', async () => {
+            const lists = {
+                test: {
+                    client: 'test',
+                    endpoint: '/test/api'
+                }
+            };
+
+            const mockedFunction = jest.fn()
+                .mockImplementation(() => {
+                    const error = new Error();
+                    error.response = { status: 401 };
+                    throw error;
+                });
+
+            const clients = {
+                test: {
+                    get: mockedFunction
+                }
+            };
+
+            await listService.initialise(lists, clients);
+            const instance = listService.getInstance(mockUUID, mockUser);
+
+            try {
+                await instance.fetch('test');
+            } catch (error) {
+                expect(error).toBeInstanceOf(AuthenticationError);
+            }
         });
     });
 

--- a/server/services/list/service.js
+++ b/server/services/list/service.js
@@ -133,6 +133,8 @@ const getInstance = (requestId, user) => {
                             return defaultValue;
                         } else if (error.response.status === 401) {
                             throw new AuthenticationError('You do not have permission to view this page.');
+                        } else if (error.response.status === 403) {
+                            throw new ForbiddenError('You are not authorised to view this page.');
                         }
                     }
                     throw new Error('Failed to request list');
@@ -154,7 +156,7 @@ const getInstance = (requestId, user) => {
                 throw new Error('List not implemented');
             }
         } catch (error) {
-            if (error instanceof AuthenticationError) {
+            if (error instanceof AuthenticationError || error instanceof ForbiddenError) {
                 throw error;
             }
             logger.error('FETCH_LIST_FAILURE', { list: listId, message: error.message, stack: error.stack });

--- a/server/services/list/service.js
+++ b/server/services/list/service.js
@@ -2,7 +2,7 @@ const listType = require('./types');
 const { createRepository } = require('./repository');
 const getLogger = require('../../libs/logger');
 const User = require('../../models/user');
-const { PermissionError } = require('../../models/error');
+const { AuthenticationError, ForbiddenError } = require('../../models/error');
 const scheduleListRefresh = require('./scheduler');
 
 const configureEndpoint = (endpoint, data, baseUrl = '') => {
@@ -132,7 +132,7 @@ const getInstance = (requestId, user) => {
                         if (error.response.status === 404 && defaultValue) {
                             return defaultValue;
                         } else if (error.response.status === 401) {
-                            throw new PermissionError('You are not authorised to work on this case');
+                            throw new AuthenticationError('You do not have permission to view this page.');
                         }
                     }
                     throw new Error('Failed to request list');
@@ -154,7 +154,7 @@ const getInstance = (requestId, user) => {
                 throw new Error('List not implemented');
             }
         } catch (error) {
-            if (error instanceof PermissionError) {
+            if (error instanceof AuthenticationError) {
                 throw error;
             }
             logger.error('FETCH_LIST_FAILURE', { list: listId, message: error.message, stack: error.stack });


### PR DESCRIPTION
When the service returns a 403 when requesting a list it currently
bubbles up as a 500. This is not ideal and we should return the actual
issue, a 403. This change implements this.

Alongside this, we have 2 errors: `PermissionError` and 
`AuthenticationError`. While `PermissionError` is accurate it should
represent what it actually is as a 401, a AuthenticationError. This 
change also  renames AuthenticationError to a ForbiddenError to 
represent a 403 and then renames PermissionError to 
AuthenticationError.