### PR TITLE
Add return to all `next` calls

### DIFF
--- a/server/middleware/__tests__/autoCreateAllocate.spec.js
+++ b/server/middleware/__tests__/autoCreateAllocate.spec.js
@@ -6,7 +6,7 @@ const tenantConfig = require('../../tenantConfig');
 jest.mock('../../middleware/action');
 jest.mock('../../services/form', () => ({
     getFormForAction: jest.fn((_, _1, next) => {
-        next();
+        return next();
     })
 }));
 jest.mock('../../tenantConfig', () => ({

--- a/server/middleware/action.js
+++ b/server/middleware/action.js
@@ -12,7 +12,7 @@ async function actionResponseMiddleware(req, res, next) {
         if (callbackUrl) {
             return await res.redirect(callbackUrl);
         }
-        next();
+        return next();
     } catch (e) {
         return next(e);
     }

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -21,7 +21,7 @@ function authMiddleware(req, res, next) {
         return next();
     }
     logger.error('AUTH_FAILURE');
-    next(new ForbiddenError('Unauthorised', 401));
+    return next(new ForbiddenError('Unauthorised', 401));
 
 }
 
@@ -31,7 +31,7 @@ function sessionExpiryMiddleware(req, res, next) {
     if (sessionExpiry) {
         res.setHeader('X-Auth-Session-ExpiresAt', sessionExpiry);
     }
-    next();
+    return next();
 }
 
 function getSessionExpiry(logger, req) {
@@ -99,7 +99,7 @@ function protect(permission) {
             return next();
         }
         logger.error('AUTH_FAILURE', { expected: permission, user: req.user.username, roles: req.user.roles });
-        next(new ForbiddenError('Unauthorised'));
+        return next(new ForbiddenError('Unauthorised'));
     };
 }
 

--- a/server/middleware/cacheControl.js
+++ b/server/middleware/cacheControl.js
@@ -1,6 +1,6 @@
 async function setCacheControl(req, res, next) {
     res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0, s-maxage=0');
-    next();
+    return next();
 }
 
 module.exports = {

--- a/server/middleware/case-notes.js
+++ b/server/middleware/case-notes.js
@@ -9,7 +9,7 @@ async function getCaseNotes(req, res, next) {
         logger.error('ERROR', { message: error.message, stack: error.stack });
         return next('Failed to fetch timeline');
     }
-    next();
+    return next();
 }
 
 async function getCaseNotesApiResponse(req, res) {

--- a/server/middleware/case.js
+++ b/server/middleware/case.js
@@ -27,7 +27,7 @@ async function caseApiResponseMiddleware(req, res, next) {
             return res.status(200).json({ redirect: callbackUrl });
         }
     } catch (error) {
-        next(error);
+        return next(error);
     }
 }
 
@@ -35,9 +35,9 @@ async function caseSummaryMiddleware(req, res, next) {
     try {
         const summary = await req.listService.fetch('CASE_SUMMARY', req.params);
         res.locals.summary = summary;
-        next();
+        return next();
     } catch (error) {
-        next(error);
+        return next(error);
     }
 }
 
@@ -49,9 +49,9 @@ async function caseTabMiddleware(req, res, next) {
     try {
         const type = await req.listService.fetch('CASE_TYPE', req.params);
         res.locals.caseTabs = fetchCaseTabsForCaseType(type);
-        next();
+        return next();
     } catch (error) {
-        next(error);
+        return next(error);
     }
 }
 
@@ -62,9 +62,9 @@ async function caseTabApiResponseMiddleware(req, res) {
 async function caseDataMiddleware(req, res, next) {
     try {
         res.locals.caseData = await req.listService.fetch('CASE_DATA', req.params);
-        next();
+        return next();
     } catch (error) {
-        next(error);
+        return next(error);
     }
 }
 
@@ -85,10 +85,10 @@ async function createCaseNote(req, res, next) {
             type: 'MANUAL'
         }, { headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId } });
     } catch (error) {
-        next(new Error(`Failed to attach case note to case ${req.params.caseId}`));
+        return next(new Error(`Failed to attach case note to case ${req.params.caseId}`));
     }
 
