### PR TITLE
HOCS-5840: change to search field label

### DIFF
--- a/server/config/searchFields/config.json
+++ b/server/config/searchFields/config.json
@@ -519,7 +519,7 @@
         "label": "Case status",
         "choices": [
           {
-            "label": "Include Active Only",
+            "label": "Include Active Cases only",
             "value": "active"
           }
         ]
@@ -581,7 +581,7 @@
         "label": "Case status",
         "choices": [
           {
-            "label": "Include Active Only",
+            "label": "Include Active Cases only",
             "value": "active"
           }
         ]


### PR DESCRIPTION
Change to search field checkbox label from `Include Active Only` to the consistently used `Include Active Cases only`.