### PR TITLE
HOCS-2005: rework Axios error handling

### DIFF
--- a/server/middleware/__tests__/request.spec.js
+++ b/server/middleware/__tests__/request.spec.js
@@ -1,4 +1,72 @@
-import { errorMiddleware, apiErrorMiddleware } from '../request';
+import { axiosErrorMiddleware, errorMiddleware, apiErrorMiddleware } from '../request';
+import { GenericError } from '../../models/error';
+
+
+describe('Axios error middleware', () => {
+    const req = {};
+    const res = {};
+    const next = jest.fn();
+
+    beforeEach(() => {
+        next.mockReset();
+    });
+
+    it('should pass through response data if present', () => {
+        const err = {
+            isAxiosError: true,
+            response: {
+                data: 'TEST',
+                status: 400
+            }
+        };
+
+        axiosErrorMiddleware(err, req, res, next);
+
+        expect(next).toHaveBeenCalledWith(new GenericError('TEST', 400));
+    });
+
+    it('should pass through request if response is not present', () => {
+        const err = {
+            isAxiosError: true,
+            request: { },
+            config: {
+                url: 'http://TESTURL/'
+            },
+            code: 'ECONNABORTED'
+        };
+
+        axiosErrorMiddleware(err, req, res, next);
+
+        expect(next).toHaveBeenCalledWith(new GenericError(`Failed to request following endpoint ${err.config.url} for reason ${err.code}`, 500));
+    });
+
+    it('should fallback to GenericError if response or request is not present', () => {
+        const err = {
+            isAxiosError: true,
+            config: {
+                url: 'http://TESTURL/'
+            },
+            code: 'ECONNABORTED'
+        };
+
+        axiosErrorMiddleware(err, req, res, next);
+
+        expect(next).toHaveBeenCalledWith(new GenericError(`Axios failed to process the request for reason ${err.code}`, 500));
+    });
+
+    it('should bypass and pass error to next middleware', () => {
+        const err = {
+            message: 'MOCK_ERROR',
+            status: 418,
+            title: 'MOCK_TITLE',
+            stack: 'MOCK_STACK'
+        };
+
+        axiosErrorMiddleware(err, req, res, next);
+
+        expect(next).toHaveBeenCalledWith(err);
+    });
+});
 
 describe('Error middleware', () => {
 

--- a/server/middleware/request.js
+++ b/server/middleware/request.js
@@ -1,12 +1,22 @@
 const logger = require('../libs/logger');
-const { ValidationError } = require('../models/error');
+const { GenericError, ValidationError } = require('../models/error');
 const { isProduction } = require('../config');
 const { v4: uuid } = require('uuid');
 const listService = require('../services/list/');
 
-/* eslint-disable-next-line  no-unused-vars*/
-function apiErrorMiddleware(err, req, res, next) {
+function axiosErrorMiddleware(err, _req, _res, next) {
+    if (err.isAxiosError) {
+        if (err.response) {
+            return next(new GenericError(err.response.data, err.response.status));
+        } else if (err.request) {
+            return next(new GenericError(`Failed to request following endpoint ${err.config.url} for reason ${err.code}`, 500));
+        }
+        return next(new GenericError(`Axios failed to process the request for reason ${err.code}`, 500));
+    }
+    return next(err);
+}
 
+function apiErrorMiddleware(err, req, res, _) {
     if (err instanceof ValidationError) {
         logger(req.requestId).info('VALIDATION_FAILED', { errors: Object.keys(err.fields) });
         return res.status(err.status).json({ errors: err.fields });
@@ -48,6 +58,7 @@ function initRequest(req, res, next) {
 }
 
 module.exports = {
+    axiosErrorMiddleware,
     apiErrorMiddleware,
     errorMiddleware,
     initRequest

--- a/server/middleware/stage.js
+++ b/server/middleware/stage.js
@@ -1,5 +1,4 @@
 const actionService = require('../services/action');
-const getLogger = require('../libs/logger');
 const User = require('../models/user');
 const { caseworkService, workflowService } = require('../clients');
 
@@ -12,8 +11,6 @@ async function stageResponseMiddleware(req, res, next) {
         return res.redirect(callbackUrl);
     } catch (error) {
         return next(error);
-    } finally {
-        next();
     }
 }
 
@@ -30,7 +27,6 @@ async function stageApiResponseMiddleware(req, res, next) {
 }
 
 async function allocateCase(req, res, next) {
-    const logger = getLogger(req.request);
     const { caseId, stageId } = req.params;
     const { user } = req;
     try {
@@ -38,28 +34,24 @@ async function allocateCase(req, res, next) {
             userUUID: user.uuid,
         }, { headers: User.createHeaders(user) });
     } catch (error) {
-        logger.error(error);
-    } finally {
-        next();
+        return next(error);
     }
+    return next();
 }
 
 async function allocateCaseToTeamMember(req, res, next) {
-    const logger = getLogger(req.request);
     const { caseId, stageId } = req.params;
     try {
         await caseworkService.put(`/case/${caseId}/stage/${stageId}/user`, {
             userUUID: req.body['user-id'],
         }, { headers: User.createHeaders(req.user) });
     } catch (error) {
-        logger.error(error);
-    } finally {
-        next();
+        return next(error);
     }
+    return next();
 }
 
 async function moveByDirection(req, res, next) {
-    const logger = getLogger(req.request);
     const { caseId, stageId, flowDirection } = req.params;
     const { user } = req;
     try {
@@ -67,11 +59,9 @@ async function moveByDirection(req, res, next) {
             userUUID: user.uuid,
         }, { headers: User.createHeaders(user) });
     } catch (error) {
-        logger.error(error);
-        next(error);
-    } finally {
-        next();
+        return next(error);
     }
+    return next();
 }
 
 module.exports = {

--- a/server/models/error.js
+++ b/server/models/error.js
@@ -75,6 +75,12 @@ class AuthenticationError extends ErrorModel {
     }
 }
 
+class GenericError extends ErrorModel {
+    constructor(message, status) {
+        super(message, status);
+    }
+}
+
 module.exports = {
     ActionError,
     AllocationError,
@@ -84,5 +90,6 @@ module.exports = {
     FormSubmissionError,
     FormServiceError,
     ValidationError,
-    AuthenticationError
+    AuthenticationError,
+    GenericError
 };

--- a/server/routes/api/index.js
+++ b/server/routes/api/index.js
@@ -6,7 +6,7 @@ const apiCaseRouter = require('./case');
 const apiWorkstackRouter = require('./workstack');
 const apiKeepaliveRouter = require('./keepalive');
 const apiStandardLines = require('./standardLines');
-const { apiErrorMiddleware } = require('../../middleware/request');
+const { axiosErrorMiddleware, apiErrorMiddleware } = require('../../middleware/request');
 
 router.use('/form', apiFormRouter);
 router.use('/case', apiDocumentRouter);
@@ -16,6 +16,6 @@ router.use('/workstack', apiWorkstackRouter);
 router.use('/keepalive', apiKeepaliveRouter);
 router.use('/standard-lines', apiStandardLines);
 
-router.use('*', apiErrorMiddleware);
+router.use('*', axiosErrorMiddleware, apiErrorMiddleware);
 
 module.exports = router;


### PR DESCRIPTION
When an error is thrown within the express middleware there were a lot of instances of logging the entire Axios object. This isn't useful, and ends up spamming our SIEM.

This change removes this instances and adds a axios error middleware that transposes this error into a `GenericError`.

This change also (partially?) fixes an `Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client` exception that we we're having.