-    next();
+    return next();
 }
 
 async function updateCaseNote({ body: { caseNote }, params: { caseId, noteId }, user, requestId }, res, next) {
@@ -117,9 +117,9 @@ function returnToCase(req, res) {
 async function caseCorrespondentsMiddleware(req, res, next) {
     try {
         res.locals.correspondents = await req.listService.fetch('CASE_CORRESPONDENTS_ALL', req.params);
-        next();
+        return next();
     } catch (error) {
-        next(error);
+        return next(error);
     }
 }
 
@@ -168,9 +168,9 @@ async function caseActionDataMiddleware(req, res, next) {
         preppedData.remainingDays = actionData.remainingDaysUntilDeadline;
 
         res.locals.caseActionData = preppedData;
-        next();
+        return next();
     } catch (error) {
-        next(error);
+        return next(error);
     }
 }
 

--- a/server/middleware/dashboard.js
+++ b/server/middleware/dashboard.js
@@ -2,9 +2,9 @@ async function dashboardMiddleware(req, res, next) {
     try {
         const response = await req.listService.fetch('DASHBOARD', req.params);
         req.form.meta.dashboard = response;
-        next();
+        return next();
     } catch (error) {
-        next(error);
+        return next(error);
     }
 }
 

--- a/server/middleware/document.js
+++ b/server/middleware/document.js
@@ -83,12 +83,11 @@ async function getDocumentList(req, res, next) {
     } catch (error) {
         res.locals.documents = [];
         if (error.response !== undefined && error.response.status === 401) {
-            return { error: new AuthenticationError('You are not authorised to work on this case') };
+            return next(new AuthenticationError('You are not authorised to work on this case'));
         }
         logger.info('CASE_DOCUMENT_LIST_RETURN_EMPTY');
-    } finally {
-        next();
     }
+    return next();
 }
 
 function apiGetDocumentList(req, res) {

--- a/server/middleware/form/process.js
+++ b/server/middleware/form/process.js
@@ -146,7 +146,7 @@ function processMiddleware(req, res, next) {
         return next(new FormSubmissionError('Unable to process form data'));
     }
 
-    next();
+    return next();
 }
 
 const reduceVisibleComponent = (field, data) => {

--- a/server/middleware/render.js
+++ b/server/middleware/render.js
@@ -54,7 +54,7 @@ async function renderMiddleware(req, res, next) {
             markup
         });
     }
-    next();
+    return next();
 }
 
 function renderResponseMiddleware(req, res) {

--- a/server/middleware/report.js
+++ b/server/middleware/report.js
@@ -20,7 +20,7 @@ const getReportList = async (req, res, next) => {
         res.json(reportsForCaseType);
     } catch (error) {
         logger.error('REQUEST_REPORT_LIST', { message: error.message, stack: error.stack });
-        next(error);
+        return next(error);
     }
 };
 
@@ -59,7 +59,7 @@ const streamReport = async (req, res, next) => {
         response.data.pipe(res);
     } catch (error) {
         logger.error('REQUEST_REPORT_DATA', { message: error.message, stack: error.stack });
-        next(error);
+        return next(error);
     }
 };
 

--- a/server/middleware/request.js
+++ b/server/middleware/request.js
@@ -45,7 +45,7 @@ function errorMiddleware(err, req, res, next) {
             title: err.title
         };
     }
