### PR TITLE
HOCS-4440: support checkbox labels

### DIFF
--- a/server/lists/adapters/__tests__/__snapshots__/case-view-all-stages.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/case-view-all-stages.spec.js.snap
@@ -318,3 +318,73 @@ Object {
   },
 }
 `;
+
+exports[`Case-view-all-stages Adapter should render checkboxes with custom label 1`] = `
+Object {
+  "data": Object {
+    "checkbox_field_1": "Test",
+    "checkbox_field_2": "Test",
+  },
+  "meta": Object {},
+  "schema": Object {
+    "defaultActionLabel": "Submit",
+    "fields": Array [
+      Object {
+        "component": "heading",
+        "props": Object {
+          "label": "Case Details",
+          "name": "case-view-heading",
+        },
+        "validation": Array [],
+      },
+      Object {
+        "component": "accordion",
+        "props": Object {
+          "name": "case-view",
+          "sections": Array [
+            Object {
+              "items": Array [
+                Object {
+                  "component": "mapped-display",
+                  "props": Object {
+                    "choices": Array [
+                      Object {
+                        "label": "Test",
+                        "value": "Test",
+                      },
+                    ],
+                    "component": "checkbox",
+                    "label": "Checkbox Field 1",
+                    "name": "checkbox_field_1",
+                  },
+                  "validation": Array [],
+                },
+                Object {
+                  "component": "mapped-display",
+                  "props": Object {
+                    "choices": Array [
+                      Object {
+                        "label": "Test",
+                        "value": "Test",
+                      },
+                    ],
+                    "component": "checkbox",
+                    "label": "Checkbox Field 1",
+                    "name": "checkbox_field_2",
+                    "showLabel": true,
+                  },
+                  "validation": Array [],
+                },
+              ],
+              "title": "STAGE_NAME",
+            },
+          ],
+        },
+        "validation": Array [],
+      },
+    ],
+    "showPrimaryAction": false,
+    "title": "TEST/1234567/18",
+  },
+}
+`;

--- a/server/lists/adapters/__tests__/case-view-all-stages.spec.js
+++ b/server/lists/adapters/__tests__/case-view-all-stages.spec.js
@@ -446,6 +446,14 @@ const mockData = {
                         label: 'My Empty Field'
                     },
                 },
+                {
+                    component: 'checkbox',
+                    validation: ['required'],
+                    props: {
+                        name: 'my_empty_field',
+                        label: 'My Empty Field'
+                    },
+                },
             ]
 
         }
@@ -486,6 +494,52 @@ describe('Case-view-all-stages Adapter', () => {
     it('should render SOMU COMP Contributions case view sections', async () => {
 
         const result = await caseViewAllStagesAdapter(mockDataWithSumoCOMPContributions, { fromStaticList: mockFromStaticList });
+
+        expect(result).toBeDefined();
+        expect(result).toMatchSnapshot();
+    });
+
+    it('should render checkboxes with custom label', async () => {
+        const mockData = {
+            caseReference: 'TEST/1234567/18',
+            schema: {
+                title: 'View Case',
+                fields: {
+                    STAGE_NAME: [
+                        {
+                            component: 'checkbox',
+                            validation: ['required'],
+                            props: {
+                                name: 'checkbox_field_1',
+                                label: 'Checkbox Field 1',
+                                choices: [
+                                    { 'label': 'Test', 'value': 'Test' }
+                                ],
+                            },
+                        },
+                        {
+                            component: 'checkbox',
+                            validation: ['required'],
+                            props: {
+                                name: 'checkbox_field_2',
+                                label: 'Checkbox Field 1',
+                                choices: [
+                                    { 'label': 'Test', 'value': 'Test' }
+                                ],
+                                showLabel: true
+                            },
+                        }
+                    ]
+                }
+            },
+            data: {
+                checkbox_field_1: 'Test',
+                checkbox_field_2: 'Test',
+            }
+        };
+
+
+        const result = await caseViewAllStagesAdapter(mockData, { fromStaticList: mockFromStaticList });
 
         expect(result).toBeDefined();
         expect(result).toMatchSnapshot();

--- a/server/lists/adapters/case-view-all-stages.js
+++ b/server/lists/adapters/case-view-all-stages.js
@@ -182,21 +182,22 @@ const hydrateFields = async (fieldTemplate, template, fromStaticList, name) => {
     }
 };
 
-const getComponentFromField = (fieldTemplate, template) => {
-    const { name, label, choices, conditionChoices } = fieldTemplate.props;
+const getComponentFromField = ( { props, component }, template) => {
+    const { name, label, choices } = props;
     const value = template.data[name];
 
-    if (fieldTemplate.component !== 'hidden') {
-        if (value) {
-            return (
-                Component('mapped-display', name)
-                    .withProp('component', fieldTemplate.component)
-                    .withProp('label', label)
-                    .withProp('choices', choices)
-                    .withProp('conditionChoices', conditionChoices)
-                    .build()
-            );
-        }
+    if (!value || component === 'hidden') {
+        return;
     }
-};
 
+    let mappedDisplayComponent = Component('mapped-display', name)
+        .withProp('component', component)
+        .withProp('label', label)
+        .withProp('choices', choices);
+
+    if (component === 'checkbox') {
+        mappedDisplayComponent.withProp('showLabel', props.showLabel);
+    }
+
+    return mappedDisplayComponent.build();
+};

--- a/src/shared/common/forms/__tests__/__snapshots__/mapped-display.spec.js.snap
+++ b/src/shared/common/forms/__tests__/__snapshots__/mapped-display.spec.js.snap
@@ -11,6 +11,17 @@ exports[`Form MappedDisplay component should render checkbox 1`] = `
 </span>
 `;
 
+exports[`Form MappedDisplay component should render checkbox with label if showLabel 1`] = `
+<span
+  class="govuk-body full-width"
+>
+  <strong>
+    Test: 
+  </strong>
+  Yes
+</span>
+`;
+
 exports[`Form MappedDisplay component should render choice option B1 value 1`] = `
 <span
   class="govuk-body full-width"

