### PR TITLE
HOCS-5679: refactor case creation document tag

### DIFF
--- a/server/config/case-type/__tests__/case-type.spec.js
+++ b/server/config/case-type/__tests__/case-type.spec.js
@@ -1,0 +1,24 @@
+jest.mock('../creation-document-tag.json', () => (
+    {
+        'TEST': 'TEST_TYPE'
+    }
+),
+{ virtual: true });
+
+const { fetchCaseTypeCreationDocumentTag } = require('../case-type');
+
+describe('Case type configuration', () => {
+
+    describe('initial document tag', () => {
+
+        test('should return undefined if case type does not exist', () => {
+            expect(fetchCaseTypeCreationDocumentTag('UNKNOWN')).not.toBeDefined();
+        });
+
+        test('should return value if case type in config', () => {
+            expect(fetchCaseTypeCreationDocumentTag('TEST')).toEqual('TEST_TYPE');
+        });
+
+    });
+
+});

--- a/server/config/case-type/case-type.js
+++ b/server/config/case-type/case-type.js
@@ -1,0 +1,9 @@
+const documentTags = require('./creation-document-tag.json');
+
+const fetchCaseTypeCreationDocumentTag = (caseType) => {
+    return documentTags[caseType];
+};
+
+module.exports = {
+    fetchCaseTypeCreationDocumentTag
+};

--- a/server/config/case-type/creation-document-tag.json
+++ b/server/config/case-type/creation-document-tag.json
@@ -1,0 +1,17 @@
+{
+  "BF": "To document",
+  "BF2": "To document",
+  "COMP": "To document",
+  "COMP2": "To document",
+  "DTEN": "ORIGINAL",
+  "FOI": "Request",
+  "IEDET": "Original complaint",
+  "MIN": "ORIGINAL",
+  "MPAM": "Original correspondence",
+  "MTS": "Original correspondence",
+  "POGR": "Original Complaint",
+  "POGR2": "Original Complaint",
+  "SMC": "To document",
+  "TO": "Initial Correspondence",
+  "TRO": "ORIGINAL"
+}

--- a/server/services/__tests__/action.spec.js
+++ b/server/services/__tests__/action.spec.js
@@ -123,6 +123,12 @@ jest.mock('../../clients', () => {
     };
 });
 
+jest.mock('../../config/case-type/creation-document-tag.json', () => (
+    {
+        'SUPPORTED_CASETYPE': 'ORIGINAL'
+    }
+),
+{ virtual: true });
 
 const createCaseRequest = {
     type: 'SUPPORTED_CASETYPE',

--- a/server/services/action.js
+++ b/server/services/action.js
@@ -5,6 +5,7 @@ const getLogger = require('../libs/logger');
 const User = require('../models/user');
 const doubleEncodeSlashes = require('../libs/encodingHelpers');
 const { isDateTodayOrAfter } = require('../libs/dateHelpers');
+const { fetchCaseTypeCreationDocumentTag } = require('../config/case-type/case-type');
 
 function createDocumentSummaryObjects(form, type) {
     return form.schema.fields.reduce((reducer, field) => {
@@ -50,10 +51,6 @@ function updateCase({ caseId, stageId, form }, headers) {
     return workflowService.post(`/case/${caseId}/stage/${stageId}`, { data: form.data }, headers);
 }
 
-function getDocumentTags(caseType) {
-    return infoService.get(`/caseType/${caseType}/documentTags`);
-}
-
 async function handleActionSuccess(response, workflow, form) {
     const { next, data } = form;
     if (response && response.callbackUrl) {
@@ -94,24 +91,36 @@ const actions = {
                 let clientResponse;
                 switch (form.action) {
                     case actionTypes.CREATE_CASE: {
-                        const { data: documentTags } = await getDocumentTags(context);
-                        response = await createCase('/case', { caseType: context, form }, documentTags[0], headers);
+                        const initialDocumentTag = fetchCaseTypeCreationDocumentTag(context);
+                        if (!initialDocumentTag) {
+                            throw new ActionError(`No initial document tag for casetype: ${context}`);
+                        }
+
+                        response = await createCase('/case', { caseType: context, form }, initialDocumentTag, headers);
                         clientResponse = { title: 'Case Created', child: { link: `${response.data.reference}` } };
                         return handleActionSuccess(clientResponse, workflow, form);
                     }
                     case actionTypes.CREATE_AND_ALLOCATE_CASE: {
-                        const { data: documentTags } = await getDocumentTags(context);
+                        const initialDocumentTag = fetchCaseTypeCreationDocumentTag(context);
+                        if (!initialDocumentTag) {
+                            throw new ActionError(`No initial document tag for casetype: ${context}`);
+                        }
+
                         const { data: { reference } } = await createCase('/case', {
                             caseType: context,
                             form
-                        }, documentTags[0], headers);
+                        }, initialDocumentTag, headers);
                         const { data: { stages } } = await caseworkService.get(`/case/${doubleEncodeSlashes(encodeURIComponent(reference))}/stage`, headers);
                         const { caseUUID, uuid: stageUUID } = stages[0];
                         return handleActionSuccess({ callbackUrl: `/case/${caseUUID}/stage/${stageUUID}/allocate` }, workflow, form);
                     }
                     case actionTypes.BULK_CREATE_CASE: {
-                        const { data: documentTags } = await getDocumentTags(context);
-                        response = await createCase('/case/bulk', { caseType: context, form }, documentTags[0], headers);
+                        const initialDocumentTag = fetchCaseTypeCreationDocumentTag(context);
+                        if (!initialDocumentTag) {
+                            throw new ActionError(`No initial document tag for casetype: ${context}`);
+                        }
+
+                        response = await createCase('/case/bulk', { caseType: context, form }, initialDocumentTag, headers);
                         clientResponse = {
                             title: `Created ${response.data.count} new case${response.data.count > 1 ? 's' : ''}`
                         };


### PR DESCRIPTION
Rework the case creation document tag away from calling info service and
using the first value returned from the array to hold a config file.
This removes one of the calls to info service and makes it clear what
the tag is that should be used.