### PR TITLE
HOCS-5184: rework field processing

### DIFF
--- a/server/middleware/form/__tests__/process.spec.js
+++ b/server/middleware/form/__tests__/process.spec.js
@@ -1,7 +1,6 @@
 import { processMiddleware } from '../process';
 
 describe('Process middleware', () => {
-
     const next = jest.fn();
 
     beforeEach(() => {
@@ -50,9 +49,7 @@ describe('Process middleware', () => {
                     fields: [
                         {
                             component: 'text',
-                            validation: [
-                                'required'
-                            ],
+                            validation: [],
                             props: {
                                 name: 'test-field',
                             }
@@ -71,7 +68,7 @@ describe('Process middleware', () => {
         expect(next).toHaveBeenCalledTimes(1);
     });
 
-    it('should return data for fields with blank values', () => {
+    it('should throw error if validation fails', () => {
         const req = {
             body: {
                 ['test-field']: ''
@@ -85,6 +82,35 @@ describe('Process middleware', () => {
                             validation: [
                                 'required'
                             ],
+                            props: {
+                                name: 'test-field',
+                            }
+                        }
+                    ]
+                }
+            }
+        };
+        const res = {};
+
+        processMiddleware(req, res, next);
+        expect(req.form).toBeDefined();
+        expect(req.form.data).toBeUndefined();
+        expect(next).toHaveBeenCalled();
+        expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+    });
+
+    it('should return data for fields with blank values without validation', () => {
+        const req = {
+            body: {
+                ['test-field']: ''
+            },
+            query: {},
+            form: {
+                schema: {
+                    fields: [
+                        {
+                            component: 'text',
+                            validation: [],
                             props: {
                                 name: 'test-field',
                             }
@@ -162,8 +188,7 @@ describe('Process middleware', () => {
 
         processMiddleware(req, res, next);
         expect(req.form).toBeDefined();
-        expect(req.form.data).toBeDefined();
-        expect(req.form.data['test-field']).toBeUndefined();
+        expect(req.form.data).toBeUndefined();
         expect(next).toHaveBeenCalled();
         expect(next).toHaveBeenCalledTimes(1);
     });
@@ -403,9 +428,7 @@ describe('Process middleware', () => {
                     fields: [
                         {
                             component: 'checkbox',
-                            validation: [
-                                'required'
-                            ],
+                            validation: [],
                             props: {
                                 name: 'test-field',
                                 choices: [
@@ -477,9 +500,7 @@ describe('Process middleware', () => {
                     fields: [
                         {
                             component: 'add-document',
-                            validation: [
-                                'required'
-                            ],
+                            validation: [],
                             props: {
                                 name: 'test-field'
                             }
@@ -667,6 +688,7 @@ describe('Process middleware', () => {
         processMiddleware(req, res, next);
         expect(req.form.data).toEqual({ testField: 'SomeRadioValue' });
     });
+
     describe('when show/hide visibility props are passed through', () => {
         it('should not process fields that are not visible with visibility function', () => {
             const req = {

--- a/server/middleware/form/fieldHelper.js
+++ b/server/middleware/form/fieldHelper.js
@@ -1,0 +1,11 @@
+/**
+ * Check to see if field component is of type.
+ * @param field the field to check
+ * @param type the type to compare the component against
+ * @returns {boolean} whether the field should be kept (true)
+ */
+const isFieldComponentOfType = ({ component }, type) => component === type;
+
+module.exports = {
+    isFieldComponentOfType,
+};

--- a/server/routes/action.js
+++ b/server/routes/action.js
@@ -1,7 +1,6 @@
 const router = require('express').Router();
 const { fileMiddleware } = require('../middleware/file');
-const { processMiddleware } = require('../middleware/process');
-const { validationMiddleware } = require('../middleware/validation');
+const { processMiddleware } = require('../middleware/form/process');
 const { actionResponseMiddleware } = require('../middleware/action');
 const { getFormForAction, hydrateFields } = require('../services/form');
 const { skipCaseTypePage } = require('../middleware/skipCaseTypePage');
@@ -21,7 +20,6 @@ router.use(['/:workflow/:context/:action', '/:workflow/:action'],
 router.post(['/:workflow/:context/:action', '/:workflow/:action'],
     fileMiddleware.any(),
     processMiddleware,
-    validationMiddleware,
     actionResponseMiddleware
 );
 

--- a/server/routes/api/action.js
+++ b/server/routes/api/action.js
@@ -1,15 +1,13 @@
 const router = require('express').Router();
 const { getFormForAction } = require('../../services/form');
 const { fileMiddleware } = require('../../middleware/file');
-const { processMiddleware } = require('../../middleware/process');
-const { validationMiddleware } = require('../../middleware/validation');
+const { processMiddleware } = require('../../middleware/form/process');
 const { apiActionResponseMiddleware } = require('../../middleware/action');
 
 router.post(['/:workflow/:context/:action', '/:workflow/:action'],
     getFormForAction,
     fileMiddleware.any(),
     processMiddleware,
-    validationMiddleware,
     apiActionResponseMiddleware
 );
 

--- a/server/routes/api/case.js
+++ b/server/routes/api/case.js
@@ -1,7 +1,6 @@
 const router = require('express').Router();
 const { fileMiddleware } = require('../../middleware/file');
-const { processMiddleware } = require('../../middleware/process');
-const { validationMiddleware } = require('../../middleware/validation');
+const { processMiddleware } = require('../../middleware/form/process');
 const { protect } = require('../../middleware/auth');
 const { stageApiResponseMiddleware, allocateCase, allocateCaseToTeamMember } = require('../../middleware/stage');
 const {
@@ -38,7 +37,6 @@ router.post([
 getFormForCase,
 fileMiddleware.any(),
 processMiddleware,
-validationMiddleware,
 caseApiResponseMiddleware
 );
 
@@ -50,7 +48,6 @@ caseActionDataMiddleware,
 getFormForCase,
 fileMiddleware.any(),
 processMiddleware,
-validationMiddleware,
 caseApiResponseMiddleware
 );
 
@@ -58,7 +55,6 @@ router.post(['/:caseId/stage/:stageId/somu/:somuTypeUuid/:somuType/:somuCaseType
     getFormForCase,
     fileMiddleware.any(),
     processMiddleware,
-    validationMiddleware,
     somuApiResponseMiddleware
 );
 
@@ -66,7 +62,6 @@ router.post(['/:caseId/stage/:stageId', '/:caseId/stage/:stageId/allocate'],
     getFormForStage,
     fileMiddleware.any(),
     processMiddleware,
-    validationMiddleware,
     stageApiResponseMiddleware
 );
 router.post('/:caseId/note',
@@ -83,7 +78,6 @@ router.post('/:caseId/stage/:stageId/schema/:schemaType/data',
     getFieldsForSchema,
     fileMiddleware.any(),
     processMiddleware,
-    validationMiddleware,
     caseDataUpdateMiddleware,
     (req, res) => {
         res.json({

--- a/server/routes/case.js
+++ b/server/routes/case.js
@@ -2,8 +2,7 @@ const router = require('express').Router();
 const { getDocumentList } = require('../middleware/document');
 const { getCaseNotes } = require('../middleware/case-notes');
 const { fileMiddleware } = require('../middleware/file');
-const { processMiddleware } = require('../middleware/process');
-const { validationMiddleware } = require('../middleware/validation');
+const { processMiddleware } = require('../middleware/form/process');
 const { caseSummaryMiddleware, createCaseNote, returnToCase } = require('../middleware/case');
 const { allocateCase, allocateCaseToTeamMember } = require('../middleware/stage');
 const { getFormForCase, getFormForStage, hydrateFields } = require('../services/form');
@@ -25,8 +24,7 @@ router.all(['/:caseId/stage/:stageId/entity/:entity/:context/:action',
 
 router.post(['/:caseId/stage/:stageId', '/:caseId/stage/:stageId/allocate'],
     fileMiddleware.any(),
-    processMiddleware,
-    validationMiddleware
+    processMiddleware
 );
 
 router.post('/:caseId/stage/:stageId/note',

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -1,7 +1,6 @@
 const router = require('express').Router();
 const { secureFileMiddleware: processRequestBody } = require('../middleware/file');
-const { processMiddleware: processForm } = require('../middleware/process');
-const { validationMiddleware: validateForm } = require('../middleware/validation');
+const { processMiddleware: processForm } = require('../middleware/form/process');
 const { dashboardMiddleware: getDashboardData } = require('../middleware/dashboard');
 const { getForm } = require('../services/form');
 const form = require('../services/forms/schemas/dashboard-search');
@@ -21,7 +20,6 @@ router.post(['/search/reference', '/api/search/reference'],
     processRequestBody(form().getFields()),
     getForm(form, { submissionUrl: '/search/results' }),
     processForm,
-    validateForm,
     async (req, res, next) => {
         const logger = getLogger(req.requestId);
 

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -1,7 +1,6 @@
 const router = require('express').Router();
 const { secureFileMiddleware: processRequestBody } = require('../middleware/file');
-const { processMiddleware: processForm } = require('../middleware/process');
-const { validationMiddleware: validateForm } = require('../middleware/validation');
+const { processMiddleware: processForm } = require('../middleware/form/process');
 const { handleSearch } = require('../middleware/searchHandler');
 const { getForm, hydrateFields } = require('../services/form');
 const form = require('../services/forms/schemas/search');
@@ -18,7 +17,6 @@ router.post(['/search/results', '/api/search/results'],
     getForm(form, { submissionUrl: '/search/results' }),
     hydrateFields,
     processForm,
-    validateForm,
     (req, res, next) => Object.keys(req.form.data).length > 0 ? next() : res.json({ errors: { form: 'No search criteria specified' } }),
     handleSearch,
     (req, res, next) => {


### PR DESCRIPTION
This change reworks the processing to allow for validation rules to be
applied before the stripping of case non-acceptable field types.

This involves effectively merging the validation step into the field
processing as they are tightly coupled. This then allows for the removal
of the data properties before forms are submitted to casework.