### PR TITLE
HOCS-5846: change unallocated data handling

### DIFF
--- a/server/lists/adapters/__tests__/__snapshots__/case-view-unallocated.spec.js.snap
+++ b/server/lists/adapters/__tests__/__snapshots__/case-view-unallocated.spec.js.snap
@@ -394,6 +394,7 @@ Object {
   "data": Object {
     "my_date_field": "2020-01-19",
     "my_field": "Some Value",
+    "test_hidden_field": "TEST",
   },
   "meta": Object {},
   "schema": Object {


### PR DESCRIPTION
For unallocated views that have a `displayAsFields` configuration, some fields that have child fields aren't having data passed through due to the filter. This change defaults to passing back the entire data blob for this to alleviate this.