-    next();
+    return next();
 }
 
 function initRequest(req, res, next) {
@@ -54,7 +54,7 @@ function initRequest(req, res, next) {
     req.requestId = requestId;
     req.listService = listService.getInstance(requestId, req.user);
     logger(requestId).info('REQUEST_RECEIVED', { method: req.method, endpoint: req.originalUrl });
-    next();
+    return next();
 }
 
 module.exports = {

--- a/server/middleware/searchHandler.js
+++ b/server/middleware/searchHandler.js
@@ -70,10 +70,10 @@ async function handleSearch(req, res, next) {
             columns: workstackTypeForSearch.workstackColumns
         };
 
-        next();
+        return next();
     } catch (error) {
         logger.error('SEARCH_FAILED', { message: error.message, stack: error.stack });
-        next(error);
+        return next(error);
     }
 }
 

--- a/server/middleware/somu.js
+++ b/server/middleware/somu.js
@@ -32,7 +32,7 @@ async function somuApiResponseMiddleware(req, res, next) {
 
         return res.status(200).json({ redirect: `/case/${caseId}/stage/${stageId}` });
     } catch (error) {
-        next(error);
+        return next(error);
     }
 }
 

--- a/server/middleware/standardLine.js
+++ b/server/middleware/standardLine.js
@@ -16,10 +16,10 @@ const getUsersStandardLines = async (req, res, next) => {
         const response = await infoService.get(`/user/${userUUID}/standardLine`, {},
             { headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId }  });
         res.locals.standardLines = mapStandardLines(response.data, topicList, policyTeamForTopicList);
-        next();
+        return next();
     } catch (error) {
         logger.error('REQUEST_USER_STANDARD_LINES_FAILURE', { message: error.message, stack: error.stack });
-        next(error);
+        return next(error);
     }
 };
 
@@ -35,10 +35,10 @@ const getAllStandardLines = async (req, res, next) => {
         const response = await infoService.get('/standardLine/all', {},
             { headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId }  });
         res.locals.standardLines = mapStandardLines(response.data, topicList, policyTeamForTopicList);
-        next();
+        return next();
     } catch (error) {
         logger.error('REQUEST_STANDARD_LINES_FAILURE', { message: error.message, stack: error.stack });
-        next(error);
+        return next(error);
     }
 };
 

--- a/server/middleware/templates.js
+++ b/server/middleware/templates.js
@@ -19,7 +19,7 @@ async function getTemplate(req, res, next) {
         response.data.pipe(res);
     } catch (error) {
         logger.error('REQUEST_TEMPLATE_FAILURE', { ...req.params });
-        next(new DocumentError('Unable to retrieve template'));
+        return next(new DocumentError('Unable to retrieve template'));
     }
 }
 

--- a/server/middleware/workstack.js
+++ b/server/middleware/workstack.js
@@ -6,9 +6,9 @@ async function userWorkstackMiddleware(req, res, next) {
     try {
         const response = await req.listService.fetch('USER_WORKSTACK', { userUuid: req.user.uuid });
         res.locals.workstack = response;
-        next();
+        return next();
     } catch (error) {
-        next(error);
+        return next(error);
     }
 }
 
@@ -16,9 +16,9 @@ async function teamWorkstackMiddleware(req, res, next) {
     try {
         const response = await req.listService.fetch('TEAM_WORKSTACK', req.params);
         res.locals.workstack = response;
-        next();
+        return next();
     } catch (error) {
-        next(error);
+        return next(error);
     }
 }
 
@@ -26,9 +26,9 @@ async function workflowWorkstackMiddleware(req, res, next) {
     try {
         const response = await req.listService.fetch('WORKFLOW_WORKSTACK', req.params);
         res.locals.workstack = response;
-        next();
+        return next();
     } catch (error) {
-        next(error);
+        return next(error);
     }
 }
 
@@ -36,9 +36,9 @@ async function stageWorkstackMiddleware(req, res, next) {
     try {
         const response = await req.listService.fetch('STAGE_WORKSTACK', req.params);
         res.locals.workstack = response;
-        next();
+        return next();
     } catch (error) {
-        next(error);
+        return next(error);
     }
 }
 
