### PR TITLE
HOCS-5652 - Add new POGR HMPO contribution business area list

### DIFF
--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -1056,6 +1056,12 @@ module.exports = {
             type: listService.types.STATIC,
             adapter: entityListItemsAdapter
         },
+        HMPO_CONTRIBUTION_BUS_AREA: {
+            client: 'INFO',
+            endpoint: '/entity/list/HMPO_CONTRIBUTION_BUS_AREA',
+            type: listService.types.STATIC,
+            adapter: entityListItemsAdapter
+        },
         S_SMC_COMP_ORIGIN: {
             client: 'INFO',
             endpoint: '/entity/list/SMC_COMP_ORIGIN',


### PR DESCRIPTION
HOCS-5652 : This PR defines HMPO list which would load them in index.js file. This is a new requirement as part of HOCS-6652 to separate HMPO and GRO business contribution areas.