### PR TITLE
HOCS-5335: disable auto allocate

### DIFF
--- a/server/config/tenant/config.json
+++ b/server/config/tenant/config.json
@@ -10,7 +10,7 @@
       "displayName": "Windrush Compensation",
       "bulkCreate": false,
       "deadlines": false,
-      "autoCreateAndAllocate": true,
+      "autoCreateAndAllocate": false,
       "viewStandardLines": false
     }
 }


### PR DESCRIPTION
Initially when WCS was created autoCreateAndAllocate was set to true.
This was subsequently disabled but not respected in this config file -
this change deactivates this for the tenant.