### PR TITLE
HOCS-5453: add new static list

### DIFF
--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -1375,6 +1375,12 @@ module.exports = {
             endpoint: '/entity/list/TO_BF_BUSINESS_UNIT_ALL',
             type: listService.types.STATIC,
             adapter: entityListItemsAdapter
+        },
+        POGR_HMPO_LOCATIONS: {
+            client: 'INFO',
+            endpoint: '/entity/list/POGR_HMPO_LOCATIONS',
+            type: listService.types.STATIC,
+            adapter: entityListItemsAdapter
         }
     },
     clients: {


### PR DESCRIPTION
Add new static list to be loaded at startup for the HMPO Locations
selection (`POGR_HMPO_LOCATIONS`).