### PR TITLE
HOCS-4514: pass through conditionChoices

### DIFF
--- a/server/lists/adapters/case-view-all-stages.js
+++ b/server/lists/adapters/case-view-all-stages.js
@@ -183,7 +183,7 @@ const hydrateFields = async (fieldTemplate, template, fromStaticList, name) => {
 };
 
 const getComponentFromField = ( { props, component }, template) => {
-    const { name, label, choices } = props;
+    const { name, label, choices, conditionChoices } = props;
     const value = template.data[name];
 
     if (!value || component === 'hidden') {
@@ -193,7 +193,8 @@ const getComponentFromField = ( { props, component }, template) => {
     let mappedDisplayComponent = Component('mapped-display', name)
         .withProp('component', component)
         .withProp('label', label)
-        .withProp('choices', choices);
+        .withProp('choices', choices)
+        .withProp('conditionChoices', conditionChoices);
 
     if (component === 'checkbox') {
         mappedDisplayComponent.withProp('showLabel', props.showLabel);


### PR DESCRIPTION
This change reverts a line removal whereby we pass through the
`conditionChoices` prop for mapped-display components within the read
only view. This is used further down the line to populate the value.