### PR TITLE
HOCS-4544: change the stage endpoint

### DIFF
--- a/server/lists/adapters/workstacks.js
+++ b/server/lists/adapters/workstacks.js
@@ -363,10 +363,10 @@ const teamAdapter = async (data, { fromStaticList, logger, teamId, configuration
     };
 };
 
-const workflowAdapter = async (data, { fromStaticList, logger, teamId, workflowId, configuration }) => {
+const workflowAdapter = async (data, { fromStaticList, logger, workflowId, configuration }) => {
     const workstackData = await Promise.all(data.stages
         .filter(byWorkable)
-        .filter(stage => stage.teamUUID === teamId && stage.caseType === workflowId)
+        .filter(stage => stage.caseType === workflowId)
         .sort(defaultCaseSort)
         .sort(tagSort)
         .map(bindDisplayElements(fromStaticList)));
@@ -408,10 +408,10 @@ const workflowAdapter = async (data, { fromStaticList, logger, teamId, workflowI
         allocateToWorkstackEndpoint: '/unallocate/'
     };
 };
-const stageAdapter = async (data, { fromStaticList, logger, teamId, workflowId, stageId, configuration }) => {
+const stageAdapter = async (data, { fromStaticList, logger, workflowId, stageId, configuration }) => {
     const workstackData = await Promise.all(data.stages
         .filter(byWorkable)
-        .filter(stage => stage.teamUUID === teamId && stage.caseType === workflowId && stage.stageType === stageId)
+        .filter(stage => stage.caseType === workflowId && stage.stageType === stageId)
         .sort(defaultCaseSort)
         .map(bindDisplayElements(fromStaticList)));
     const stageDisplayName = await fromStaticList('S_STAGETYPES', stageId);

--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -411,12 +411,12 @@ module.exports = {
         },
         WORKFLOW_WORKSTACK: {
             client: 'CASEWORK',
-            endpoint: '/stage',
+            endpoint: '/stage/team/${teamId}',
             adapter: workstack.workflowAdapter
         },
         STAGE_WORKSTACK: {
             client: 'CASEWORK',
-            endpoint: '/stage',
+            endpoint: '/stage/team/${teamId}',
             adapter: workstack.stageAdapter
         },
         DRAFT_TEAMS: {

--- a/server/middleware/workstack.js
+++ b/server/middleware/workstack.js
@@ -24,7 +24,7 @@ async function teamWorkstackMiddleware(req, res, next) {
 
 async function workflowWorkstackMiddleware(req, res, next) {
     try {
-        const response = await await req.listService.fetch('WORKFLOW_WORKSTACK', req.params);
+        const response = await req.listService.fetch('WORKFLOW_WORKSTACK', req.params);
         res.locals.workstack = response;
         next();
     } catch (error) {
@@ -124,7 +124,7 @@ async function allocateToTeamMember(req, res, next) {
             .map(([caseId, stageId]) => [`/case/${caseId}/stage/${stageId}/user`, { userUUID: selected_user }, {
                 headers: User.createHeaders(req.user)
             }])
-            .map(async options => await sendAllocateUserRequest(req, res, options));
+            .map(async options => sendAllocateUserRequest(req, res, options));
         await Promise.all(requests);
     }
     next();
@@ -150,7 +150,7 @@ async function moveTeam(req, res, next) {
                     { value: selected_team },
                     { headers: User.createHeaders(req.user) }
                 ])
-                .map(async options => await updateCaseDataMoveTeamRequest(req, res, options));
+                .map(async options => updateCaseDataMoveTeamRequest(req, res, options));
 
         const sendMoveTeamRequests =
             requests
@@ -159,7 +159,7 @@ async function moveTeam(req, res, next) {
                     { teamUUID: selected_team },
                     { headers: User.createHeaders(req.user) }
                 ])
-                .map(async options => await sendMoveTeamRequest(req, res, options));
+                .map(async options => sendMoveTeamRequest(req, res, options));
 
         await Promise.all([...updateCaseDataRequests, ...sendMoveTeamRequests]);
     }
@@ -179,7 +179,7 @@ async function allocateToUser(req, res, next) {
             .map(([caseId, stageId]) => [`/case/${caseId}/stage/${stageId}/user`, { userUUID: req.user.uuid }, {
                 headers: User.createHeaders(req.user)
             }])
-            .map(async options => await sendAllocateUserRequest(req, res, options));
+            .map(async options => sendAllocateUserRequest(req, res, options));
         await Promise.all(requests);
     }
     next();
@@ -220,7 +220,7 @@ async function unallocate(req, res, next) {
             .map(([caseId, stageId]) => [`/case/${caseId}/stage/${stageId}/user`, { userUUID: null }, {
                 headers: User.createHeaders(req.user)
             }])
-            .map(async options => await sendAllocateUserRequest(req, res, options));
+            .map(async options => sendAllocateUserRequest(req, res, options));
         await Promise.all(requests);
     }
     next();


### PR DESCRIPTION
Repoint the calls for `STAGE_WORKSTACK` & `WORKFLOW_WORKSTACK` to a
drilled team endpoint on casework. As we are filtering by teams in
casework the filter on team has been removed.