--- a/src/shared/common/forms/__tests__/mapped-display.spec.js
+++ b/src/shared/common/forms/__tests__/mapped-display.spec.js
@@ -12,6 +12,15 @@ describe('Form MappedDisplay component', () => {
         ).toMatchSnapshot();
     });
 
+    it('should render checkbox with label if showLabel', () => {
+        const choices = [
+            { label: 'isA', value: 'true' }
+        ];
+        expect(
+            render(<MappedDisplay label="Test" component="checkbox" choices={choices} showLabel={true}/>)
+        ).toMatchSnapshot();
+    });
+
     it('should render date', () => {
         expect(
             render(<MappedDisplay label="When" component="date" value="2021-05-17"/>)

--- a/src/shared/common/forms/mapped-display.jsx
+++ b/src/shared/common/forms/mapped-display.jsx
@@ -11,6 +11,12 @@ const getMapOfChoicesAndChoiceOptions = (choices) => {
     return new Map(allChoices.map(choice => [choice.value, choice.label]));
 };
 
+const renderCheckbox = (label, showLabel, choicesLabel) =>  {
+    return (
+        <span className='govuk-body full-width'><strong>{showLabel ? label : choicesLabel}: </strong>Yes</span>
+    );
+};
+
 class MappedDisplay extends Component {
 
     constructor(props) {
@@ -24,11 +30,10 @@ class MappedDisplay extends Component {
             label,
             value
         } = this.props;
+
         const mappings = getMapOfChoicesAndChoiceOptions(choices);
         if (component === 'checkbox') {
-            return (
-                <span className='govuk-body full-width'><strong>{choices[0].label}: </strong>Yes</span>
-            );
+            return (renderCheckbox(label, this.props.showLabel, choices[0].label));
         } else {
             return (
                 <span className='govuk-body full-width'><strong>{label}: </strong>{mappings.get(value) ? mappings.get(value) : value}</span>
@@ -41,14 +46,18 @@ MappedDisplay.propTypes = {
     choices: PropTypes.arrayOf(PropTypes.object),
     component: PropTypes.string,
     label: PropTypes.string,
-    value: PropTypes.string
+    value: PropTypes.string,
+    props: PropTypes.object,
+    showLabel: PropTypes.bool
 };
 
 MappedDisplay.defaultProps = {
     choices: [],
     component: 'text',
     label: 'MappedDisplay field',
-    value: ''
+    value: '',
+    props: {},
+    showLabel: false
 };
 
 export default MappedDisplay;


### PR DESCRIPTION
Checkboxes currently have the choice label shown on the frontend by
default for the unallocated view. This change supports the passing
through of the showLabel prop from the checkbox that drives if the field
label should be used or the choice label.