### PR TITLE
Hocs-4696: replace deploy by SHA with TAG

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -297,7 +297,7 @@ steps:
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     environment:
       ENVIRONMENT: cs-dev
-      VERSION: "${DRONE_COMMIT_SHA}"
+      VERSION: "${DRONE_TAG}"
       KUBE_TOKEN:
         from_secret: hocs_frontend_cs_dev
       POISE_IPS:
@@ -312,7 +312,7 @@ steps:
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     environment:
       ENVIRONMENT: wcs-dev
-      VERSION: "${DRONE_COMMIT_SHA}"
+      VERSION: "${DRONE_TAG}"
       KUBE_TOKEN:
         from_secret: hocs_frontend_wcs_dev
       POISE_IPS:


### PR DESCRIPTION
This commit correct an omission from the previous 4696 commit, deploy to dev using the tag not the sha.