### PR TITLE
HOCS-5364 Use user from base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,18 +15,16 @@ RUN npm --loglevel warn ci && npm run build-prod
 
 FROM base AS production
 
-RUN addgroup -S group_hocs && adduser -S -u 1000 user_hocs -G group_hocs -h /app
-
 WORKDIR /app
 
-COPY --from=builder-client --chown=user_hocs:group_hocs ./scripts/run.sh ./
-COPY --from=builder-client --chown=user_hocs:group_hocs ./package.json ./
-COPY --from=builder-client --chown=user_hocs:group_hocs ./package-lock.json ./
-COPY --from=builder-client --chown=user_hocs:group_hocs ./build ./build
-COPY --from=builder-client --chown=user_hocs:group_hocs ./src ./src
-COPY --from=builder-client --chown=user_hocs:group_hocs ./server ./server
-COPY --from=builder-client --chown=user_hocs:group_hocs ./index.js ./
-COPY --from=builder-server --chown=user_hocs:group_hocs ./node_modules ./node_modules
+COPY --from=builder-client --chown=node:node ./scripts/run.sh ./
+COPY --from=builder-client --chown=node:node ./package.json ./
+COPY --from=builder-client --chown=node:node ./package-lock.json ./
+COPY --from=builder-client --chown=node:node ./build ./build
+COPY --from=builder-client --chown=node:node ./src ./src
+COPY --from=builder-client --chown=node:node ./server ./server
+COPY --from=builder-client --chown=node:node ./index.js ./
+COPY --from=builder-server --chown=node:node ./node_modules ./node_modules
 
 USER 1000
 


### PR DESCRIPTION
The user with uid 1000 is in use, causing the build to fail as `adduser`
wasn't able to add a user that already exists.

This commit removes the adduser line and replaces the chmod lines with
ones that utilise the existing base image's user instead of trying to
create a new one like in the commit reverted by
14b2681ed4909d2f1fc8599271634dd8d810de8f.

This builds locally, although I haven't tried running it.