### PR TITLE
HOCS-5615: rework Workstack form submission

### DIFF
--- a/src/shared/pages/workstack.jsx
+++ b/src/shared/pages/workstack.jsx
@@ -79,15 +79,20 @@ class WorkstackPage extends Component {
         // TODO: Remove
         /* eslint-disable-next-line no-undef */
         const payload = new FormData();
-        Object.keys(formData).forEach(field => {
-            if (Array.isArray(formData[field])) {
-                formData[field].map(value => {
-                    payload.append(`${field}`, value);
+
+        for (const [key, value] of
+            Object.entries(formData)
+                .filter(([_, value]) => (value !== null && value !== undefined))) {
+            if (Array.isArray(value)) {
+                value.map(v => {
+                    payload.append(`${key}`, v);
                 });
             } else {
-                payload.append(field, formData[field]);
+                if (typeof value === 'string') {
+                    payload.append(key, value);
+                }
             }
-        });
+        }
 
         axios.post('/api' + endpoint, payload, { headers: { 'Content-Type': 'multipart/form-data' } })
             .then(({ data: { workstack, redirect } }) => {


### PR DESCRIPTION
The current use of FormData and `append` results in undefined values being passed with the value as string "undefined".

This is causing parsing errors within the Node server and further downstream as "undefined" is not valid JSON.

This change reworks this FormData propagation to strip out any underlying null/undefined.