### PR TITLE
Improve correlation ID use

### DIFF
--- a/server/lists/adapters/case-summary.js
+++ b/server/lists/adapters/case-summary.js
@@ -92,8 +92,9 @@ const getPreviousCase = previousCase => {
 };
 
 module.exports = async (summary, options) => {
-    const { fromStaticList, fetchList, configuration, user } = options;
-    const { data: caseProfile } = await caseworkService.get(`/case/profile/${options.caseId}`, { headers: User.createHeaders(user) });
+    const { fromStaticList, fetchList, configuration, user, requestId } = options;
+    const { data: caseProfile } = await caseworkService.get(`/case/profile/${options.caseId}`,
+        { headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId } });
     const stageDeadlineEnabled = caseProfile && caseProfile.summaryDeadlineEnabled;
     const deadlinesEnabled = configuration.deadlinesEnabled;
     return {

--- a/server/middleware/__tests__/document.spec.js
+++ b/server/middleware/__tests__/document.spec.js
@@ -24,7 +24,8 @@ describe('Document middleware', () => {
 
         beforeEach(() => {
             next.mockReset();
-            req = { params: { documentId: '1234', caseId: '5522' }, user: mockUser };
+            req = { params: { documentId: '1234', caseId: '5522' }, user: mockUser,
+                requestId: '00000000-0000-0000-0000-000000000000' };
             res = { setHeader: jest.fn() };
             mockResponse.status = 200;
             mockResponse.data.on = jest.fn();
@@ -32,8 +33,12 @@ describe('Document middleware', () => {
 
         });
 
-        const expecteOptions = {
-            headers: { 'X-Auth-Groups': '', 'X-Auth-Roles': '', 'X-Auth-UserId': 'TEST' },
+        const expectedOptions = {
+            headers: { 'X-Auth-Groups': '',
+                'X-Auth-Roles': '',
+                'X-Auth-UserId': 'TEST',
+                'X-Correlation-Id': '00000000-0000-0000-0000-000000000000'
+            },
             responseType: 'stream'
         };
 
@@ -41,7 +46,7 @@ describe('Document middleware', () => {
             caseworkService.get.mockImplementation(() => Promise.resolve(mockResponse));
             await getOriginalDocument(req, res, next);
             expect(caseworkService.get).toHaveBeenCalled();
-            expect(caseworkService.get).toHaveBeenCalledWith('/case/5522/document/1234/file', expecteOptions);
+            expect(caseworkService.get).toHaveBeenCalledWith('/case/5522/document/1234/file', expectedOptions);
             expect(res.setHeader).toHaveBeenCalled();
             expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'max-age=86400');
             expect(mockResponse.data.pipe).toHaveBeenCalled();
@@ -68,7 +73,8 @@ describe('Document middleware', () => {
 
         beforeEach(() => {
             next.mockReset();
-            req = { params: { documentId: '1234', caseId: '5522' }, user: mockUser };
+            req = { params: { documentId: '1234', caseId: '5522' }, user: mockUser,
+                requestId: '00000000-0000-0000-0000-000000000000' };
             res = { setHeader: jest.fn() };
             mockResponse.status = 200;
             mockResponse.data.on = jest.fn();
@@ -76,8 +82,13 @@ describe('Document middleware', () => {
 
         });
 
-        const expecteOptions = {
-            headers: { 'X-Auth-Groups': '', 'X-Auth-Roles': '', 'X-Auth-UserId': 'TEST' },
+        const expectedOptions = {
+            headers: {
+                'X-Auth-Groups': '',
+                'X-Auth-Roles': '',
+                'X-Auth-UserId': 'TEST',
+                'X-Correlation-Id': '00000000-0000-0000-0000-000000000000'
+            },
             responseType: 'stream'
         };
 
@@ -85,7 +96,7 @@ describe('Document middleware', () => {
             caseworkService.get.mockImplementation(() => Promise.resolve(mockResponse));
             await getPdfDocument(req, res, next);
             expect(caseworkService.get).toHaveBeenCalled();
-            expect(caseworkService.get).toHaveBeenCalledWith('/case/5522/document/1234/pdf', expecteOptions);
+            expect(caseworkService.get).toHaveBeenCalledWith('/case/5522/document/1234/pdf', expectedOptions);
             expect(res.setHeader).toHaveBeenCalled();
             expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'max-age=86400');
             expect(mockResponse.data.pipe).toHaveBeenCalled();

--- a/server/middleware/__tests__/searchHandler.spec.js
+++ b/server/middleware/__tests__/searchHandler.spec.js
@@ -38,7 +38,7 @@ describe('handleSearch', () => {
                     'MinSignOffTeam': 'Test Min Sign Off Team'
                 }
             },
-            requestId: 'reqid',
+            requestId: '00000000-0000-0000-0000-000000000000',
             user: mockUser,
             listService: {
                 getFromStaticList: jest.fn(async (listId, key) => {
@@ -111,8 +111,13 @@ describe('handleSearch', () => {
             activeOnly: true
         };
 
-        const expecteHeaders = {
-            headers: { 'X-Auth-Groups': '', 'X-Auth-Roles': '', 'X-Auth-UserId': 'TEST' }
+        const expectedHeaders = {
+            headers: {
+                'X-Auth-Groups': '',
+                'X-Auth-Roles': '',
+                'X-Auth-UserId': 'TEST',
+                'X-Correlation-Id': '00000000-0000-0000-0000-000000000000'
+            }
         };
 
         expect(res.locals.workstack).toBeDefined();
@@ -129,6 +134,6 @@ describe('handleSearch', () => {
 
         expect(next).toHaveBeenCalled();
         expect(caseworkService.post).toHaveBeenCalled();
-        expect(caseworkService.post).toHaveBeenCalledWith('/search', expectedRequest, expecteHeaders);
+        expect(caseworkService.post).toHaveBeenCalledWith('/search', expectedRequest, expectedHeaders);
     });
 });

--- a/server/middleware/__tests__/standardLines.spec.js
+++ b/server/middleware/__tests__/standardLines.spec.js
@@ -5,16 +5,19 @@ const {
 } = require('./../standardLine');
 
 jest.mock('../../clients/index');
-jest.mock('../../models/user');
 const { infoService, documentService } = require('../../clients/index');
-const User = require('../../models/user');
 
 const next = jest.fn();
 let req = {};
 let res = {};
 
 const mockUser = { username: 'TEST_USER', uuid: 'TEST', roles: [], groups: [] };
-const headers = '__headers__';
+const headers = {
+    'X-Auth-Groups': '',
+    'X-Auth-Roles': '',
+    'X-Auth-UserId': 'TEST',
+    'X-Correlation-Id': '00000000-0000-0000-0000-000000000000'
+};
 
 describe('standard lines middlware', () => {
 
@@ -44,7 +47,7 @@ describe('standard lines middlware', () => {
                     })
                 },
                 user: mockUser,
-                requestId: 'reqid',
+                requestId: '00000000-0000-0000-0000-000000000000'
             };
             res = {
                 locals: {}
@@ -72,19 +75,12 @@ describe('standard lines middlware', () => {
             expect(next).toHaveBeenCalledWith('MOCK_ERROR');
         });
 
-        it('should call the user create headers method', async () => {
-            await getUsersStandardLines(req, res, next);
-            expect(User.createHeaders).toHaveBeenCalled();
-        });
-
         it('should call the get method on the info service', async () => {
-            User.createHeaders.mockImplementation(() => headers);
             await getUsersStandardLines(req, res, next);
             expect(infoService.get).toHaveBeenCalledWith(`/user/${req.user.uuid}/standardLine`, { }, { headers: headers });
         });
 
         it('should call the get method on the info service', async () => {
-            User.createHeaders.mockImplementation(() => headers);
             infoService.get.mockImplementation(() => Promise.resolve(MOCK_STANDARD_LINE));
             await getUsersStandardLines(req, res, next);
             expect(infoService.get).toHaveBeenCalledWith(`/user/${req.user.uuid}/standardLine`, { }, { headers: headers });
@@ -120,7 +116,8 @@ describe('standard lines middlware', () => {
                         return Promise.reject();
                     })
                 },
-                requestId: 'reqid',
+                user: mockUser,
+                requestId: '00000000-0000-0000-0000-000000000000',
             };
             res = {
                 locals: {}
@@ -148,19 +145,12 @@ describe('standard lines middlware', () => {
             expect(next).toHaveBeenCalledWith('MOCK_ERROR');
         });
 
-        it('should call the user create headers method', async () => {
-            await getAllStandardLines(req, res, next);
-            expect(User.createHeaders).toHaveBeenCalled();
-        });
-
         it('should call the get method on the info service', async () => {
-            User.createHeaders.mockImplementation(() => headers);
             await getAllStandardLines(req, res, next);
             expect(infoService.get).toHaveBeenCalledWith('/standardLine/all', { }, { headers: headers });
         });
 
         it('should call the get method on the info service', async () => {
-            User.createHeaders.mockImplementation(() => headers);
             infoService.get.mockImplementation(() => Promise.resolve(MOCK_STANDARD_LINE));
             await getAllStandardLines(req, res, next);
             expect(infoService.get).toHaveBeenCalledWith('/standardLine/all', { }, { headers: headers });
@@ -177,7 +167,7 @@ describe('standard lines middlware', () => {
 
         beforeEach(() => {
             next.mockReset();
-            req = { params: { documentId: '1234' }, user: mockUser };
+            req = { params: { documentId: '1234' }, user: mockUser, requestId: '00000000-0000-0000-0000-000000000000' };
             res = { setHeader: jest.fn() };
             mockResponse.status = 200;
             mockResponse.data.on = jest.fn();

--- a/server/middleware/__tests__/workstack.spec.js
+++ b/server/middleware/__tests__/workstack.spec.js
@@ -115,6 +115,7 @@ describe('Workstack middleware', () => {
                 'X-Auth-Groups': 'some_groups',
                 'X-Auth-Roles': 'some_roles',
                 'X-Auth-UserId': 'userUuid',
+                'X-Correlation-Id': '00000000-0000-0000-0000-000000000000'
             }
         };
 
@@ -123,7 +124,12 @@ describe('Workstack middleware', () => {
             res = {};
 
             req = {
-                user: { uuid: 'userUuid', roles: { join: () => 'some_roles' }, groups: { join: () => 'some_groups' } }
+                user: {
+                    uuid: 'userUuid',
+                    roles: { join: () => 'some_roles' },
+                    groups: { join: () => 'some_groups' }
+                },
+                requestId: '00000000-0000-0000-0000-000000000000'
             };
 
             caseworkService.put.mockClear();

--- a/server/middleware/action.js
+++ b/server/middleware/action.js
@@ -2,9 +2,9 @@ const actionService = require('../services/action');
 
 async function actionResponseMiddleware(req, res, next) {
     const { workflow, context, action } = req.params;
-    const { form, user } = req;
+    const { form, user, requestId } = req;
     try {
-        const response = await actionService.performAction('ACTION', { workflow, context, action, form, user });
+        const response = await actionService.performAction('ACTION', { workflow, context, action, form, user, requestId });
         const { callbackUrl, confirmation } = response;
         if (confirmation) {
             res.locals.confirmation = confirmation;
@@ -20,9 +20,9 @@ async function actionResponseMiddleware(req, res, next) {
 
 async function apiActionResponseMiddleware(req, res, next) {
     const { workflow, context, action } = req.params;
-    const { form, user } = req;
+    const { form, user, requestId } = req;
     try {
-        const response = await actionService.performAction('ACTION', { workflow, context, action, form, user });
+        const response = await actionService.performAction('ACTION', { workflow, context, action, form, user, requestId });
         const { callbackUrl, confirmation } = response;
         if (confirmation) {
             return res.status(200).json({ confirmation });

--- a/server/middleware/document.js
+++ b/server/middleware/document.js
@@ -7,7 +7,7 @@ async function getOriginalDocument(req, res, next) {
     const logger = getLogger(req.requestId);
     const { caseId, documentId } = req.params;
     let options = {
-        headers: User.createHeaders(req.user),
+        headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId },
         responseType: 'stream'
     };
     logger.info('REQUEST_DOCUMENT_ORIGINAL', { ...req.params });
@@ -32,7 +32,7 @@ async function getPdfDocument(req, res, next) {
     logger.info('REQUEST_DOCUMENT_PDF', { ...req.params });
 
     let options = {
-        headers: User.createHeaders(req.user),
+        headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId },
         responseType: 'stream'
     };
 
@@ -56,7 +56,7 @@ async function getPdfDocumentPreview(req, res, next) {
     const { caseId, documentId } = req.params;
 
     let options = {
-        headers: User.createHeaders(req.user),
+        headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId } ,
         responseType: 'stream'
     };
 

--- a/server/middleware/report.js
+++ b/server/middleware/report.js
@@ -50,7 +50,7 @@ const streamReport = async (req, res, next) => {
         const response = await caseworkService.get(
             `/report/${caseType}/${reportSlug}`,
             {
-                headers: User.createHeaders(req.user),
+                headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId } ,
                 responseType: 'stream'
             }
         );

--- a/server/middleware/searchHandler.js
+++ b/server/middleware/searchHandler.js
@@ -51,7 +51,7 @@ async function handleSearch(req, res, next) {
 
         logger.info('SEARCH', { request });
         const response = await caseworkService.post('/search', request, {
-            headers: User.createHeaders(req.user)
+            headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId }
         });
 
         const fromStaticList = req.listService.getFromStaticList;

--- a/server/middleware/somu.js
+++ b/server/middleware/somu.js
@@ -6,6 +6,8 @@ async function getSomuItem({ caseId, somuTypeUuid, somuItemUuid, user, requestId
     const response = await caseworkService.get(`/case/${caseId}/item/${somuTypeUuid}/${somuItemUuid}`,
         { headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId } });
 
+    getLogger(requestId).info('SOMU_ITEM_FETCHED', { somuItemUuid } );
+
     const { data } = response.data;
     try {
         return JSON.parse(data);
@@ -16,11 +18,11 @@ async function getSomuItem({ caseId, somuTypeUuid, somuItemUuid, user, requestId
     }}
 
 async function somuApiResponseMiddleware(req, res, next) {
-    const { form, user, params: { caseId, stageId, somuItemUuid, somuTypeUuid } = {} } = req;
+    const { form, params: { caseId, stageId, somuItemUuid, somuTypeUuid } = {} } = req;
 
     try {
         let headers = {
-            headers: User.createHeaders(user)
+            headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId }
         };
 
         await caseworkService.post(`/case/${caseId}/item/${somuTypeUuid}`, {

--- a/server/middleware/stage.js
+++ b/server/middleware/stage.js
@@ -4,9 +4,9 @@ const { caseworkService, workflowService } = require('../clients');
 
 async function stageResponseMiddleware(req, res, next) {
     const { caseId, stageId } = req.params;
-    const { form, user } = req;
+    const { form, user, requestId } = req;
     try {
-        const response = await actionService.performAction('WORKFLOW', { caseId, stageId, form, user }, { headers: User.createHeaders(user) });
+        const response = await actionService.performAction('WORKFLOW', { caseId, stageId, form, user, requestId }, { headers: User.createHeaders(user) });
         const { callbackUrl } = response;
         return res.redirect(callbackUrl);
     } catch (error) {
@@ -16,9 +16,9 @@ async function stageResponseMiddleware(req, res, next) {
 
 async function stageApiResponseMiddleware(req, res, next) {
     const { caseId, stageId } = req.params;
-    const { form, user } = req;
+    const { form, user, requestId } = req;
     try {
-        const response = await actionService.performAction('WORKFLOW', { caseId, stageId, form, user }, { headers: User.createHeaders(user) });
+        const response = await actionService.performAction('WORKFLOW', { caseId, stageId, form, user, requestId }, { headers: User.createHeaders(user) });
         const { callbackUrl } = response;
         return res.status(200).json({ redirect: callbackUrl });
     } catch (error) {
@@ -32,7 +32,7 @@ async function allocateCase(req, res, next) {
     try {
         await caseworkService.put(`/case/${caseId}/stage/${stageId}/user`, {
             userUUID: user.uuid,
-        }, { headers: User.createHeaders(user) });
+        }, { headers: { ...User.createHeaders(user), 'X-Correlation-Id': req.requestId }  });
     } catch (error) {
         return next(error);
     }
@@ -44,7 +44,7 @@ async function allocateCaseToTeamMember(req, res, next) {
     try {
         await caseworkService.put(`/case/${caseId}/stage/${stageId}/user`, {
             userUUID: req.body['user-id'],
-        }, { headers: User.createHeaders(req.user) });
+        }, { headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId }  });
     } catch (error) {
         return next(error);
     }
@@ -57,7 +57,7 @@ async function moveByDirection(req, res, next) {
     try {
         await workflowService.post(`/case/${caseId}/stage/${stageId}/direction/${flowDirection}`, {
             userUUID: user.uuid,
-        }, { headers: User.createHeaders(user) });
+        }, { headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId } });
     } catch (error) {
         return next(error);
     }

--- a/server/middleware/standardLine.js
+++ b/server/middleware/standardLine.js
@@ -13,7 +13,8 @@ const getUsersStandardLines = async (req, res, next) => {
         const topicList = await req.listService.fetch('TOPICS', req.params);
         const policyTeamForTopicList = await req.listService.fetch('DCU_POLICY_TEAM_FOR_TOPIC', req.params);
 
-        const response = await infoService.get(`/user/${userUUID}/standardLine`, {}, { headers: User.createHeaders(req.user) });
+        const response = await infoService.get(`/user/${userUUID}/standardLine`, {},
+            { headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId }  });
         res.locals.standardLines = mapStandardLines(response.data, topicList, policyTeamForTopicList);
         next();
     } catch (error) {
@@ -31,7 +32,8 @@ const getAllStandardLines = async (req, res, next) => {
         const topicList = await req.listService.fetch('TOPICS', req.params);
         const policyTeamForTopicList = await req.listService.fetch('DCU_POLICY_TEAM_FOR_TOPIC', req.params);
 
-        const response = await infoService.get('/standardLine/all', {}, { headers: User.createHeaders(req.user) });
+        const response = await infoService.get('/standardLine/all', {},
+            { headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId }  });
         res.locals.standardLines = mapStandardLines(response.data, topicList, policyTeamForTopicList);
         next();
     } catch (error) {
@@ -54,7 +56,7 @@ const getOriginalDocument = async (req, res, next) => {
     const logger = getLogger(req.requestId);
     const { documentId } = req.params;
     let options = {
-        headers: User.createHeaders(req.user),
+        headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId } ,
         responseType: 'stream'
     };
     logger.info('REQUEST_DOCUMENT_ORIGINAL', { ...req.params });

--- a/server/middleware/templates.js
+++ b/server/middleware/templates.js
@@ -6,9 +6,8 @@ const User = require('../models/user');
 async function getTemplate(req, res, next) {
     const logger = getLogger(req.requestId);
     const { caseId, templateId } = req.params;
-    const { user } = req;
     let options = {
-        headers: User.createHeaders(user),
+        headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId } ,
         responseType: 'stream'
     };
     logger.info('REQUEST_TEMPLATE', { ...req.params });

--- a/server/middleware/workstack.js
+++ b/server/middleware/workstack.js
@@ -122,7 +122,7 @@ async function allocateToTeamMember(req, res, next) {
         const requests = selected_cases
             .map(selected => selected.split(':'))
             .map(([caseId, stageId]) => [`/case/${caseId}/stage/${stageId}/user`, { userUUID: selected_user }, {
-                headers: User.createHeaders(req.user)
+                headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId }
             }])
             .map(async options => sendAllocateUserRequest(req, res, options));
         await Promise.all(requests);
@@ -148,7 +148,7 @@ async function moveTeam(req, res, next) {
                 .map(([caseId, stageId]) => [
                     `/case/${caseId}/stage/${stageId}/CaseworkTeamUUID`,
                     { value: selected_team },
-                    { headers: User.createHeaders(req.user) }
+                    { headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId }  }
                 ])
                 .map(async options => updateCaseDataMoveTeamRequest(req, res, options));
 
@@ -157,7 +157,7 @@ async function moveTeam(req, res, next) {
                 .map(([caseId, stageId]) => [
                     `/case/${caseId}/stage/${stageId}/team`,
                     { teamUUID: selected_team },
-                    { headers: User.createHeaders(req.user) }
+                    { headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId }  }
                 ])
                 .map(async options => sendMoveTeamRequest(req, res, options));
 
@@ -177,7 +177,7 @@ async function allocateToUser(req, res, next) {
         const requests = selected_cases
             .map(selected => selected.split(':'))
             .map(([caseId, stageId]) => [`/case/${caseId}/stage/${stageId}/user`, { userUUID: req.user.uuid }, {
-                headers: User.createHeaders(req.user)
+                headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId }
             }])
             .map(async options => sendAllocateUserRequest(req, res, options));
         await Promise.all(requests);
@@ -191,7 +191,7 @@ async function allocateNextCaseToUser(req, res, next) {
         res.locals.stage = await caseworkService.put(
             `/case/team/${req.params.teamId}/allocate/user/next`,
             {},
-            { headers: User.createHeaders(req.user) }
+            { headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId } }
         );
     } catch (error) {
         logger.error('ALLOCATE_NEXT_CASE_FAILED');
@@ -218,7 +218,7 @@ async function unallocate(req, res, next) {
         const requests = selected_cases
             .map(selected => selected.split(':'))
             .map(([caseId, stageId]) => [`/case/${caseId}/stage/${stageId}/user`, { userUUID: null }, {
-                headers: User.createHeaders(req.user)
+                headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId }
             }])
             .map(async options => sendAllocateUserRequest(req, res, options));
         await Promise.all(requests);

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -31,7 +31,7 @@ router.post(['/search/reference', '/api/search/reference'],
             const reference = doubleEncodeSlashes(encodeURIComponent(caseRef));
 
             const response = await caseworkService.get(`/case/${reference}/stage`, {
-                headers: User.createHeaders(req.user)
+                headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId }
             });
 
             const fromStaticList = req.listService.getFromStaticList;

--- a/server/services/action.js
+++ b/server/services/action.js
@@ -79,11 +79,11 @@ function handleWorkflowSuccess(response, { caseId }) {
 }
 
 const actions = {
-    ACTION: async ({ workflow, context, form, user }) => {
+    ACTION: async ({ workflow, context, form, user, requestId }) => {
         let headers = {
-            headers: User.createHeaders(user)
+            headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId }
         };
-        const logger = getLogger();
+        const logger = getLogger(requestId);
         try {
             if (form && form.action) {
                 logger.info('ACTION', { action: form.action });
@@ -161,12 +161,12 @@ const actions = {
     },
     CASE: async (options) => {
 
-        const { caseId, stageId, context, form, user } = options;
+        const { caseId, stageId, context, form, user, requestId } = options;
 
         let headers = {
-            headers: User.createHeaders(user)
+            headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId }
         };
-        const logger = getLogger();
+        const logger = getLogger(requestId);
 
         try {
 
@@ -461,11 +461,11 @@ const actions = {
             throw new ActionError('Failed to perform action', status);
         }
     },
-    WORKFLOW: async ({ caseId, stageId, form, user }) => {
+    WORKFLOW: async ({ caseId, stageId, form, user, requestId }) => {
         let headers = {
-            headers: User.createHeaders(user)
+            headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId }
         };
-        const logger = getLogger();
+        const logger = getLogger(requestId);
         logger.info('WORKFLOW_ACTION', { action: actionTypes.UPDATE_CASE, case: caseId });
         try {
             const response = await updateCase({ caseId, stageId, form }, headers);

--- a/server/services/forms/schemas/remove-correspondent.js
+++ b/server/services/forms/schemas/remove-correspondent.js
@@ -4,7 +4,8 @@ const { caseworkService } = require('../../../clients');
 const User = require('../../../models/user');
 
 module.exports = async options => {
-    const response = await caseworkService.get(`/case/${options.caseId}/correspondent/${options.context}`, { headers: User.createHeaders(options.user) });
+    const response = await caseworkService.get(`/case/${options.caseId}/correspondent/${options.context}`,
+        { headers: { ...User.createHeaders(options.user), 'X-Correlation-Id': options.requestId } });
     const displayName = response.data.fullname;
     return Form()
         .withTitle('Remove Correspondent')

--- a/server/services/forms/schemas/remove-document.js
+++ b/server/services/forms/schemas/remove-document.js
@@ -4,7 +4,8 @@ const { caseworkService } = require('../../../clients');
 const User = require('../../../models/user');
 
 module.exports = async options => {
-    const response = await caseworkService.get(`/case/${options.caseId}/document/${options.context}`, { headers: User.createHeaders(options.user) });
+    const response = await caseworkService.get(`/case/${options.caseId}/document/${options.context}`,
+        { headers: { ...User.createHeaders(options.user), 'X-Correlation-Id': options.requestId } });
     const displayName = response.data.displayName;
     return Form()
         .withTitle('Remove document')

--- a/server/services/forms/schemas/remove-topic.js
+++ b/server/services/forms/schemas/remove-topic.js
@@ -4,7 +4,8 @@ const { caseworkService } = require('../../../clients');
 const User = require('../../../models/user');
 
 module.exports = async options => {
-    const response = await caseworkService.get(`/case/${options.caseId}/topic/${options.context}`, { headers: User.createHeaders(options.user) });
+    const response = await caseworkService.get(`/case/${options.caseId}/topic/${options.context}`,
+        { headers: { ...User.createHeaders(options.user), 'X-Correlation-Id': options.requestId } });
     const displayName = response.data.label;
     return Form()
         .withTitle('Remove Topic')

--- a/server/services/forms/schemas/search.js
+++ b/server/services/forms/schemas/search.js
@@ -5,10 +5,10 @@ const User = require('../../../models/user');
 const { fetchSearchFieldsForCaseTypes } = require('../../../config/searchFields/searchFields');
 
 const search = async (options = {}) => {
-    const { submissionUrl, user } = options;
+    const { submissionUrl, user, requestId } = options;
 
     let headers = {
-        headers: User.createHeaders(user)
+        headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId }
     };
 
     const { data: caseTypes } = await infoService.get('/profileNames?initialCaseType=false', headers);

--- a/server/services/forms/schemas/update-correspondent-details-foi.js
+++ b/server/services/forms/schemas/update-correspondent-details-foi.js
@@ -4,7 +4,8 @@ const { caseworkService } = require('../../../clients');
 const User = require('../../../models/user');
 
 module.exports = async ({ caseId, stageId, context, user, requestId }) => {
-    const { data: { address, ...data } } = await caseworkService.get(`/case/${caseId}/correspondent/${context}`, { headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId } });
+    const { data: { address, ...data } } = await caseworkService.get(`/case/${caseId}/correspondent/${context}`,
+        { headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId } });
     return Form()
         .withTitle('Edit Correspondent Details')
         .withField(

--- a/server/services/forms/schemas/update-correspondent-details.js
+++ b/server/services/forms/schemas/update-correspondent-details.js
@@ -4,7 +4,8 @@ const { caseworkService } = require('../../../clients');
 const User = require('../../../models/user');
 
 module.exports = async ({ caseId, stageId, context, user, requestId }) => {
-    const { data: { address, ...data } } = await caseworkService.get(`/case/${caseId}/correspondent/${context}`, { headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId } });
+    const { data: { address, ...data } } = await caseworkService.get(`/case/${caseId}/correspondent/${context}`,
+        { headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId } });
     return Form()
         .withTitle('Edit correspondent details')
         .withField(

--- a/server/services/list/service.js
+++ b/server/services/list/service.js
@@ -122,7 +122,8 @@ const getInstance = (requestId, user) => {
                 logger.info('FETCH_LIST', { list: listId, client, endpoint: configuredEndpoint });
                 let response;
                 try {
-                    response = await clientInstance.get(configuredEndpoint, { headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId } });
+                    response = await clientInstance.get(configuredEndpoint,
+                        { headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId } });
                 } catch (error) {
                     logger.error('FETCH_LIST_REQUEST_FAILURE', { list: listId, message: error.message, stack: error.stack });
                     if (error.response) {


### PR DESCRIPTION
When requesting to backend services, there are currently places where we don't propagate the request id down to use as a correlation id. This is causing the inability to trace most logs from the frontend downstream.

Alongside this, we aren't passing the request id into the logger resulting in instances were we cannot correlate even within the service.