### PR TITLE
HOCS-4808: support tagging on support branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -155,6 +155,7 @@ trigger:
     - tag
   branch:
     - main
+    - support/*
 
 steps:
   - name: install dependencies
@@ -199,6 +200,28 @@ steps:
     depends_on:
       - build project
       - test project
+    when:
+      branch:
+        - main
+
+  - name: build & push tag
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/ukhomeofficedigital/hocs-frontend
+      tags:
+        - ${DRONE_TAG}
+        - ${DRONE_COMMIT_SHA}
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    depends_on:
+      - build project
+      - test project
+    when:
+      branch:
+        - support/*
 
 ---
 kind: pipeline


### PR DESCRIPTION
To support hotfixing this change allows the for a build and tag step to
be run on support branches aswell.