### PR TITLE
HOCS-5364 Move running user back to 1000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN npm --loglevel warn ci && npm run build-prod
 
 FROM base AS production
 
-RUN addgroup -S group_hocs && adduser -S -u 10000 user_hocs -G group_hocs -h /app
+RUN addgroup -S group_hocs && adduser -S -u 1000 user_hocs -G group_hocs -h /app
 
 WORKDIR /app
 
@@ -28,6 +28,6 @@ COPY --from=builder-client --chown=user_hocs:group_hocs ./server ./server
 COPY --from=builder-client --chown=user_hocs:group_hocs ./index.js ./
 COPY --from=builder-server --chown=user_hocs:group_hocs ./node_modules ./node_modules
 
-USER 10000
+USER 1000
 
 CMD ["sh", "/app/run.sh"]


### PR DESCRIPTION
The `certs` container runs as uid 1000, and creates its certificates
with permissions of 0600/-rw-------, meaning that when it is mounted on
the frontend container only the user with uid of 1000 is permitted to
read it.

In 535ae8e245debb053604573467ab2819766eebfe the frontend's user was
changed to a different uid and therefore the running user was no longer
able to access the certificates mounted with an owner of uid 1000.

This commit changes the uid of the container's user back to 1000. To
migrate it to 10000 again, one will need to update the certs container
to grant valid permissions (for example, by granting +r to a wider
audience).