### PR TITLE
HOCS-4921: trim case note contents

### DIFF
--- a/server/middleware/__tests__/case.spec.js
+++ b/server/middleware/__tests__/case.spec.js
@@ -13,12 +13,14 @@ jest.mock('../../services/action.js', () => ({
 
 jest.mock('../../clients', () => ({
     caseworkService: {
-        get: jest.fn()
+        get: jest.fn(),
+        post: jest.fn(),
+        put: jest.fn()
     }
 }));
 
 const { caseworkService } = require('../../clients');
-const { caseDataMiddleware } = require('../case');
+const { caseDataMiddleware, createCaseNote, updateCaseNote } = require('../case');
 
 describe('Case middleware', () => {
 
@@ -331,6 +333,141 @@ describe('Case middleware', () => {
             expect(res.locals.correspondents).not.toBeDefined();
             expect(next).toHaveBeenCalled();
             expect(next).toHaveBeenCalledWith(mockError);
+        });
+    });
+
+    describe('createCaseNote', () => {
+        let req = {};
+        let res = {};
+        const next = jest.fn();
+
+        const generateWhitespace = (number) => ''.padEnd(number, ' ');
+
+        beforeEach(() => {
+            req = {
+                params: {
+                    caseId: 'CASE_ID'
+                },
+                user: {
+                    id: 'test',
+                    roles: [],
+                    groups: []
+                },
+                body: {}
+            };
+
+            res = {
+                status: null,
+                locals: {}
+            };
+
+            next.mockReset();
+            caseworkService.post.mockReset();
+        });
+
+        it('should call next with error if caseNote is undefined', async () => {
+            await createCaseNote(req, res, next);
+            expect(next).toHaveBeenCalled();
+            expect(res.locals.error).toEqual('Case note must not be blank');
+        });
+
+
+        it('should call next with error if caseNote is all whitespace', async () => {
+            req.body = { caseNote: generateWhitespace(100000) };
+
+            await createCaseNote(req, res, next);
+            expect(next).toHaveBeenCalled();
+            expect(res.locals.error).toEqual('Case note must not be blank');
+        });
+
+        it('should call next after successful post', async () => {
+            req.body = { caseNote: 'Test' + generateWhitespace(10) };
+
+            caseworkService.post.mockImplementation(() => Promise.resolve({ data: 'MOCK_SUMMARY' }));
+            await createCaseNote(req, res, next);
+
+            expect(caseworkService.post.mock.calls.length).toEqual(1);
+            // The request param of the first call
+            expect(caseworkService.post.mock.calls[0][1]).toEqual({ 'text': 'Test', 'type': 'MANUAL' });
+            expect(next).toHaveBeenCalled();
+        });
+
+        it('should call next with error if failed to add note', async () => {
+            req.body = { caseNote: 'Test' };
+
+            caseworkService.post.mockImplementation(() => Promise.reject({ data: 'MOCK_SUMMARY' }));
+            await createCaseNote(req, res, next);
+
+            expect(next).toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith(new Error('Failed to attach case note to case CASE_ID'));
+        });
+    });
+
+    describe('updateCaseNote', () => {
+        let req = {};
+        let res = {};
+        const next = jest.fn();
+
+        const generateWhitespace = (number) => ''.padEnd(number, ' ');
+
+        beforeEach(() => {
+            req = {
+                params: {
+                    caseId: 'CASE_ID',
+                    noteId: 'NOTE_ID'
+                },
+                user: {
+                    id: 'test',
+                    roles: [],
+                    groups: []
+                },
+                body: {}
+            };
+
+            res = {
+                status: null,
+                locals: {}
+            };
+
+            next.mockReset();
+            caseworkService.put.mockReset();
+        });
+
+        it('should call next with error if caseNote is undefined', async () => {
+            await updateCaseNote(req, res, next);
+            expect(next).toHaveBeenCalled();
+            expect(res.locals.error).toEqual('Case note must not be blank');
+        });
+
+
+        it('should call next with error if caseNote is all whitespace', async () => {
+            req.body = { caseNote: generateWhitespace(100000) };
+
+            await updateCaseNote(req, res, next);
+            expect(next).toHaveBeenCalled();
+            expect(res.locals.error).toEqual('Case note must not be blank');
+        });
+
+        it('should call next after successful post', async () => {
+            req.body = { caseNote: 'Test' + generateWhitespace(10) };
+
+            caseworkService.put.mockImplementation(() => Promise.resolve({ data: 'MOCK_SUMMARY' }));
+            await updateCaseNote(req, res, next);
+
+            expect(caseworkService.put.mock.calls.length).toEqual(1);
+            // The request param of the first call
+            expect(caseworkService.put.mock.calls[0][1]).toEqual({ 'text': 'Test', 'type': 'MANUAL' });
+            expect(next).toHaveBeenCalled();
+        });
+
+        it('should call next with error if failed to add note', async () => {
+            req.body = { caseNote: 'Test' };
+
+            caseworkService.put.mockImplementation(() => Promise.reject({ data: 'MOCK_SUMMARY' }));
+            await updateCaseNote(req, res, next);
+
+            expect(next).toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith(new Error('Failed to update case note NOTE_ID on case CASE_ID'));
         });
     });
 

--- a/server/middleware/case.js
+++ b/server/middleware/case.js
@@ -59,33 +59,37 @@ function caseDataApiResponseMiddleware(req, res) {
 
 async function createCaseNote(req, res, next) {
     try {
-        if (!req.body.caseNote) {
+        const caseNote = req.body.caseNote?.trim();
+        if (!caseNote) {
             res.locals.error = 'Case note must not be blank';
             next();
         }
+
         await caseworkService.post(`/case/${req.params.caseId}/note`, {
-            text: req.body.caseNote,
+            text: caseNote,
             type: 'MANUAL'
         }, { headers: User.createHeaders(req.user) });
     } catch (error) {
-        next(new Error(`Failed to attach case note to case ${req.params.caseId} `));
+        next(new Error(`Failed to attach case note to case ${req.params.caseId}`));
     }
     next();
 }
 
 async function updateCaseNote({ body: { caseNote }, params: { caseId, noteId }, user }, res, next) {
     try {
+        caseNote = caseNote?.trim();
         if (!caseNote) {
             res.locals.error = 'Case note must not be blank';
-            return next();
+            next();
         }
+
         const updated = await caseworkService.put(`/case/${caseId}/note/${noteId}`, {
             text: caseNote,
             type: 'MANUAL'
         }, { headers: User.createHeaders(user) });
         res.locals.caseNote = updated.data;
     } catch (error) {
-        return next(new Error(`Failed to update case note ${noteId} on case ${caseId} `));
+        return next(new Error(`Failed to update case note ${noteId} on case ${caseId}`));
     }
     return next();
 }


### PR DESCRIPTION
On addition and updating of a case note the user can enter a string of
whitespace and this will be entered. This change prevents that by
trimming the entry of the whitespace. This ensures that only the
required text is entered into case notes and no extra whitespace. The
default empty message is shown to the user in this case.