### PR TITLE
HOCS-2083: change usage of Panel

### DIFF
--- a/server/services/action.js
+++ b/server/services/action.js
@@ -96,7 +96,7 @@ const actions = {
                     case actionTypes.CREATE_CASE: {
                         const { data: documentTags } = await getDocumentTags(context);
                         response = await createCase('/case', { caseType: context, form }, documentTags[0], headers);
-                        clientResponse = { summary: 'Case Created ', link: `${response.data.reference}` };
+                        clientResponse = { title: 'Case Created', child: { link: `${response.data.reference}` } };
                         return handleActionSuccess(clientResponse, workflow, form);
                     }
                     case actionTypes.CREATE_AND_ALLOCATE_CASE: {
@@ -112,7 +112,9 @@ const actions = {
                     case actionTypes.BULK_CREATE_CASE: {
                         const { data: documentTags } = await getDocumentTags(context);
                         response = await createCase('/case/bulk', { caseType: context, form }, documentTags[0], headers);
-                        clientResponse = { summary: `Created ${response.data.count} new case${response.data.count > 1 ? 's' : ''}` };
+                        clientResponse = {
+                            title: `Created ${response.data.count} new case${response.data.count > 1 ? 's' : ''}`
+                        };
                         return handleActionSuccess(clientResponse, workflow, form);
                     }
                     case actionTypes.ADD_STANDARD_LINE:
@@ -244,10 +246,12 @@ const actions = {
                                     requestBody, headers);
 
                             const clientResponse = {
-                                'summary': `Case: ${response.data.reference} extended`,
-                                'link': {
-                                    label: `${response.data.reference}`,
-                                    href: `/case/${options.caseId}/stage/${options.stageId}/?tab=CASE_ACTIONS`
+                                title: `Case: ${response.data.reference} extended`,
+                                child: {
+                                    link: {
+                                        label: `${response.data.reference}`,
+                                        href: `/case/${options.caseId}/stage/${options.stageId}/?tab=CASE_ACTIONS`
+                                    }
                                 }
                             };
 
@@ -289,10 +293,12 @@ const actions = {
                                     requestBody, headers);
 
                             const clientResponse = {
-                                'summary': `Appeal for ${response.data.reference} updated`,
-                                'link': {
-                                    label: `${response.data.reference}`,
-                                    href: `/case/${options.caseId}/stage/${options.stageId}/?tab=CASE_ACTIONS`
+                                title: `Appeal for ${response.data.reference} updated`,
+                                child: {
+                                    link: {
+                                        label: `${response.data.reference}`,
+                                        href: `/case/${options.caseId}/stage/${options.stageId}/?tab=CASE_ACTIONS`
+                                    }
                                 }
                             };
 
@@ -325,10 +331,12 @@ const actions = {
                                     requestBody, headers);
 
                             const clientResponse = {
-                                'summary': `Appeal for ${response.data.reference} registered`,
-                                'link': {
-                                    label: `${response.data.reference}`,
-                                    href: `/case/${options.caseId}/stage/${options.stageId}/?tab=CASE_ACTIONS`
+                                title: `Appeal for ${response.data.reference} registered`,
+                                child: {
+                                    link: {
+                                        label: `${response.data.reference}`,
+                                        href: `/case/${options.caseId}/stage/${options.stageId}/?tab=CASE_ACTIONS`
+                                    }
                                 }
                             };
 
@@ -346,10 +354,12 @@ const actions = {
                                 requestBody, headers);
 
                             const clientResponse = {
-                                'summary': `Case ${response.data.reference} has been suspended.`,
-                                'link': {
-                                    label: `${response.data.reference}`,
-                                    href: `/case/${options.caseId}/stage/${options.stageId}/?tab=CASE_ACTIONS`
+                                title: `Case ${response.data.reference} has been suspended.`,
+                                child: {
+                                    link: {
+                                        label: `${response.data.reference}`,
+                                        href: `/case/${options.caseId}/stage/${options.stageId}/?tab=CASE_ACTIONS`
+                                    }
                                 }
                             };
 
@@ -362,10 +372,12 @@ const actions = {
                             const response =  await caseworkService.put(`/case/${caseId}/stage/${stageId}/actions/suspension/${caseActionId}`, null, headers);
 
                             const clientResponse = {
-                                'summary': `Suspension for case ${response.data.reference} has been removed.`,
-                                'link': {
-                                    label: `${response.data.reference}`,
-                                    href: `/case/${options.caseId}/stage/${options.stageId}/?tab=CASE_ACTIONS`
+                                title: `Suspension for case ${response.data.reference} has been removed.`,
+                                child: {
+                                    link: {
+                                        label: `${response.data.reference}`,
+                                        href: `/case/${options.caseId}/stage/${options.stageId}/?tab=CASE_ACTIONS`
+                                    }
                                 }
                             };
 
@@ -386,8 +398,10 @@ const actions = {
                                     requestBody, headers);
 
                             const clientResponse = {
-                                'summary': `External Interest for ${response.data.reference} registered`,
-                                'link': `${response.data.reference}`
+                                title: `External Interest for ${response.data.reference} registered`,
+                                child: {
+                                    link: `${response.data.reference}`
+                                }
                             };
 
                             return handleActionSuccess(clientResponse, {}, form);
@@ -409,8 +423,10 @@ const actions = {
                                     requestBody, headers);
 
                             const clientResponse = {
-                                'summary': `External Interest for ${response.data.reference} updated`,
-                                'link': `${response.data.reference}`
+                                title: `External Interest for ${response.data.reference} updated`,
+                                child: {
+                                    link: `${response.data.reference}`
+                                }
                             };
 
                             return handleActionSuccess(clientResponse, {}, form);

--- a/src/shared/common/forms/__tests__/__snapshots__/panel.spec.js.snap
+++ b/src/shared/common/forms/__tests__/__snapshots__/panel.spec.js.snap
@@ -4,11 +4,7 @@ exports[`Panel component should render with content when passed 1`] = `
 <div>
   <div
     class="govuk-panel govuk-panel--confirmation"
-  >
-    <div
-      class="govuk-panel__body"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -35,9 +31,6 @@ exports[`Panel component should render with title when passed 1`] = `
     >
       Testing
     </h1>
-    <div
-      class="govuk-panel__body"
-    />
   </div>
 </div>
 `;

--- a/src/shared/common/forms/panel.jsx
+++ b/src/shared/common/forms/panel.jsx
@@ -4,6 +4,41 @@ import { ApplicationConsumer } from '../../contexts/application.jsx';
 import { Link } from 'react-router-dom';
 
 class Panel extends Component {
+
+    renderSummary(children) {
+        const summary = children?.summary;
+
+        if (!summary) {
+            return;
+        }
+
+        return (<div className="govuk-panel__body">
+            {children.summary}
+        </div>);
+    }
+
+    renderLink(children, csrf) {
+        const link = children?.link;
+
+        if (!link) {
+            return;
+        }
+
+        if (typeof link === 'string') {
+            return (<form action={`/search/reference?_csrf=${csrf}`} method='POST'
+                encType='multipart/form-data'>
+                <input className="govuk-input" id="case-reference" type="hidden" name="case-reference"
+                    value={children.link} />
+                <input className="govuk-button-panel--link" id="submit" type="submit"
+                    value={children.link} />
+            </form>);
+        } else if (typeof link === 'object') {
+            return (<Link to={children.link.href} className="govuk-input govuk-button-panel--link">
+                {children.link.label}
+            </Link>);
+        }
+    }
+
     /*
      * A visible container used on confirmation or results pages to highlight important content
      */
@@ -14,31 +49,16 @@ class Panel extends Component {
             <div>
                 <div className="govuk-panel govuk-panel--confirmation">
                     {title && <h1 className="govuk-panel__title">{title}</h1>}
-                    <div className="govuk-panel__body">{children.summary}
-                    </div>
+                    {this.renderSummary(children)}
                 </div>
-                {/* todo: why is the body not passed to the csrf parsing? */}
-                {children.link && typeof children.link === 'string' &&
-                    <form action={`/search/reference?_csrf=${csrf}`} method='POST'
-                        encType='multipart/form-data'>
-                        <input className="govuk-input" id="case-reference" type="hidden" name="case-reference"
-                            value={children.link} />
-                        <input className="govuk-button-panel--link" id="submit" type="submit"
-                            value={children.link} />
-                    </form>
-                }
-                {children.link && typeof children.link === 'object' &&
-                    <Link to={children.link.href} className="govuk-input govuk-button-panel--link">
-                        {children.link.label}
-                    </Link>
-                }
+                {this.renderLink(children, csrf)}
             </div>
         );
     }
 }
 
 Panel.propTypes = {
-    children: PropTypes.node,
+    children: PropTypes.node.isRequired,
     title: PropTypes.string,
     csrf: PropTypes.string
 };

--- a/src/shared/pages/form-enabled.jsx
+++ b/src/shared/pages/form-enabled.jsx
@@ -209,8 +209,8 @@ function withForm(Page) {
         renderConfirmation() {
             return (
                 <Fragment>
-                    <Panel >
-                        {this.state.confirmation}
+                    <Panel title={this.state.confirmation.title}>
+                        {this.state.confirmation.child}
                     </Panel >
                     <BackLink />
                 </Fragment>


### PR DESCRIPTION
Multiple usages of the Panel for actions pass the title as the summary
which breaks the Accessibility guidelines. All actions that pass title
incorrectly have been changed.

Also, includes a change that if the summary is not present then the
`div` does not present as an empty element.