### PR TITLE
HOCS-4270: fix falsey casenote request

### DIFF
--- a/server/middleware/__tests__/case.spec.js
+++ b/server/middleware/__tests__/case.spec.js
@@ -419,6 +419,7 @@ describe('Case middleware', () => {
             await createCaseNote(req, res, next);
             expect(next).toHaveBeenCalled();
             expect(res.locals.error).toEqual('Case note must not be blank');
+            expect(caseworkService.post.mock.calls.length).toEqual(0);
         });
 
 
@@ -428,6 +429,7 @@ describe('Case middleware', () => {
             await createCaseNote(req, res, next);
             expect(next).toHaveBeenCalled();
             expect(res.locals.error).toEqual('Case note must not be blank');
+            expect(caseworkService.post.mock.calls.length).toEqual(0);
         });
 
         it('should call next after successful post', async () => {
@@ -487,6 +489,7 @@ describe('Case middleware', () => {
             await updateCaseNote(req, res, next);
             expect(next).toHaveBeenCalled();
             expect(res.locals.error).toEqual('Case note must not be blank');
+            expect(caseworkService.put.mock.calls.length).toEqual(0);
         });
 
 
@@ -496,6 +499,7 @@ describe('Case middleware', () => {
             await updateCaseNote(req, res, next);
             expect(next).toHaveBeenCalled();
             expect(res.locals.error).toEqual('Case note must not be blank');
+            expect(caseworkService.put.mock.calls.length).toEqual(0);
         });
 
         it('should call next after successful post', async () => {

--- a/server/middleware/case.js
+++ b/server/middleware/case.js
@@ -75,7 +75,7 @@ async function createCaseNote(req, res, next) {
         const caseNote = req.body.caseNote?.trim();
         if (!caseNote) {
             res.locals.error = 'Case note must not be blank';
-            next();
+            return next();
         }
 
         await caseworkService.post(`/case/${req.params.caseId}/note`, {
@@ -85,6 +85,7 @@ async function createCaseNote(req, res, next) {
     } catch (error) {
         next(new Error(`Failed to attach case note to case ${req.params.caseId}`));
     }
+
     next();
 }
 
@@ -93,7 +94,7 @@ async function updateCaseNote({ body: { caseNote }, params: { caseId, noteId }, 
         caseNote = caseNote?.trim();
         if (!caseNote) {
             res.locals.error = 'Case note must not be blank';
-            next();
+            return next();
         }
 
         const updated = await caseworkService.put(`/case/${caseId}/note/${noteId}`, {


### PR DESCRIPTION
When sending a casenote with a falsey value, the codepath calls next
with an error but does not return at that point, this means that after
completion of the response a request to casework happens with a invalid
casenote. This is causing exceptions to be thrown from casework as we
don't support empty case notes and also express router failures.

This change fixes this by returning the value of the next as to
terminate the function.