### PR TITLE
HOCS-4931: improve skip link

### DIFF
--- a/src/shared/layouts/components/__tests__/__snapshots__/body.spec.js.snap
+++ b/src/shared/layouts/components/__tests__/__snapshots__/body.spec.js.snap
@@ -9,9 +9,10 @@ Object {
         class="govuk-width-container"
       >
         <main
-          class="govuk-main-wrapper "
+          class="govuk-main-wrapper"
           id="main-content"
           role="main"
+          tabindex="-1"
         />
       </div>
     </div>
@@ -21,9 +22,10 @@ Object {
       class="govuk-width-container"
     >
       <main
-        class="govuk-main-wrapper "
+        class="govuk-main-wrapper"
         id="main-content"
         role="main"
+        tabindex="-1"
       />
     </div>
   </div>,
@@ -112,9 +114,10 @@ Object {
           </p>
         </div>
         <main
-          class="govuk-main-wrapper "
+          class="govuk-main-wrapper"
           id="main-content"
           role="main"
+          tabindex="-1"
         />
       </div>
     </div>
@@ -146,9 +149,10 @@ Object {
         </p>
       </div>
       <main
-        class="govuk-main-wrapper "
+        class="govuk-main-wrapper"
         id="main-content"
         role="main"
+        tabindex="-1"
       />
     </div>
   </div>,

--- a/src/shared/layouts/components/__tests__/skip-link.spec.js
+++ b/src/shared/layouts/components/__tests__/skip-link.spec.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import SkipLink from '../skip-link';
+
+describe('Skip link component', () => {
+    it('should render', () => {
+        const wrapper = render(<SkipLink />);
+
+        expect(wrapper).toBeDefined();
+        expect(screen.getByText('Skip to main content')).toBeInTheDocument();
+    });
+});

--- a/src/shared/layouts/components/body.jsx
+++ b/src/shared/layouts/components/body.jsx
@@ -11,7 +11,7 @@ class Body extends Component {
         return (
             <div className="govuk-width-container">
                 {phaseBanner.isVisible && <PhaseBanner {...phaseBanner} />}
-                <main className="govuk-main-wrapper " id="main-content" role="main">
+                <main className="govuk-main-wrapper" id="main-content" role="main" tabIndex="-1">
                     {children}
                 </main>
             </div>

--- a/src/shared/layouts/components/header.jsx
+++ b/src/shared/layouts/components/header.jsx
@@ -1,13 +1,13 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import SkipLink from './skip-link.jsx';
 
 class Header extends Component {
 
     createLogotype(service, serviceLink, bulkCreateEnabled, viewStandardLinesEnabled) {
         return (
             <div className='govuk-header__container govuk-width-container'>
-                <a href='#main-content' className='govuk-skip-link' data-module='govuk-skip-link'>Skip to main content</a>
                 <div className='govuk-header__logo'>
                     <span className='govuk-header__logotype'>
                         <Link to={serviceLink} className='govuk-header__link govuk-header__link--homepage govuk-header__logotype-text'>{service}</Link>
@@ -42,9 +42,12 @@ class Header extends Component {
     render() {
         const { service, serviceLink, bulkCreateEnabled, viewStandardLinesEnabled } = this.props;
         return (
-            <header className='govuk-header ' role='banner' data-module='header'>
-                {this.createLogotype(service, serviceLink, bulkCreateEnabled, viewStandardLinesEnabled)}
-            </header>
+            <>
+                <SkipLink/>
+                <header className='govuk-header ' role='banner' data-module='header'>
+                    {this.createLogotype(service, serviceLink, bulkCreateEnabled, viewStandardLinesEnabled)}
+                </header>
+            </>
         );
     }
 

--- a/src/shared/layouts/components/skip-link.jsx
+++ b/src/shared/layouts/components/skip-link.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default function SkipLink() {
+
+    const handleSkipLinkClick = (event, target) => {
+        event.preventDefault();
+
+        // eslint-disable-next-line no-undef
+        const targetElement = document.getElementById(target);
+        if (targetElement) {
+            targetElement.scrollIntoView();
+            targetElement.focus();
+        }
+    };
+
+    return (
+        <a className='govuk-skip-link'
+            data-module='govuk-skip-link'
+            href="#main-content"
+            onClick={(event) => handleSkipLinkClick(event, 'main-content')}>Skip to main content</a>
+    );
+
+
+}


### PR DESCRIPTION
This change pulls out the skip-link into its own distinct class to better utilise React. This new class handles the scrolling to the `main-content` id if it exists. To enable tab indexes to work after the focus, a value of "-1" has been provided. This makes it so that programmatically it can be focused but not through a keyboard.

This change should also fix HOCS-2050.