### PR TITLE
Alter maxUnavailable to 0 based on prod experience

### DIFF
--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       name: hocs-frontend
   strategy:
     rollingUpdate:
-      maxUnavailable: 50%
+      maxUnavailable: 0
       maxSurge: 1
     type: RollingUpdate
   template:


### PR DESCRIPTION
This was originally changed to 50% to help provision not prod environments, however we had a failed deployment and the working deployment scaled down to 1 which is undesirable.