@@ -46,9 +46,9 @@ async function getTeamMembers(req, res, next) {
     try {
         const response = await req.listService.fetch('USERS_IN_TEAM', req.params);
         res.locals.workstack.teamMembers = response;
-        next();
+        return next();
     } catch (error) {
-        next(error);
+        return next(error);
     }
 }
 
@@ -56,9 +56,9 @@ async function getMoveTeamOptions(req, res, next) {
     try {
         const response = await req.listService.fetch('MOVE_TEAM_OPTIONS', req.params);
         res.locals.workstack.moveTeamOptions = response;
-        next();
+        return next();
     } catch (error) {
-        next(error);
+        return next(error);
     }
 }
 
@@ -91,11 +91,9 @@ const sendAllocateUserRequest = async (req, res, [endpoint, body, headers]) => {
     const logger = getLogger(req.requestId);
     try {
         await caseworkService.put(endpoint, body, headers);
-        return;
     } catch (error) {
         logger.error('ALLOCATION_FAILED', { endpoint, body, status: error.response.status });
         res.locals.notification = 'Failed to allocate all cases';
-        return;
     }
 };
 
@@ -127,7 +125,7 @@ async function allocateToTeamMember(req, res, next) {
             .map(async options => sendAllocateUserRequest(req, res, options));
         await Promise.all(requests);
     }
-    next();
+    return next();
 }
 
 async function moveTeam(req, res, next) {
@@ -165,7 +163,7 @@ async function moveTeam(req, res, next) {
     }
     logger.debug('MOVING_CASE_TEAMS', { selected_cases, selected_team });
 
-    next();
+    return next();
 }
 
 async function allocateToUser(req, res, next) {
@@ -182,7 +180,7 @@ async function allocateToUser(req, res, next) {
             .map(async options => sendAllocateUserRequest(req, res, options));
         await Promise.all(requests);
     }
-    next();
+    return next();
 }
 
 async function allocateNextCaseToUser(req, res, next) {
@@ -197,7 +195,7 @@ async function allocateNextCaseToUser(req, res, next) {
         logger.error('ALLOCATE_NEXT_CASE_FAILED');
         return next(error);
     }
-    next();
+    return next();
 }
 
 function sendCaseRedirectResponse(req, res) {
@@ -223,7 +221,7 @@ async function unallocate(req, res, next) {
             .map(async options => sendAllocateUserRequest(req, res, options));
         await Promise.all(requests);
     }
-    next();
+    return next();
 }
 
 module.exports = {

--- a/server/routes/api/workstack.js
+++ b/server/routes/api/workstack.js
@@ -20,7 +20,7 @@ router.get('/user', userWorkstackMiddleware, (req, res, next) => {
     res.locals.workstack.breadcrumbs = [
         { to: '/', label: 'Dashboard' }
     ];
-    next();
+    return next();
 }, workstackApiResponseMiddleware);
 
 router.get('/team/:teamId', teamWorkstackMiddleware, getTeamMembers, getMoveTeamOptions, (req, res, next) => {
@@ -28,7 +28,7 @@ router.get('/team/:teamId', teamWorkstackMiddleware, getTeamMembers, getMoveTeam
         { to: '/', label: 'Dashboard' },
         { to: `/workstack/team/${req.params.teamId}`, label: 'Team' }
     ];
-    next();
+    return next();
 }, workstackApiResponseMiddleware);
 
 router.get('/team/:teamId/workflow/:workflowId', workflowWorkstackMiddleware, getTeamMembers, getMoveTeamOptions, (req, res, next) => {
@@ -37,7 +37,7 @@ router.get('/team/:teamId/workflow/:workflowId', workflowWorkstackMiddleware, ge
         { to: `/workstack/team/${req.params.teamId}`, label: 'Team' },
         { to: `/workstack/team/${req.params.teamId}/workflow/${req.params.workflowId}`, label: 'Workflow' }
     ];
-    next();
+    return next();
 }, workstackApiResponseMiddleware);
 
 router.get('/team/:teamId/workflow/:workflowId/stage/:stageId', stageWorkstackMiddleware, getTeamMembers, getMoveTeamOptions, (req, res, next) => {
@@ -47,7 +47,7 @@ router.get('/team/:teamId/workflow/:workflowId/stage/:stageId', stageWorkstackMi
         { to: `/workstack/team/${req.params.teamId}/workflow/${req.params.workflowId}`, label: 'Workflow' },
         { to: `/workstack/team/${req.params.teamId}/workflow/${req.params.workflowId}/stage/${req.params.stageId}`, label: 'Stage' },
     ];
-    next();
+    return next();
 }, workstackApiResponseMiddleware);
 
 function sendWorkstackAllocateApiResponse(req, res) {

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -44,7 +44,7 @@ router.post(['/search/reference', '/api/search/reference'],
                 items: workstackData
             };
 
-            next();
+            return next();
         } catch (error) {
             logger.error('SEARCH_REFERENCE_FAILED', { message: error.message, stack: error.stack });
             return res.json({ errors: { 'case-reference': 'Failed to perform search' } });
@@ -57,7 +57,7 @@ router.post('/search/reference', async (req, res, next) => {
         const { uuid, caseUUID } = res.locals.workstack.items[0];
         return res.redirect(`/case/${caseUUID}/stage/${uuid}`);
     }
-    next();
+    return next();
 });
 
 router.post('/api/search/reference', async (req, res) => {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -45,7 +45,7 @@ router.get('/members/refresh',
             logger(req.requestId).info('REFRESH_MEMBERS', { user: req.user.email });
             res.status(200).send();
         } catch (error) {
-            next(error);
+            return next(error);
         }
     }
 );
@@ -58,7 +58,7 @@ router.get('/admin/list/flush',
             flush('S_USERS');
             res.status(200).send();
         } catch (error) {
-            next(error);
+            return next(error);
         }
     }
 );

