### PR TITLE
Use en dash instead of hyphen-minus in test banner

### DIFF
--- a/src/shared/common/components/__tests__/__snapshots__/phase-banner.spec.js.snap
+++ b/src/shared/common/components/__tests__/__snapshots__/phase-banner.spec.js.snap
@@ -338,7 +338,7 @@ Object {
             PROTOTYPE
           </strong>
           <span>
-            This is a test system - do not upload real documents or information
+            This is a test system – do not upload real documents or information
           </span>
         </p>
       </div>
@@ -357,7 +357,7 @@ Object {
           PROTOTYPE
         </strong>
         <span>
-          This is a test system - do not upload real documents or information
+          This is a test system – do not upload real documents or information
         </span>
       </p>
     </div>

--- a/src/shared/common/components/phase-banner.jsx
+++ b/src/shared/common/components/phase-banner.jsx
@@ -8,7 +8,7 @@ export default class PhaseBannerComponent extends Component {
         let envDisplay;
 
         if (isNotProd) {
-            envDisplay = <>This is a test system - do not upload real documents or information</>;
+            envDisplay = <>This is a test system – do not upload real documents or information</>;
         } else {
             envDisplay = <>This is a new service – your <a href={feedback}>feedback</a> will help us to improve it.</>;
         }


### PR DESCRIPTION
The non-production banner uses a hyphen (-) instead of a dash (–), which is incorrect grammatically and does not match the production banner, which uses an en dash.

This commit changes the hyphen in that banner to use an en dash, which is UK usage. Some sources say to use an em dash instead, but that appears limited to US English.