### PR TITLE
Pass-through request id to function

### DIFF
--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -11,7 +11,8 @@ router.get('/api/form/search', (req, res) => res.json(req.form));
 
 router.post(['/search/results', '/api/search/results'],
     async (req, res, next) => {
-        const formBuilder = await form({ submissionUrl: '/search/results', user: req.user, listService: req.listService });
+        const formBuilder = await form({ submissionUrl: '/search/results', user: req.user,
+            requestId: req.requestId, listService: req.listService });
         processRequestBody(formBuilder.getFields())(req, res, next);
     },
     getForm(form, { submissionUrl: '/search/results' }),


### PR DESCRIPTION
There was a missing pass-through of the requestId causing an non-allowed undefined header to attempt to be sent.