### PR TITLE
Pass-through request id to functions

### DIFF
--- a/server/services/form.js
+++ b/server/services/form.js
@@ -214,7 +214,7 @@ const getForm = (form, options) => {
 
         logger.info('GET_FORM');
         try {
-            const formBuilder = await form({ ...options, user: req.user, listService: req.listService });
+            const formBuilder = await form({ ...options, user: req.user, requestId: req.requestId, listService: req.listService });
             const { schema, data, meta } = formBuilder.build();
             req.form = { schema, data, meta };
             return next();

--- a/server/services/list/service.js
+++ b/server/services/list/service.js
@@ -144,7 +144,8 @@ const getInstance = (requestId, user) => {
                     configuration = await fetchList('S_SYSTEM_CONFIGURATION');
                 }
 
-                const listData = await applyAdapter(response.data, adapter, { ...options, user, fromStaticList, fetchList, logger, configuration });
+                const listData = await applyAdapter(response.data, adapter, { ...options, user, requestId,
+                    fromStaticList, fetchList, logger, configuration });
                 if (type === listType.STATIC && listData) {
                     listCache.store(listId, listData);
                 }


### PR DESCRIPTION
There was a missing pass-through of the requestId causing an non-allowed undefined header to attempt to be sent.