### PR TITLE
HOCS-5947: trim date component inputs

### DIFF
--- a/src/shared/common/forms/__tests__/date.spec.js
+++ b/src/shared/common/forms/__tests__/date.spec.js
@@ -78,20 +78,20 @@ describe('Form date component', () => {
             <DateInput name="date" updateState={mockCallback} />
         );
 
-        let event = { target: { value: '19' } };
+        let event = { target: { value: '19 ' } };
         mockCallback.mockReset();
         fireEvent.change(wrapper.getAllByRole('textbox')[0],  event);
         expect(mockCallback).toHaveBeenCalledTimes(1);
         expect(mockCallback).toHaveBeenCalledWith({ 'date': '--19' });
 
         mockCallback.mockReset();
-        event = { target: { value: '01' } };
+        event = { target: { value: ' 01' } };
         fireEvent.change(wrapper.getAllByRole('textbox')[1],  event);
         expect(mockCallback).toHaveBeenCalledTimes(1);
         expect(mockCallback).toHaveBeenCalledWith({ 'date': '-01-' });
 
         mockCallback.mockReset();
-        event = { target: { value: '2018' } };
+        event = { target: { value: ' 2018 ' } };
         fireEvent.change(wrapper.getAllByRole('textbox')[2],  event);
         expect(mockCallback).toHaveBeenCalledTimes(1);
         expect(mockCallback).toHaveBeenCalledWith({ 'date': '2018--' });
@@ -116,5 +116,5 @@ describe('Form date component', () => {
         expect(screen.getAllByRole('textbox')[1]).not.toHaveValue('03');
         expect(screen.getAllByRole('textbox')[2]).not.toHaveValue('2019');
     });
-});
 
+});

--- a/src/shared/common/forms/date.jsx
+++ b/src/shared/common/forms/date.jsx
@@ -10,7 +10,7 @@ class DateInput extends Component {
     _onChange(field, value) {
         const updatedPart = { [field]: value };
         const parts = { ...this.parseValue(this.props.value), ...updatedPart };
-        this.props.updateState({ [this.props.name]: `${parts.year}-${parts.month}-${parts.day}` });
+        this.props.updateState({ [this.props.name]: `${parts.year.trim()}-${parts.month.trim()}-${parts.day.trim()}` });
     }
 
     datePart(field) { return `${this.props.name}-${field}`; }


### PR DESCRIPTION
Trim date input fields to remove errant spaces at the start and end of each input field.