### PR TITLE
Allow "skip-release" as a valid pull request label

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -10,5 +10,5 @@ jobs:
     steps:
       - uses: UKHomeOffice/match-label-action@v1.0.0
         with:
-          labels: minor,major,patch
+          labels: minor,major,patch,skip-release
           mode: singular


### PR DESCRIPTION
I have a commit that doesn't contain any code changes, but at the moment
I'm forced to bump a version number for the app even though that doesn't
make sense.

This commit reconfigures the label check to also allow "skip-release", a
label that already exists on this repository.