### PR TITLE
HOCS-1504 Updated labels on correspondent forms

### DIFF
--- a/server/services/forms/schemas/add-correspondent-details.js
+++ b/server/services/forms/schemas/add-correspondent-details.js
@@ -31,12 +31,12 @@ module.exports = options => Form()
     )
     .withField(
         Component('text', 'address1')
-            .withProp('label', 'Building')
+            .withProp('label', 'Address line 1')
             .build()
     )
     .withField(
         Component('text', 'address2')
-            .withProp('label', 'Street')
+            .withProp('label', 'Address line 2')
             .build()
     )
     .withField(

--- a/server/services/forms/schemas/add-member-details.js
+++ b/server/services/forms/schemas/add-member-details.js
@@ -22,12 +22,12 @@ module.exports = async options => {
         )
         .withField(
             Component('text', 'address1')
-                .withProp('label', 'Building')
+                .withProp('label', 'Address line 1')
                 .build()
         )
         .withField(
             Component('text', 'address2')
-                .withProp('label', 'Street')
+                .withProp('label', 'Address line 2')
                 .build()
         )
         .withField(

--- a/server/services/forms/schemas/decorators/__test__/form-decorations.spec.js
+++ b/server/services/forms/schemas/decorators/__test__/form-decorations.spec.js
@@ -226,7 +226,7 @@ describe('Form schema decorations', function () {
                         ],
                         'props': {
                             'name': 'Address1',
-                            'label': 'Building',
+                            'label': 'Address line 1',
                             'visibilityConditions': [
                                 {
                                     'conditionPropertyName': 'OriginalChannel',
@@ -244,7 +244,7 @@ describe('Form schema decorations', function () {
                         ],
                         'props': {
                             'name': 'Address2',
-                            'label': 'Street',
+                            'label': 'Address line 2',
                             'visibilityConditions': [
                                 {
                                     'conditionPropertyName': 'OriginalChannel',

--- a/server/services/forms/schemas/decorators/form_decorations/schema-decorations.js
+++ b/server/services/forms/schemas/decorators/form_decorations/schema-decorations.js
@@ -82,7 +82,7 @@ module.exports = {
                         .withField(
                             Component('text', 'Address1')
                                 .withValidator('required')
-                                .withProp('label', 'Building')
+                                .withProp('label', 'Address line 1')
                                 .withProp('visibilityConditions', [
                                     {
                                         'conditionPropertyName': 'OriginalChannel',
@@ -94,7 +94,7 @@ module.exports = {
                         .withField(
                             Component('text', 'Address2')
                                 .withValidator('required')
-                                .withProp('label', 'Street')
+                                .withProp('label', 'Address line 2')
                                 .withProp('visibilityConditions', [
                                     {
                                         'conditionPropertyName': 'OriginalChannel',

--- a/server/services/forms/schemas/update-correspondent-details-foi.js
+++ b/server/services/forms/schemas/update-correspondent-details-foi.js
@@ -20,12 +20,12 @@ module.exports = async ({ caseId, stageId, context, user, requestId }) => {
         )
         .withField(
             Component('text', 'address1')
-                .withProp('label', 'Building')
+                .withProp('label', 'Address line 1')
                 .build()
         )
         .withField(
             Component('text', 'address2')
-                .withProp('label', 'Street')
+                .withProp('label', 'Address line 2')
                 .build()
         )
         .withField(

--- a/server/services/forms/schemas/update-correspondent-details.js
+++ b/server/services/forms/schemas/update-correspondent-details.js
@@ -20,12 +20,12 @@ module.exports = async ({ caseId, stageId, context, user, requestId }) => {
         )
         .withField(
             Component('text', 'address1')
-                .withProp('label', 'Building')
+                .withProp('label', 'Address line 1')
                 .build()
         )
         .withField(
             Component('text', 'address2')
-                .withProp('label', 'Street')
+                .withProp('label', 'Address line 2')
                 .build()
         )
         .withField(


### PR DESCRIPTION
Changed labels from Building and Street to Address line 1 and Address line 2
This is in line with the guidance from the GOV Design System:
https://design-system.service.gov.uk/patterns/addresses/