### PR TITLE
HOCS-5184: correct field processing

### DIFF
--- a/server/middleware/__tests__/process.spec.js
+++ b/server/middleware/__tests__/process.spec.js
@@ -912,4 +912,52 @@ describe('Process middleware', () => {
             expect(req.form.data).toEqual({ TestField1: 'Other', TestField2: 'Blah' });
         });
     });
+
+    describe('when passed fields that should not be processed', () => {
+        const req = {
+            body: {
+                'TestSomuList': '1',
+                'TestDisplay': '2',
+                'TestField': '3',
+            },
+            query: {},
+            form: {
+                schema: {
+                    fields: [
+                        {
+                            component: 'display',
+                            validation: [],
+                            props: {
+                                name: 'TestDisplay',
+                                label: 'Test Field 1'
+                            }
+                        },
+                        {
+                            component: 'somu-list',
+                            validation: ['required'],
+                            props: {
+                                name: 'TestSomuList',
+                                label: 'Test Field 2'
+                            }
+                        },
+                        {
+                            component: 'text-area',
+                            validation: ['required'],
+                            props: {
+                                name: 'TestField',
+                                label: 'Test Field 3'
+                            }
+                        }
+                    ]
+                }
+            }
+        };
+        const res = {};
+
+        it('should remove fields from response', () => {
+            processMiddleware(req, res, next);
+            expect(req.form.data).toEqual({ TestField: '3' });
+        });
+    });
+
 });

--- a/server/middleware/process.js
+++ b/server/middleware/process.js
@@ -76,8 +76,8 @@ const createReducer = (data, req) => (reducer, field) => {
 };
 
 const byAcceptedFormData = (field) => {
-    return field.type !== 'display' &&
-        field.type !== 'somu-list';
+    return field.component !== 'display' &&
+        field.component !== 'somu-list';
 };
 
 function processMiddleware(req, res, next) {


### PR DESCRIPTION
During field submission we don't want to pass-through `somu-list` or
`display` fields. Previously, this was set to 'type' but the payload
actually used 'component' for the field type so this never worked. This
change allows this to be used correctly.