### PR TITLE
HOCS-4775: rename document list

### DIFF
--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -561,7 +561,7 @@ module.exports = {
         },
         CASE_DOCUMENT_LIST_INTERIM_LETTERS: {
             client: 'CASEWORK',
-            endpoint: '/case/document/reference/${caseId}/?type=Interim%20Letters',
+            endpoint: '/case/document/reference/${caseId}/?type=Interim%20Letter',
             adapter: documentListAdapter
         },
         CASE_DOCUMENT_TAGS: {


### PR DESCRIPTION
Rename of the endpoint for the CASE_DOCUMENT_LIST_INTERIM_LETTERS to the
 plural type of `Interim Letter`