### PR TITLE
HOCS-4636: add Draft document list to index

### DIFF
--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -582,6 +582,11 @@ module.exports = {
             endpoint: '/case/document/reference/${caseId}/?type=Interim%20Letter',
             adapter: documentListAdapter
         },
+        CASE_DOCUMENT_LIST_POGR_DRAFT: {
+            client: 'CASEWORK',
+            endpoint: '/case/document/reference/${caseId}/?type=Draft',
+            adapter: documentListAdapter
+        },
         CASE_DOCUMENT_TAGS: {
             client: 'CASEWORK',
             endpoint: '/case/${caseId}/documentTags',


### PR DESCRIPTION
Add the Draft document list to the dynamic collection of lists that can
be called at runtime. This list is currently called through POGR to
return all documents with the `Draft` tag associated with it.