### PR TITLE
HOCS-6261: support hint text in somu-list

### DIFF
--- a/src/shared/common/forms/composite/__tests__/somu-list.spec.jsx
+++ b/src/shared/common/forms/composite/__tests__/somu-list.spec.jsx
@@ -463,4 +463,19 @@ describe('Somu list component', () => {
         expect(screen.getByText('Complete - rejected')).toBeInTheDocument();
     });
 
+    it('should render with hint when passed in props', () => {
+        const PROPS = {
+            ...DEFAULT_PROPS,
+            hint: 'Test Hint Text'
+        };
+        const wrapper = render(
+            <ApplicationProvider config={{ ...MOCK_CONFIG, ...PROPS }}>
+                <MemoryRouter>
+                    <SomuList baseUrl={BASE_URL} name={NAME} updateState={MOCK_CALLBACK} {...PROPS} />
+                </MemoryRouter>
+            </ApplicationProvider>
+        );
+        expect(wrapper).toBeDefined();
+        expect(screen.getByText('Test Hint Text')).toBeInTheDocument();
+    });
 });

--- a/src/shared/common/forms/composite/somu-list.jsx
+++ b/src/shared/common/forms/composite/somu-list.jsx
@@ -176,7 +176,8 @@ class SomuList extends Component {
             primaryLink,
             label,
             name,
-            className
+            className,
+            hint
         } = this.props;
 
         const { renderer } = this.state;
@@ -192,6 +193,7 @@ class SomuList extends Component {
                         <span className="govuk-fieldset__heading govuk-label--s">{label}</span>
                     </legend>
 
+                    {hint && <div className="govuk-hint">{hint}</div>}
                     {error && <p id={`${name}-error`} className="govuk-error-message">{error}</p>}
 
                     <table className='govuk-table'>
@@ -235,6 +237,7 @@ SomuList.propTypes = {
     somuItems: PropTypes.array,
     somuType: PropTypes.object.isRequired,
     updateState: PropTypes.func.isRequired,
+    hint: PropTypes.string
 };
 
 SomuList.defaultProps = {


### PR DESCRIPTION
To allow information to be passed to the user before they interact with the component, this change adds a hint text property.