--- a/server/routes/page.js
+++ b/server/routes/page.js
@@ -17,7 +17,7 @@ router.get('/workstack/user', userWorkstackMiddleware, (req, res, next) => {
         { to: '/', label: 'Dashboard' },
         { to: '/workstack/user', label: 'User' }
     ];
-    next();
+    return next();
 });
 
 router.get('/workstack/team/:teamId`', teamWorkstackMiddleware, getTeamMembers, getMoveTeamOptions, (req, res, next) => {
@@ -25,7 +25,7 @@ router.get('/workstack/team/:teamId`', teamWorkstackMiddleware, getTeamMembers, 
         { to: '/', label: 'Dashboard' },
         { to: `/workstack/team/${req.params.teamId}`, label: 'Team' }
     ];
-    next();
+    return next();
 });
 
 router.get('/workstack/team/:teamId/workflow/:workflowId', workflowWorkstackMiddleware, getTeamMembers, getMoveTeamOptions, (req, res, next) => {
@@ -34,7 +34,7 @@ router.get('/workstack/team/:teamId/workflow/:workflowId', workflowWorkstackMidd
         { to: `/workstack/team/${req.params.teamId}`, label: 'Team' },
         { to: `/workstack/team/${req.params.teamId}/workflow/${req.params.workflowId}`, label: 'Workflow' }
     ];
-    next();
+    return next();
 });
 
 router.get('/workstack/team/:teamId/workflow/:workflowId/stage/:stageId', stageWorkstackMiddleware, getTeamMembers, getMoveTeamOptions, (req, res, next) => {
@@ -44,7 +44,7 @@ router.get('/workstack/team/:teamId/workflow/:workflowId/stage/:stageId', stageW
         { to: `/workstack/team/${req.params.teamId}/workflow/${req.params.workflowId}`, label: 'Workflow' },
         { to: `/workstack/team/${req.params.teamId}/workflow/${req.params.workflowId}/stage/${req.params.stageId}`, label: 'Stage' },
     ];
-    next();
+    return next();
 });
 
 router.post('/workstack/team/:teamId/allocate/user',

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -25,7 +25,7 @@ router.post(['/search/results', '/api/search/results'],
             { to: '/search', label: 'Search' },
             { to: '/search/results', label: 'Results' }
         ];
-        next();
+        return next();
     }
 );
 

