### PR TITLE
Make form events specific

### DIFF
--- a/server/middleware/stage.js
+++ b/server/middleware/stage.js
@@ -6,7 +6,8 @@ async function stageResponseMiddleware(req, res, next) {
     const { caseId, stageId } = req.params;
     const { form, user, requestId } = req;
     try {
-        const response = await actionService.performAction('WORKFLOW', { caseId, stageId, form, user, requestId }, { headers: User.createHeaders(user) });
+        const response = await actionService.performAction('WORKFLOW', { caseId, stageId, form, user, requestId },
+            { headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId } });
         const { callbackUrl } = response;
         return res.redirect(callbackUrl);
     } catch (error) {
@@ -18,7 +19,8 @@ async function stageApiResponseMiddleware(req, res, next) {
     const { caseId, stageId } = req.params;
     const { form, user, requestId } = req;
     try {
-        const response = await actionService.performAction('WORKFLOW', { caseId, stageId, form, user, requestId }, { headers: User.createHeaders(user) });
+        const response = await actionService.performAction('WORKFLOW', { caseId, stageId, form, user, requestId },
+            { headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId } });
         const { callbackUrl } = response;
         return res.status(200).json({ redirect: callbackUrl });
     } catch (error) {

--- a/server/services/form.js
+++ b/server/services/form.js
@@ -268,7 +268,7 @@ async function getSomuItemsByType(req, res, next) {
 const getFormForAction = async (req, res, next) => {
 
     const logger = getLogger(req.requestId);
-    logger.info('GET_FORM', { ...req.params });
+    logger.info('GET_ACTION_FORM', { ...req.params });
 
     try {
         const { workflow, context, action } = req.params;
@@ -287,7 +287,7 @@ const getFormForAction = async (req, res, next) => {
 
 const getFormForCase = async (req, res, next) => {
     const logger = getLogger(req.requestId);
-    logger.info('GET_FORM', { ...req.params });
+    logger.info('GET_CASE_FORM', { ...req.params });
     let caseActionData;
     if (res.locals && res.locals.caseActionData) {
         caseActionData = res.locals.caseActionData;
@@ -309,7 +309,7 @@ const getFormForCase = async (req, res, next) => {
 const getFormForStage = async (req, res, next) => {
 
     const logger = getLogger(req.requestId);
-    logger.info('GET_FORM', { ...req.params });
+    logger.info('GET_STAGE_FORM', { ...req.params });
 
     const { user } = req;
     try {
@@ -331,7 +331,7 @@ const getFormForStage = async (req, res, next) => {
 
 const getGlobalFormForCase = async (req, res, next) => {
     const logger = getLogger(req.requestId);
-    logger.info('GET_FORM', { ...req.params });
+    logger.info('GET_GLOBAL_FORM', { ...req.params });
 
     const { user } = req;
     try {


### PR DESCRIPTION
There are currently 5 different `GET_FORM` events within the frontend. This makes it difficult to trace the logs in investigations.