### PR TITLE
HOCS-5455: add static lists

### DIFF
--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -1399,6 +1399,18 @@ module.exports = {
             endpoint: '/entity/list/POGR_HMPO_EX_GRATIA_PAYMENT_METHOD',
             type: listService.types.STATIC,
             adapter: entityListItemsAdapter
+        },
+        POGR_HMPO_DOCUMENT_DAMAGE_TYPE: {
+            client: 'INFO',
+            endpoint: '/entity/list/POGR_HMPO_DOCUMENT_DAMAGE_TYPE',
+            type: listService.types.STATIC,
+            adapter: entityListItemsAdapter
+        },
+        POGR_HMPO_DOCUMENT_TYPE: {
+            client: 'INFO',
+            endpoint: '/entity/list/POGR_HMPO_DOCUMENT_TYPE',
+            type: listService.types.STATIC,
+            adapter: entityListItemsAdapter
         }
     },
     clients: {


### PR DESCRIPTION
Add the two static lists for new fields within the HMPO Dispatch screen:
- `POGR_HMPO_DOCUMENT_DAMAGE_TYPE`
- `POGR_HMPO_DOCUMENT_TYPE`