--- a/server/services/form.js
+++ b/server/services/form.js
@@ -204,7 +204,7 @@ const hydrateFields = async (req, res, next) => {
             return next(new FormServiceError('Failed to fetch form'));
         }
     }
-    next();
+    return next();
 };
 
 const getForm = (form, options) => {
@@ -217,10 +217,10 @@ const getForm = (form, options) => {
             const formBuilder = await form({ ...options, user: req.user, listService: req.listService });
             const { schema, data, meta } = formBuilder.build();
             req.form = { schema, data, meta };
-            next();
+            return next();
         } catch (error) {
             logger.error(error);
-            next('Something went wrong');
+            return next('Something went wrong');
         }
     };
 };
@@ -234,7 +234,7 @@ async function getSomuType(req, res, next) {
     );
 
     req.somuType = somuTypeData;
-    next();
+    return next();
 }
 
 async function getSomuItemData(req, res, next) {
@@ -244,7 +244,7 @@ async function getSomuItemData(req, res, next) {
         req.somuItemData = await getSomuItem({ caseId, somuTypeUuid, somuItemUuid, user, requestId });
     }
 
-    next();
+    return next();
 }
 
 async function getList(req, res, next) {
@@ -253,7 +253,7 @@ async function getList(req, res, next) {
     const listContent = await req.listService.fetch(listName);
 
     req.listContent = listContent;
-    next();
+    return next();
 }
 
 async function getSomuItemsByType(req, res, next) {
@@ -262,7 +262,7 @@ async function getSomuItemsByType(req, res, next) {
     const somuItems = await req.listService.fetch('CASE_SOMU_ITEM', { ...req.params, somuTypeId: somuTypeUuid });
     req.somuItems = somuItems;
 
-    next();
+    return next();
 }
 
 const getFormForAction = async (req, res, next) => {
@@ -296,7 +296,7 @@ const getFormForCase = async (req, res, next) => {
     try {
         const form = await getFormSchemaForCase({ ...req.params, user: req.user, requestId: req.requestId, caseActionData });
         req.form = form;
-        next();
+        return next();
     } catch (error) {
         logger.error('CASE_FORM_FAILURE', { message: error.message, stack: error.stack });
         if (error.response !== undefined && error.response.status === 401) {
@@ -318,7 +318,7 @@ const getFormForStage = async (req, res, next) => {
             return next(error);
         } else {
             req.form = form;
-            next();
+            return next();
         }
     } catch (error) {
         logger.error('WORKFLOW_FORM_FAILURE', { message: error.message, stack: error.stack });
@@ -341,7 +341,7 @@ const getGlobalFormForCase = async (req, res, next) => {
         }
 
         req.form = form;
-        next();
+        return next();
     } catch (error) {
         logger.error('WORKFLOW_FORM_FAILURE', { message: error.message, stack: error.stack });
         return next(new FormServiceError('Failed to fetch form'));
@@ -374,7 +374,7 @@ const getFormForSomu = async (req, res, next) => {
 
         req.form = form;
 
-        next();
+        return next();
     } catch (error) {
         logger.error('CASEWORK_SOMU_FORM_FAILURE', { message: error.message, stack: error.stack });
         return next(new FormServiceError(`Failed to fetch form for somuType: ${uuid} and action: ${action}`));


### PR DESCRIPTION
General cleanup to add return to all `next` calls. In most instances this is not required. Edge cases can exist that leads to a snowballing effect, where a next is called after a request is returned, effectively causing an error in the frontend.