### PR TITLE
HOCS-4837 Add matrix to test against latest-LTS of NodeJS as well as prod version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,26 +11,27 @@ trigger:
 
 steps:
   - name: install dependencies
-    image: node:14.15.4-alpine
+    image: &node-version
+      node:14.15.4-alpine
     commands:
       - npm --loglevel warn install --production=false --no-optional
 
   - name: build project
-    image: node:14.15.4-alpine
+    image: *node-version
     commands:
       - npm run build-prod
     depends_on:
       - install dependencies
 
   - name: test project
-    image: node:14.15.4-alpine
+    image: *node-version
     commands:
       - npm test
     depends_on:
       - install dependencies
 
   - name: lint project
-    image: node:14.15.4-alpine
+    image: *node-version
     commands:
       - npm run lint
     depends_on:
@@ -159,26 +160,27 @@ trigger:
 
 steps:
   - name: install dependencies
-    image: node:14.15.4-alpine
+    image: &node-version
+      node:14.15.4-alpine
     commands:
       - npm --loglevel warn install --production=false --no-optional
 
   - name: build project
-    image: node:14.15.4-alpine
+    image: *node-version
     commands:
       - npm run build-prod
     depends_on:
       - install dependencies
 
   - name: test project
-    image: node:14.15.4-alpine
+    image: *node-version
     commands:
       - npm test
     depends_on:
       - install dependencies
 
   - name: lint project
-    image: node:14.15.4-alpine
+    image: *node-version
     commands:
       - npm run lint
     depends_on:

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,6 +12,7 @@ trigger:
 steps:
   - name: install dependencies
     image: &node-version
+      # The version we're targeting for production
       node:14.15.4-alpine
     commands:
       - npm --loglevel warn install --production=false --no-optional
@@ -58,6 +59,40 @@ steps:
       - build project
       - test project
       - lint project
+
+---
+kind: pipeline
+type: kubernetes
+name: build-lts
+trigger:
+  event:
+    - push
+  branch:
+    exclude:
+      - main
+
+steps:
+  - name: install dependencies
+    image: &node-version
+      # the latest version of the LTS (prospective production)
+      node:lts-alpine
+    commands:
+      - npm --loglevel warn install --production=false --no-optional
+
+  - name: build project
+    image: *node-version
+    commands:
+      - npm run build-prod
+    depends_on:
+      - install dependencies
+
+  - name: test project
+    image: *node-version
+    failure: ignore # Remove this once we upgrade to LTS 16 (HOCS-4838)
+    commands:
+      - npm test
+    depends_on:
+      - install dependencies
 
 ---
 kind: pipeline


### PR DESCRIPTION
We're currently deploying an explicit version of NodeJS, which will inevitably end up being older than we'd like. This PR  changes our pipeline to also test against the latest LTS release of NodeJS, so that when we update we're definitely sure it'll work.

Most of the time the two builds will be running against the same binary. I considered adding the latest-latest version of NodeJS (at time of writing, Node 18) but I think that added overhead to the build that we don't need to consider: we're not going to upgrade for a few years yet.

This has a "failure: ignore" step on the new pipeline for now, as the LTS version of NodeJS breaks our build. We'll remove it as part of the LTS upgrade work.