### PR TITLE
Correct contribution request validation

### DIFF
--- a/server/middleware/form/__tests__/validation.spec.js
+++ b/server/middleware/form/__tests__/validation.spec.js
@@ -1,5 +1,5 @@
 import { FormSubmissionError, ValidationError } from '../../../models/error';
-import { validators, validateForm } from '../validation';
+import { validateForm, validators } from '../validation';
 
 jest.mock('../../../config.js', () => {
     return {
@@ -348,6 +348,9 @@ describe('Validators', () => {
         it('should reject if value passed in is undefined', () => {
             expect(validators.contributionsFulfilled({ value: undefined })).not.toEqual(null);
         });
+        it('should reject if value passed in is invalid JSON', () => {
+            expect(validators.contributionsFulfilled({ value: '{ "test": 1' })).not.toEqual(null);
+        });
         it('should reject if value passed in is not an array', () => {
             expect(validators.contributionsFulfilled({ value: '{ "test": 1 }' })).not.toEqual(null);
         });
@@ -358,7 +361,7 @@ describe('Validators', () => {
             expect(validators.contributionsFulfilled({ value: '[{ "data": { "contributionStatus": "test" } }]' })).not.toEqual(null);
         });
         it('should reject if one value has contributionStatus that is not cancelled or received', () => {
-            expect(validators.contributionsFulfilled({ value: '[{ "data": { "contributionStatus": "contributionReceived" }, { "contributionStatus": "test" } }]' })).not.toEqual(null);
+            expect(validators.contributionsFulfilled({ value: '[{ "data": { "contributionStatus": "contributionReceived" } }, { "data": { "contributionStatus": "test" } }]' })).not.toEqual(null);
         });
         it('should accept if value has contributionStatus as cancelled', () => {
             expect(validators.contributionsFulfilled({ value: '[{ "data": { "contributionStatus": "contributionCancelled" } }]' })).toEqual(null);

--- a/server/middleware/form/validation.js
+++ b/server/middleware/form/validation.js
@@ -96,9 +96,9 @@ const approvalRequestsFulfilled = (value, message, defaultError) => {
 const requestsFulfilled = ( value, message, statusField, cancelledValue, completeValue, defaultError ) => {
     const logger = getLogger();
 
-    let valid = true;
+    let valid = false;
     try {
-        const contributions = JSON.parse(value);
+        const contributions = value ? JSON.parse(value) : undefined;
 
         if (Array.isArray(contributions)) {
             const result = contributions.filter(contribution => {
@@ -106,14 +106,11 @@ const requestsFulfilled = ( value, message, statusField, cancelledValue, complet
                 return (!(contributionStatus === cancelledValue || contributionStatus === completeValue));
             });
 
-            if (result.length !== 0) {
-                valid = false;
+            if (result.length === 0) {
+                valid = true;
             }
-        } else {
-            valid = false;
         }
     } catch (error) {
-        valid = false;
         logger.error('REQUEST_FULFILLED_VALIDATION_ERROR', { message: error.message, stack: error.stack  });
     }
 


### PR DESCRIPTION
Validation on contributions are currently trying to parse falsey values, this change ensures we only call `JSON.parse` on values that aren't falsey.

This change also simplifies the logic to default invalid and calculate for a true value.

Exceptions will not only be thrown if the format of the JSON is incorrect.