### PR TITLE
HOCS-4774: pass through labels to document

### DIFF
--- a/server/lists/adapters/__tests__/__snapshots__/documents.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/documents.spec.js.snap
@@ -29,6 +29,19 @@ Array [
         "type": "type1",
         "value": 2,
       },
+      Object {
+        "hasOriginalFile": false,
+        "hasPdf": false,
+        "label": "Document E",
+        "status": "PENDING",
+        "tags": Array [
+          "Pending",
+          "Test Label",
+        ],
+        "timeStamp": "01-01-2019",
+        "type": "type1",
+        "value": 5,
+      },
     ],
   ],
   Array [

--- a/server/lists/adapters/__tests__/documents.spec.js
+++ b/server/lists/adapters/__tests__/documents.spec.js
@@ -14,8 +14,9 @@ describe('Documents Adapter', () => {
             documents: [
                 { created: '02-01-2019', displayName: 'Document A', type: 'type1', uuid: 1, status: 'PENDING', hasPdf: true, hasOriginalFile: true },
                 { created: '01-01-2019', displayName: 'Document B', type: 'type1', uuid: 2, status: 'FAILED_CONVERSION', hasPdf: false, hasOriginalFile: true },
-                { created: '03-01-2019', displayName: 'Document C', type: 'type2', uuid: 3, status: 'FAILED_VIRUS', hasPdf: false, hasOriginalFile: false },
-                { created: '01-01-2019', displayName: 'Document D', type: 'type2', uuid: 4, status: 'INVALID', hasPdf: false, hasOriginalFile: false },
+                { created: '03-01-2019', displayName: 'Document C', type: 'type2', uuid: 3, status: 'FAILED_VIRUS', labels: [], hasPdf: false, hasOriginalFile: false },
+                { created: '01-01-2019', displayName: 'Document D', type: 'type2', uuid: 4, status: 'INVALID', labels: undefined, hasPdf: false, hasOriginalFile: false },
+                { created: '01-01-2019', displayName: 'Document E', type: 'type1', uuid: 5, status: 'PENDING', labels: ['Test Label'], hasPdf: false, hasOriginalFile: false }
             ],
             documentTags: ['type1', 'type2', 'type3']
         };

--- a/server/lists/adapters/documents.js
+++ b/server/lists/adapters/documents.js
@@ -44,8 +44,7 @@ module.exports = async (data, { logger }) => {
             tags.push(translatedStatus);
         }
 
-        tags.concat(labels ?? []);
-        return tags;
+        return tags.concat(labels ?? []);
     };
 
     return [...data.documents


### PR DESCRIPTION
[].concat returns a new label and does not modify the existing arrays
that are merged. This change returns the value of the concat.