### PR TITLE
HOCS-5363: form embedded cleanup

### DIFF
--- a/src/shared/common/components/tab-ex-gratia.jsx
+++ b/src/shared/common/components/tab-ex-gratia.jsx
@@ -5,8 +5,6 @@ import status from '../../helpers/api-status';
 import {
     updateApiStatus,
     unsetCaseData,
-    clearApiStatus,
-    updateCaseData,
 } from '../../contexts/actions/index.jsx';
 import axios from 'axios';
 import FormEmbeddedWrapped from '../forms/form-embedded-wrapped.jsx';
@@ -14,7 +12,6 @@ import FormEmbeddedWrapped from '../forms/form-embedded-wrapped.jsx';
 const TabExGratia = (props) => {
     const { dispatch, page } = useContext(Context);
     const [form, setForm] = useState(null);
-    const [error, setError] = useState(null);
 
     useEffect(() => {
         getForm();
@@ -32,61 +29,16 @@ const TabExGratia = (props) => {
             .then(() => dispatch(updateApiStatus(status.REQUEST_FORM_SUCCESS)));
     };
 
-    const submitHandler = (wrappedState, setWrappedState, actionDispatch) => {
-        return React.useCallback(e => {
-            e.preventDefault();
-            setWrappedState({ submittingForm: true });
-            const { screen } = props;
-
-            // eslint-disable-next-line no-undef
-            const formData = new FormData();
-            for (const [key, value] of Object.entries(wrappedState)) {
-                formData.append(key, value);
-            }
-            actionDispatch(updateApiStatus(status.UPDATE_CASE_DATA))
-                .then(() => {
-                    axios.post(`/api/case/${page.params.caseId}/stage/${page.params.stageId}/form/${screen}/data?type=EX_GRATIA_UPDATE`,
-                        formData,
-                        { headers: { 'Content-Type': 'multipart/form-data' } })
-                        .then((res) => {
-                            if (res.data.errors) {
-                                actionDispatch(updateApiStatus(status.SUBMIT_FORM_VALIDATION_ERROR))
-                                    .then(() => setError(res.data.errors))
-                                    .then(() => setWrappedState({ submittingForm: false }));
-                            } else {
-                                actionDispatch(updateApiStatus(status.UPDATE_CASE_DATA_SUCCESS))
-                                    .then(() => setError(null))
-                                    .then(() => actionDispatch(updateCaseData(wrappedState)))
-                                    .then(() => setWrappedState({ submittingForm: false }));
-                            }
-                        })
-                        .then(() => {
-                            actionDispatch(clearApiStatus());
-                        })
-                        .catch(() => {
-                            actionDispatch(updateApiStatus(status.UPDATE_CASE_DATA_FAILURE))
-                                .then(() => setWrappedState({ submittingForm: false }));
-                        });
-                })
-                .catch(() => {
-                    actionDispatch(updateApiStatus(status.REQUEST_CASE_DATA_FAILURE))
-                        .then(() => setWrappedState({ submittingForm: false }));
-                });
-        }, [wrappedState]);
-    };
-
     return (
         <Fragment>
             {form &&
             <Fragment>
                 <h2 className='govuk-heading-m'>{form.schema.title}</h2>
                 <FormEmbeddedWrapped
-                    schema={form.schema}
+                    schema={ form.schema }
                     fieldData={ form.data }
-                    errors={ error }
-                    action={`/case/${page.params.caseId}/stage/${page.params.stageId}/data`}
+                    action={`/api/case/${page.params.caseId}/stage/${page.params.stageId}/form/${props.screen}/data?type=EX_GRATIA_UPDATE`}
                     baseUrl={`/case/${page.params.caseId}/stage/${page.params.stageId}`}
-                    submitHandler={submitHandler}
                 />
             </Fragment>
             }

--- a/src/shared/common/forms/form-embedded-wrapped.jsx
+++ b/src/shared/common/forms/form-embedded-wrapped.jsx
@@ -2,6 +2,9 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Form from '../forms/form.jsx';
 import { ApplicationConsumer, Context } from '../../contexts/application.jsx';
+import { clearApiStatus, updateApiStatus } from '../../contexts/actions/index.jsx';
+import status from '../../helpers/api-status';
+import axios from 'axios';
 
 /**
  * Embedded form with a wrapped state, designed to be embedded outside of workflows or pages.
@@ -10,25 +13,81 @@ import { ApplicationConsumer, Context } from '../../contexts/application.jsx';
  * @constructor
  */
 const FormEmbeddedWrapped = (props) => {
-    const [formState, setFormState] = useState( { ...props.fieldData, submittingForm: false });
     const { dispatch } = React.useContext(Context);
 
-    const setWrappedState = (data) => {
-        setFormState((state) => (
-            { ...state, ...data }
-        ));
+    const [formData, setFormData] = useState(props.fieldData);
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState(null);
+
+    const submitHandler = (e) => {
+        e.preventDefault();
+
+        if (submitting) {
+            return;
+        }
+
+        const { action } = props;
+        setSubmitting({ submittingForm: true });
+
+        // eslint-disable-next-line no-undef
+        const submissionFormData = new FormData();
+        for(const [key, value] of Object.entries(formData)) {
+            if (!value) {
+                continue;
+            }
+
+            if (Array.isArray(value)) {
+                value.map(arrVal => {
+                    submissionFormData.append(`${key}[]`, arrVal);
+                });
+            } else {
+                submissionFormData.append(key, value);
+            }
+        }
+
+        return dispatch(updateApiStatus(status.UPDATE_CASE_DATA))
+            .then(() => {
+                axios.post(action,
+                    submissionFormData,
+                    { headers: { 'Content-Type': 'multipart/form-data' } })
+                    .then((res) => {
+                        if (res.data.errors) {
+                            dispatch(updateApiStatus(status.SUBMIT_FORM_VALIDATION_ERROR))
+                                .then(() => setError(res.data.errors));
+                        } else {
+                            dispatch(updateApiStatus(status.UPDATE_CASE_DATA_SUCCESS))
+                                .then(() => setError(null));
+                        }
+                    })
+                    .then(() => {
+                        dispatch(clearApiStatus());
+                    })
+                    .catch(() => {
+                        dispatch(updateApiStatus(status.UPDATE_CASE_DATA_FAILURE));
+                    })
+                    .finally(() => {
+                        setSubmitting(false);
+                    });
+            })
+            .catch(() => {
+                dispatch(updateApiStatus(status.REQUEST_CASE_DATA_FAILURE));
+            });
+    };
+
+    const updateFormData = (data) => {
+        setFormData({ ...formData, ...data });
     };
 
     return <Form
         page={props.page}
         schema={props.schema}
-        updateFormState={setWrappedState}
-        errors={props.errors}
-        data={formState}
+        updateFormState={updateFormData}
+        errors={error}
+        data={formData}
         action={props.action}
         baseUrl={props.baseUrl}
-        submitHandler={props.submitHandler(formState, setWrappedState, dispatch)}
-        submittingForm={formState.submittingForm}
+        submitHandler={submitHandler}
+        submittingForm={submitting}
         summary={props.schema.summary}
     />;
 };
@@ -40,9 +99,7 @@ FormEmbeddedWrapped.propTypes = {
     fieldData: PropTypes.object,
     submitHandler: PropTypes.func,
     action: PropTypes.string,
-    baseUrl: PropTypes.string,
-    errors: PropTypes.object,
-    summary: PropTypes.array
+    baseUrl: PropTypes.string
 };
 
 const FormEmbeddedWrappedWrapper = props => (


### PR DESCRIPTION
Improve the form embedded component to now handle its own state
representation of data, errors and submit handler (using action to
designate API endpoint).

This provided no functional difference to how the ex-gratia tab works at
face value.

This is blocked until #1067 and #1068 are merged as this build upon them.