### PR TITLE
HOCS-4682: doc viewer requests when PDF exists 

### DIFF
--- a/server/lists/adapters/__tests__/__snapshots__/documents.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/documents.spec.js.snap
@@ -6,22 +6,24 @@ Array [
     "type1",
     Array [
       Object {
+        "hasOriginalFile": true,
+        "hasPdf": true,
         "label": "Document A",
-        "labels": undefined,
-        "status": undefined,
+        "status": "PENDING",
         "tags": Array [
-          undefined,
+          "Pending",
         ],
         "timeStamp": "02-01-2019",
         "type": "type1",
         "value": 1,
       },
       Object {
+        "hasOriginalFile": true,
+        "hasPdf": false,
         "label": "Document B",
-        "labels": undefined,
-        "status": undefined,
+        "status": "FAILED_CONVERSION",
         "tags": Array [
-          undefined,
+          "Failed Conversion",
         ],
         "timeStamp": "01-01-2019",
         "type": "type1",
@@ -33,15 +35,28 @@ Array [
     "type2",
     Array [
       Object {
+        "hasOriginalFile": false,
+        "hasPdf": false,
         "label": "Document C",
-        "labels": undefined,
-        "status": undefined,
+        "status": "FAILED_VIRUS",
         "tags": Array [
-          undefined,
+          "Failed Virus Scan",
         ],
         "timeStamp": "03-01-2019",
         "type": "type2",
         "value": 3,
+      },
+      Object {
+        "hasOriginalFile": false,
+        "hasPdf": false,
+        "label": "Document D",
+        "status": "INVALID",
+        "tags": Array [
+          "INVALID",
+        ],
+        "timeStamp": "01-01-2019",
+        "type": "type2",
+        "value": 4,
       },
     ],
   ],

--- a/server/lists/adapters/__tests__/documents.spec.js
+++ b/server/lists/adapters/__tests__/documents.spec.js
@@ -12,9 +12,10 @@ describe('Documents Adapter', () => {
     it('should transform document data and sort by creation date descending', async () => {
         const mockData = {
             documents: [
-                { created: '02-01-2019', displayName: 'Document A', type: 'type1', uuid: 1 },
-                { created: '01-01-2019', displayName: 'Document B', type: 'type1', uuid: 2 },
-                { created: '03-01-2019', displayName: 'Document C', type: 'type2', uuid: 3 },
+                { created: '02-01-2019', displayName: 'Document A', type: 'type1', uuid: 1, status: 'PENDING', hasPdf: true, hasOriginalFile: true },
+                { created: '01-01-2019', displayName: 'Document B', type: 'type1', uuid: 2, status: 'FAILED_CONVERSION', hasPdf: false, hasOriginalFile: true },
+                { created: '03-01-2019', displayName: 'Document C', type: 'type2', uuid: 3, status: 'FAILED_VIRUS', hasPdf: false, hasOriginalFile: false },
+                { created: '01-01-2019', displayName: 'Document D', type: 'type2', uuid: 4, status: 'INVALID', hasPdf: false, hasOriginalFile: false },
             ],
             documentTags: ['type1', 'type2', 'type3']
         };

--- a/server/lists/adapters/documents.js
+++ b/server/lists/adapters/documents.js
@@ -17,23 +17,48 @@ module.exports = async (data, { logger }) => {
         }
     };
 
+    const translateDocumentStatus = (status) => {
+        const statusMap = {
+            PENDING: 'Pending',
+            FAILED_VIRUS: 'Failed Virus Scan',
+            FAILED_CONVERSION: 'Failed Conversion'
+        };
+
+        if (status === 'UPLOADED') {
+            return;
+        }
+
+        const mappedStatus = statusMap[status];
+        if (!mappedStatus) {
+            logger.warn('REQUEST_CASE_DOCUMENTS', { message: `Unmapped status found: ${status}` });
+        }
+
+        return mappedStatus ?? status;
+    };
+
+    const generateTags = (labels, status) => {
+        const tags = [];
+
+        const translatedStatus = translateDocumentStatus(status);
+        if (translatedStatus) {
+            tags.push(translatedStatus);
+        }
+
+        tags.concat(labels ?? []);
+        return tags;
+    };
+
     return [...data.documents
-        .map(({ displayName, uuid, created, status, type, labels }) => {
-            var tags = [];
-            if (status !== 'UPLOADED') {
-                tags.push(status);
-            }
-            if (labels) {
-                tags = tags.concat(labels);
-            }
+        .map(({ displayName, uuid, created, status, type, labels, hasPdf, hasOriginalFile }) => {
             return {
                 label: displayName,
                 status,
-                tags,
                 timeStamp: created,
                 type,
                 value: uuid,
-                labels
+                tags: generateTags(labels, status),
+                hasPdf,
+                hasOriginalFile
             };
         })
         .reduce(reduceDocumentsByType, new Map(data.documentTags.map(label => [label, []])))]

--- a/src/shared/common/components/__tests__/__snapshots__/document-list.spec.jsx.snap
+++ b/src/shared/common/components/__tests__/__snapshots__/document-list.spec.jsx.snap
@@ -444,6 +444,30 @@ Array [
           </a>
         </td>
       </tr>
+      <tr
+        class="govuk-table__row"
+      >
+        <td
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          TEST_DOCUMENT_13
+        </td>
+        <td
+          class="govuk-table__cell govuk-!-width-one-quarter"
+        >
+          <strong
+            class="govuk-tag margin-right--small"
+          >
+            INVALID
+          </strong>
+        </td>
+        <td
+          class="govuk-table__cell"
+        />
+        <td
+          class="govuk-table__cell"
+        />
+      </tr>
     </tbody>
   </table>,
 ]

--- a/src/shared/common/components/__tests__/__snapshots__/document-list.spec.jsx.snap
+++ b/src/shared/common/components/__tests__/__snapshots__/document-list.spec.jsx.snap
@@ -71,15 +71,6 @@ Array [
           TEST_DOCUMENT_1
         </td>
         <td
-          class="govuk-table__cell govuk-!-width-one-quarter"
-        >
-          <strong
-            class="govuk-tag margin-right--small"
-          >
-            UPLOADED
-          </strong>
-        </td>
-        <td
           class="govuk-table__cell"
         >
           <a
@@ -116,20 +107,12 @@ Array [
           <strong
             class="govuk-tag margin-right--small"
           >
-            UPLOADED
+            Failed Conversion
           </strong>
         </td>
         <td
           class="govuk-table__cell"
-        >
-          <a
-            class="govuk-link"
-            href="/case/MOCK_CASE_ID/stage/undefined/download/document/MOCK_DOC_ID_2/pdf"
-            id="MOCK_DOC_ID_2-pdf"
-          >
-            Preview
-          </a>
-        </td>
+        />
         <td
           class="govuk-table__cell"
         >
@@ -156,7 +139,7 @@ Array [
           <strong
             class="govuk-tag margin-right--small"
           >
-            PENDING
+            Failed Virus
           </strong>
         </td>
         <td
@@ -165,6 +148,32 @@ Array [
         <td
           class="govuk-table__cell"
         />
+      </tr>
+      <tr
+        class="govuk-table__row"
+      >
+        <td
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          TEST_DOCUMENT_4
+        </td>
+        <td
+          class="govuk-table__cell govuk-!-width-one-quarter"
+        />
+        <td
+          class="govuk-table__cell"
+        />
+        <td
+          class="govuk-table__cell"
+        >
+          <a
+            class="govuk-link"
+            download="TEST_DOCUMENT_4"
+            href="/case/MOCK_CASE_ID/stage/undefined/download/document/MOCK_DOC_ID_4/original"
+          >
+            Download
+          </a>
+        </td>
       </tr>
     </tbody>
   </table>,
@@ -185,56 +194,7 @@ Array [
         <td
           class="govuk-table__cell govuk-!-width-full"
         >
-          TEST_DOCUMENT_4
-        </td>
-        <td
-          class="govuk-table__cell govuk-!-width-one-quarter"
-        >
-          <strong
-            class="govuk-tag margin-right--small"
-          >
-            UPLOADED
-          </strong>
-        </td>
-        <td
-          class="govuk-table__cell"
-        >
-          <a
-            class="govuk-link"
-            href="/case/MOCK_CASE_ID/stage/undefined/download/document/MOCK_DOC_ID_4/pdf"
-            id="MOCK_DOC_ID_4-pdf"
-          >
-            Preview
-          </a>
-        </td>
-        <td
-          class="govuk-table__cell"
-        >
-          <a
-            class="govuk-link"
-            download="TEST_DOCUMENT_4"
-            href="/case/MOCK_CASE_ID/stage/undefined/download/document/MOCK_DOC_ID_4/original"
-          >
-            Download
-          </a>
-        </td>
-      </tr>
-      <tr
-        class="govuk-table__row"
-      >
-        <td
-          class="govuk-table__cell govuk-!-width-full"
-        >
           TEST_DOCUMENT_5
-        </td>
-        <td
-          class="govuk-table__cell govuk-!-width-one-quarter"
-        >
-          <strong
-            class="govuk-tag margin-right--small"
-          >
-            UPLOADED
-          </strong>
         </td>
         <td
           class="govuk-table__cell"
@@ -273,20 +233,12 @@ Array [
           <strong
             class="govuk-tag margin-right--small"
           >
-            UPLOADED
+            Failed Conversion
           </strong>
         </td>
         <td
           class="govuk-table__cell"
-        >
-          <a
-            class="govuk-link"
-            href="/case/MOCK_CASE_ID/stage/undefined/download/document/MOCK_DOC_ID_6/pdf"
-            id="MOCK_DOC_ID_6-pdf"
-          >
-            Preview
-          </a>
-        </td>
+        />
         <td
           class="govuk-table__cell"
         >
@@ -294,6 +246,62 @@ Array [
             class="govuk-link"
             download="TEST_DOCUMENT_6"
             href="/case/MOCK_CASE_ID/stage/undefined/download/document/MOCK_DOC_ID_6/original"
+          >
+            Download
+          </a>
+        </td>
+      </tr>
+      <tr
+        class="govuk-table__row"
+      >
+        <td
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          TEST_DOCUMENT_7
+        </td>
+        <td
+          class="govuk-table__cell govuk-!-width-one-quarter"
+        >
+          <strong
+            class="govuk-tag margin-right--small"
+          >
+            Failed Virus
+          </strong>
+        </td>
+        <td
+          class="govuk-table__cell"
+        />
+        <td
+          class="govuk-table__cell"
+        />
+      </tr>
+      <tr
+        class="govuk-table__row"
+      >
+        <td
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          TEST_DOCUMENT_8
+        </td>
+        <td
+          class="govuk-table__cell govuk-!-width-one-quarter"
+        >
+          <strong
+            class="govuk-tag margin-right--small"
+          >
+            Pending
+          </strong>
+        </td>
+        <td
+          class="govuk-table__cell"
+        />
+        <td
+          class="govuk-table__cell"
+        >
+          <a
+            class="govuk-link"
+            download="TEST_DOCUMENT_8"
+            href="/case/MOCK_CASE_ID/stage/undefined/download/document/MOCK_DOC_ID_8/original"
           >
             Download
           </a>
@@ -318,24 +326,15 @@ Array [
         <td
           class="govuk-table__cell govuk-!-width-full"
         >
-          TEST_DOCUMENT_7
-        </td>
-        <td
-          class="govuk-table__cell govuk-!-width-one-quarter"
-        >
-          <strong
-            class="govuk-tag margin-right--small"
-          >
-            UPLOADED
-          </strong>
+          TEST_DOCUMENT_9
         </td>
         <td
           class="govuk-table__cell"
         >
           <a
             class="govuk-link"
-            href="/case/MOCK_CASE_ID/stage/undefined/download/document/MOCK_DOC_ID_7/pdf"
-            id="MOCK_DOC_ID_7-pdf"
+            href="/case/MOCK_CASE_ID/stage/undefined/download/document/MOCK_DOC_ID_9/pdf"
+            id="MOCK_DOC_ID_9-pdf"
           >
             Preview
           </a>
@@ -345,8 +344,8 @@ Array [
         >
           <a
             class="govuk-link"
-            download="TEST_DOCUMENT_7"
-            href="/case/MOCK_CASE_ID/stage/undefined/download/document/MOCK_DOC_ID_7/original"
+            download="TEST_DOCUMENT_9"
+            href="/case/MOCK_CASE_ID/stage/undefined/download/document/MOCK_DOC_ID_9/original"
           >
             Download
           </a>
@@ -358,7 +357,7 @@ Array [
         <td
           class="govuk-table__cell govuk-!-width-full"
         >
-          TEST_DOCUMENT_8
+          TEST_DOCUMENT_10
         </td>
         <td
           class="govuk-table__cell govuk-!-width-one-quarter"
@@ -366,7 +365,39 @@ Array [
           <strong
             class="govuk-tag margin-right--small"
           >
-            PENDING
+            Failed Conversion
+          </strong>
+        </td>
+        <td
+          class="govuk-table__cell"
+        />
+        <td
+          class="govuk-table__cell"
+        >
+          <a
+            class="govuk-link"
+            download="TEST_DOCUMENT_10"
+            href="/case/MOCK_CASE_ID/stage/undefined/download/document/MOCK_DOC_ID_10/original"
+          >
+            Download
+          </a>
+        </td>
+      </tr>
+      <tr
+        class="govuk-table__row"
+      >
+        <td
+          class="govuk-table__cell govuk-!-width-full"
+        >
+          TEST_DOCUMENT_11
+        </td>
+        <td
+          class="govuk-table__cell govuk-!-width-one-quarter"
+        >
+          <strong
+            class="govuk-tag margin-right--small"
+          >
+            Failed Virus
           </strong>
         </td>
         <td
@@ -382,7 +413,7 @@ Array [
         <td
           class="govuk-table__cell govuk-!-width-full"
         >
-          TEST_DOCUMENT_9
+          TEST_DOCUMENT_12
         </td>
         <td
           class="govuk-table__cell govuk-!-width-one-quarter"
@@ -390,7 +421,12 @@ Array [
           <strong
             class="govuk-tag margin-right--small"
           >
-            PENDING
+            UNKNOWN
+          </strong>
+          <strong
+            class="govuk-tag margin-right--small"
+          >
+            Pending
           </strong>
         </td>
         <td
@@ -398,7 +434,15 @@ Array [
         />
         <td
           class="govuk-table__cell"
-        />
+        >
+          <a
+            class="govuk-link"
+            download="TEST_DOCUMENT_12"
+            href="/case/MOCK_CASE_ID/stage/undefined/download/document/MOCK_DOC_ID_12/original"
+          >
+            Download
+          </a>
+        </td>
       </tr>
     </tbody>
   </table>,

--- a/src/shared/common/components/__tests__/document-list.spec.jsx
+++ b/src/shared/common/components/__tests__/document-list.spec.jsx
@@ -20,6 +20,7 @@ describe('Document list component', () => {
             { label: 'TEST_DOCUMENT_10', value: 'MOCK_DOC_ID_10', status: 'FAILED_CONVERSION', tags: ['Failed Conversion'], hasPdf: false, hasOriginalFile: true },
             { label: 'TEST_DOCUMENT_11', value: 'MOCK_DOC_ID_11', status: 'FAILED_VIRUS',  tags: ['Failed Virus'], hasPdf: false, hasOriginalFile: false },
             { label: 'TEST_DOCUMENT_12', value: 'MOCK_DOC_ID_12', status: 'PENDING', tags: ['UNKNOWN', 'Pending'], hasPdf: false, hasOriginalFile: true },
+            { label: 'TEST_DOCUMENT_13', value: 'MOCK_DOC_ID_13', status: 'INVALID', tags: ['INVALID'], hasPdf: false, hasOriginalFile: false },
         ]]
     ];
 

--- a/src/shared/common/components/__tests__/document-list.spec.jsx
+++ b/src/shared/common/components/__tests__/document-list.spec.jsx
@@ -5,17 +5,21 @@ describe('Document list component', () => {
 
     const documentList = [
         ['group 1', [
-            { label: 'TEST_DOCUMENT_1', value: 'MOCK_DOC_ID_1', status: 'UPLOADED', tags: ['UPLOADED'] },
-            { label: 'TEST_DOCUMENT_2', value: 'MOCK_DOC_ID_2', status: 'UPLOADED', tags: ['UPLOADED'] },
-            { label: 'TEST_DOCUMENT_3', value: 'MOCK_DOC_ID_3', status: 'PENDING', tags: ['PENDING'] },
+            { label: 'TEST_DOCUMENT_1', value: 'MOCK_DOC_ID_1', status: 'UPLOADED', hasPdf: true, hasOriginalFile: true },
+            { label: 'TEST_DOCUMENT_2', value: 'MOCK_DOC_ID_2', status: 'FAILED_CONVERSION', tags: ['Failed Conversion'], hasPdf: false, hasOriginalFile: true },
+            { label: 'TEST_DOCUMENT_3', value: 'MOCK_DOC_ID_3', status: 'FAILED_VIRUS', tags: ['Failed Virus'], hasPdf: false, hasOriginalFile: false },
+            { label: 'TEST_DOCUMENT_4', value: 'MOCK_DOC_ID_4', status: 'PENDING', tags: [], hasPdf: false, hasOriginalFile: true },
+
         ]], ['group 2', [
-            { label: 'TEST_DOCUMENT_4', value: 'MOCK_DOC_ID_4', status: 'UPLOADED', tags: ['UPLOADED'] },
-            { label: 'TEST_DOCUMENT_5', value: 'MOCK_DOC_ID_5', status: 'UPLOADED', tags: ['UPLOADED'] },
-            { label: 'TEST_DOCUMENT_6', value: 'MOCK_DOC_ID_6', status: 'UPLOADED', tags: ['UPLOADED'] },
+            { label: 'TEST_DOCUMENT_5', value: 'MOCK_DOC_ID_5', status: 'UPLOADED', hasPdf: true, hasOriginalFile: true },
+            { label: 'TEST_DOCUMENT_6', value: 'MOCK_DOC_ID_6', status: 'FAILED_CONVERSION', tags: ['Failed Conversion'], hasPdf: false, hasOriginalFile: true },
+            { label: 'TEST_DOCUMENT_7', value: 'MOCK_DOC_ID_7', status: 'FAILED_VIRUS', tags: ['Failed Virus'], hasPdf: false, hasOriginalFile: false },
+            { label: 'TEST_DOCUMENT_8', value: 'MOCK_DOC_ID_8', status: 'PENDING', tags: ['Pending'], hasPdf: false, hasOriginalFile: true },
         ]], ['group 3', [
-            { label: 'TEST_DOCUMENT_7', value: 'MOCK_DOC_ID_7', status: 'UPLOADED', tags: ['UPLOADED'] },
-            { label: 'TEST_DOCUMENT_8', value: 'MOCK_DOC_ID_8', status: 'PENDING', tags: ['PENDING'] },
-            { label: 'TEST_DOCUMENT_9', value: 'MOCK_DOC_ID_9', status: 'PENDING', tags: ['PENDING'] },
+            { label: 'TEST_DOCUMENT_9', value: 'MOCK_DOC_ID_9', status: 'UPLOADED', hasPdf: true, hasOriginalFile: true },
+            { label: 'TEST_DOCUMENT_10', value: 'MOCK_DOC_ID_10', status: 'FAILED_CONVERSION', tags: ['Failed Conversion'], hasPdf: false, hasOriginalFile: true },
+            { label: 'TEST_DOCUMENT_11', value: 'MOCK_DOC_ID_11', status: 'FAILED_VIRUS',  tags: ['Failed Virus'], hasPdf: false, hasOriginalFile: false },
+            { label: 'TEST_DOCUMENT_12', value: 'MOCK_DOC_ID_12', status: 'PENDING', tags: ['UNKNOWN', 'Pending'], hasPdf: false, hasOriginalFile: true },
         ]]
     ];
 

--- a/src/shared/common/components/document-list.jsx
+++ b/src/shared/common/components/document-list.jsx
@@ -22,7 +22,7 @@ class DocumentList extends Component {
                         <table className='govuk-table'>
                             <tbody className='govuk-table__body'>
                                 {
-                                    caseId && Array.isArray(groupedDocuments) && groupedDocuments.map(({ label, status, tags, value }, i) => (
+                                    caseId && Array.isArray(groupedDocuments) && groupedDocuments.map(({ label, tags, value, hasPdf, hasOriginalFile }, i) => (
                                         <tr key={i} className='govuk-table__row'>
                                             <td className='govuk-table__cell govuk-!-width-full'>
                                                 {label}
@@ -36,7 +36,7 @@ class DocumentList extends Component {
                                             </td>
                                             }
                                             <td className='govuk-table__cell'>
-                                                {value && status === 'UPLOADED' && caseId && activeDocument !== value &&
+                                                {value && hasPdf && caseId && activeDocument !== value &&
                                                     <a
                                                         id={`${value}-pdf`}
                                                         href={`/case/${caseId}/stage/${stageId}/download/document/${value}/pdf`}
@@ -48,7 +48,7 @@ class DocumentList extends Component {
                                                 }
                                             </td>
                                             <td className='govuk-table__cell'>
-                                                {value && status === 'UPLOADED' && caseId &&
+                                                {value && hasOriginalFile && caseId &&
                                                     <a
                                                         href={`/case/${caseId}/stage/${stageId}/download/document/${value}/original`}
                                                         className='govuk-link'

--- a/src/shared/common/components/document-pane.jsx
+++ b/src/shared/common/components/document-pane.jsx
@@ -12,7 +12,7 @@ import status from '../../helpers/api-status.js';
 import { Link } from 'react-router-dom';
 import {
     flattenDocuments,
-    getFirstDocument,
+    getFirstDocumentWithPdfLink,
     hasPendingDocuments
 } from '../../helpers/document-helpers';
 
@@ -23,7 +23,7 @@ class DocumentPanel extends Component {
         super(props);
         let activeDocument;
         if (props.documents && props.documents.length > 0) {
-            activeDocument = getFirstDocument(flattenDocuments(props.documents));
+            activeDocument = getFirstDocumentWithPdfLink(flattenDocuments(props.documents));
         }
         this.state = { ...props, activeDocument };
     }
@@ -57,7 +57,7 @@ class DocumentPanel extends Component {
                                         this.setState((currentState) => ({
                                             ...currentState,
                                             documents: response.data,
-                                            activeDocument: currentState.activeDocument || getFirstDocument(allDocuments)
+                                            activeDocument: currentState.activeDocument || getFirstDocumentWithPdfLink(allDocuments)
                                         }));
                                         if (!hasPendingDocuments(allDocuments)) {
                                             if (this.interval) {

--- a/src/shared/helpers/__tests__/document-helpers.spec.js
+++ b/src/shared/helpers/__tests__/document-helpers.spec.js
@@ -1,22 +1,22 @@
 import {
     flattenDocuments,
-    getFirstDocument,
+    getFirstDocumentWithPdfLink,
     hasPendingDocuments
 } from '../document-helpers';
 
 const documentList = [
     ['group 1', [
-        { label: 'TEST_DOCUMENT_1', value: 'MOCK_DOC_ID_1', status: 'UPLOADED' },
-        { label: 'TEST_DOCUMENT_2', value: 'MOCK_DOC_ID_2', status: 'UPLOADED' },
-        { label: 'TEST_DOCUMENT_3', value: 'MOCK_DOC_ID_3', status: 'PENDING' },
+        { label: 'TEST_DOCUMENT_1', value: 'MOCK_DOC_ID_1', status: 'UPLOADED', hasPdf: true, hasOriginalFile: true },
+        { label: 'TEST_DOCUMENT_2', value: 'MOCK_DOC_ID_2', status: 'UPLOADED', hasPdf: true, hasOriginalFile: true },
+        { label: 'TEST_DOCUMENT_3', value: 'MOCK_DOC_ID_3', status: 'PENDING', hasPdf: false, hasOriginalFile: true },
     ]], ['group 2', [
-        { label: 'TEST_DOCUMENT_4', value: 'MOCK_DOC_ID_4', status: 'UPLOADED' },
-        { label: 'TEST_DOCUMENT_5', value: 'MOCK_DOC_ID_5', status: 'UPLOADED' },
-        { label: 'TEST_DOCUMENT_6', value: 'MOCK_DOC_ID_6', status: 'UPLOADED' },
+        { label: 'TEST_DOCUMENT_4', value: 'MOCK_DOC_ID_4', status: 'UPLOADED', hasPdf: true, hasOriginalFile: true },
+        { label: 'TEST_DOCUMENT_5', value: 'MOCK_DOC_ID_5', status: 'UPLOADED', hasPdf: true, hasOriginalFile: true },
+        { label: 'TEST_DOCUMENT_6', value: 'MOCK_DOC_ID_6', status: 'UPLOADED', hasPdf: true, hasOriginalFile: true },
     ]], ['group 3', [
-        { label: 'TEST_DOCUMENT_7', value: 'MOCK_DOC_ID_7', status: 'UPLOADED' },
-        { label: 'TEST_DOCUMENT_8', value: 'MOCK_DOC_ID_8', status: 'PENDING' },
-        { label: 'TEST_DOCUMENT_9', value: 'MOCK_DOC_ID_9', status: 'PENDING' },
+        { label: 'TEST_DOCUMENT_7', value: 'MOCK_DOC_ID_7', status: 'UPLOADED', hasPdf: true, hasOriginalFile: true },
+        { label: 'TEST_DOCUMENT_8', value: 'MOCK_DOC_ID_8', status: 'PENDING', hasPdf: false, hasOriginalFile: false },
+        { label: 'TEST_DOCUMENT_9', value: 'MOCK_DOC_ID_9', status: 'PENDING', hasPdf: false, hasOriginalFile: true },
     ]]
 ];
 
@@ -24,47 +24,65 @@ const flattenedDocuments = [
     {
         'label': 'TEST_DOCUMENT_1',
         'status': 'UPLOADED',
-        'value': 'MOCK_DOC_ID_1'
+        'value': 'MOCK_DOC_ID_1',
+        'hasPdf': true,
+        'hasOriginalFile': true,
     },
     {
         'label': 'TEST_DOCUMENT_2',
         'status': 'UPLOADED',
-        'value': 'MOCK_DOC_ID_2'
+        'value': 'MOCK_DOC_ID_2',
+        'hasPdf': true,
+        'hasOriginalFile': true
     },
     {
         'label': 'TEST_DOCUMENT_3',
         'status': 'PENDING',
-        'value': 'MOCK_DOC_ID_3'
+        'value': 'MOCK_DOC_ID_3',
+        'hasPdf': false,
+        'hasOriginalFile': true
     },
     {
         'label': 'TEST_DOCUMENT_4',
         'status': 'UPLOADED',
-        'value': 'MOCK_DOC_ID_4'
+        'value': 'MOCK_DOC_ID_4',
+        'hasPdf': true,
+        'hasOriginalFile': true
     },
     {
         'label': 'TEST_DOCUMENT_5',
         'status': 'UPLOADED',
-        'value': 'MOCK_DOC_ID_5'
+        'value': 'MOCK_DOC_ID_5',
+        'hasPdf': true,
+        'hasOriginalFile': true
     },
     {
         'label': 'TEST_DOCUMENT_6',
         'status': 'UPLOADED',
-        'value': 'MOCK_DOC_ID_6'
+        'value': 'MOCK_DOC_ID_6',
+        'hasPdf': true,
+        'hasOriginalFile': true
     },
     {
         'label': 'TEST_DOCUMENT_7',
         'status': 'UPLOADED',
-        'value': 'MOCK_DOC_ID_7'
+        'value': 'MOCK_DOC_ID_7',
+        'hasPdf': true,
+        'hasOriginalFile': true
     },
     {
         'label': 'TEST_DOCUMENT_8',
         'status': 'PENDING',
-        'value': 'MOCK_DOC_ID_8'
+        'value': 'MOCK_DOC_ID_8',
+        'hasPdf': false,
+        'hasOriginalFile': false
     },
     {
         'label': 'TEST_DOCUMENT_9',
         'status': 'PENDING',
-        'value': 'MOCK_DOC_ID_9'
+        'value': 'MOCK_DOC_ID_9',
+        'hasPdf': false,
+        'hasOriginalFile': true
     }
 ];
 
@@ -86,16 +104,16 @@ describe('DocumentPanelHelpers', () => {
 
     describe('getFirstDocument', () => {
         it('returns undefined when called with invalid value', () => {
-            expect(getFirstDocument([])).toStrictEqual(undefined);
-            expect(getFirstDocument('test')).toStrictEqual(undefined);
-            expect(getFirstDocument(null)).toStrictEqual(undefined);
-            expect(getFirstDocument(123)).toStrictEqual(undefined);
-            expect(getFirstDocument(undefined)).toStrictEqual(undefined);
-            expect(getFirstDocument()).toStrictEqual(undefined);
+            expect(getFirstDocumentWithPdfLink([])).toStrictEqual(undefined);
+            expect(getFirstDocumentWithPdfLink('test')).toStrictEqual(undefined);
+            expect(getFirstDocumentWithPdfLink(null)).toStrictEqual(undefined);
+            expect(getFirstDocumentWithPdfLink(123)).toStrictEqual(undefined);
+            expect(getFirstDocumentWithPdfLink(undefined)).toStrictEqual(undefined);
+            expect(getFirstDocumentWithPdfLink()).toStrictEqual(undefined);
         });
 
         it('returns a flat array of documents when called with a valid value', () => {
-            expect(getFirstDocument(flattenedDocuments)).toStrictEqual('MOCK_DOC_ID_1');
+            expect(getFirstDocumentWithPdfLink(flattenedDocuments)).toStrictEqual('MOCK_DOC_ID_1');
         });
     });
 

--- a/src/shared/helpers/document-helpers.js
+++ b/src/shared/helpers/document-helpers.js
@@ -10,10 +10,12 @@ const flattenDocuments = (documents) => {
     return [];
 };
 
-const getFirstDocument = (flatDocumentList) => {
+const getFirstDocumentWithPdfLink = (flatDocumentList) => {
     if (Array.isArray(flatDocumentList)) {
-        const { value: firstDocument } = flatDocumentList.filter(({ status }) => status !== 'PENDING')[0] || { value: undefined };
-        return firstDocument;
+        const firstDocument = flatDocumentList
+            .filter(({ hasPdf }) => hasPdf)
+            .shift();
+        return firstDocument?.value;
     }
     return undefined;
 };
@@ -27,7 +29,6 @@ const hasPendingDocuments = (documents) => {
 
 export {
     flattenDocuments,
-    getFirstDocument,
+    getFirstDocumentWithPdfLink,
     hasPendingDocuments
 };
-


### PR DESCRIPTION
When we load the documents page - even if a PDF does not exist (not
PENDING) it requests the file. This change ensures that only when a PDF
link exists we request the preview of the first matching document.

Currently, the backend status code is added to the tags that are
appending to the user display. This means that documents that fail virus
scan have `FAILED_VIRUS` displayed to the user within tags.
This change converts the status to a human-readable display - for the
above example `FAILED_VIRUS` -> `Failed Virus Scan`.