### PR TITLE
HOCS-6597: add allocation tab support

### DIFF
--- a/server/config/caseTabs/config.json
+++ b/server/config/caseTabs/config.json
@@ -313,6 +313,11 @@
     {
       "type": "TIMELINE",
       "label": "Timeline"
+    },
+    {
+      "type": "OUT_OF_CONTACT",
+      "label": "Out of Contact",
+      "screen": "TAB_OUT_OF_CONTACT"
     }
   ]
 }

--- a/server/lists/index.js
+++ b/server/lists/index.js
@@ -1499,6 +1499,12 @@ module.exports = {
             endpoint: '/entity/list/HMPO_COMPLAINT_CATEGORIES_DOCUMENT_HANDLING',
             type: listService.types.STATIC,
             adapter: entityListItemsAdapter
+        },
+        WCS_OUT_OF_CONTACT_TEAMS: {
+            client: 'INFO',
+            endpoint: '/entity/list/OUT_OF_CONTACT_TEAMS',
+            type: listService.types.STATIC,
+            adapter: entityListItemsAdapter
         }
     },
     clients: {

--- a/server/middleware/__tests__/allocate.spec.js
+++ b/server/middleware/__tests__/allocate.spec.js
@@ -1,0 +1,94 @@
+const { allocationMiddleware } = require('../allocate.js');
+const { caseworkService } = require('../../clients');
+jest.mock('../../clients', () => ({
+    caseworkService: {
+        put: jest.fn()
+    }
+}));
+
+describe('Allocate middleware', () => {
+    let req = {};
+    let res = {};
+    const next = jest.fn();
+
+    beforeEach(() => {
+        res = {
+            json: jest.fn()
+        };
+        req = {
+            query: {
+                type: 'OUT_OF_CONTACT'
+            },
+            params: {
+                caseId: 'CASE_ID',
+                stageId: 'STAGE_ID'
+            },
+            body: {
+                'OutOfContactTeam': 'TEAM_UUID'
+            },
+            requestId: 'REQUEST_ID',
+            user: {
+                uuid: 'TEST_UUID',
+                roles: [],
+                groups: []
+            }
+        };
+        next.mockReset();
+    });
+
+    it('should throw error if type not present', async () => {
+        delete req.query.type;
+        await allocationMiddleware(req, res, next);
+        expect(next).toHaveBeenCalled();
+        expect(next).toHaveBeenCalledWith(new Error('Type not specified for case CASE_ID allocation'));
+    });
+
+    it('should throw error if type not supported', async () => {
+        req.query = { type: 'NOT_SUPPORTED' };
+
+        await allocationMiddleware(req, res, next);
+        expect(next).toHaveBeenCalled();
+        expect(next).toHaveBeenCalledWith(new Error('Invalid type NOT_SUPPORTED for case CASE_ID allocation'));
+    });
+
+    describe('should call updateOutOfContact if type is OUT_OF_CONTACT', async () => {
+
+        it('should set the teamUUID to OutOfContactTeam and saveLast to true if OutOfContactTeam is present',
+            async () => {
+                await allocationMiddleware(req, res, next);
+                expect(caseworkService.put).toHaveBeenCalledWith(
+                    '/case/CASE_ID/stage/STAGE_ID/team?saveLast=true&saveLastFieldName=XOutOfContactPreviousTeam',
+                    { teamUUID: 'TEAM_UUID' },
+                    { headers: { 'X-Correlation-Id': 'REQUEST_ID', 'X-Auth-Groups': '', 'X-Auth-Roles': '', 'X-Auth-UserId': 'TEST_UUID' } });
+                expect(res.json).toHaveBeenCalledWith({ redirect: '/case/CASE_ID/stage/STAGE_ID?tab=OUT_OF_CONTACT' });
+            });
+
+        it('should set the teamUUID to XOutOfContactPreviousTeam and saveLast to false if XOutOfContactPreviousTeam is present',
+            async () => {
+                req.body = {
+                    'XOutOfContactPreviousTeam': 'TEAM_UUID'
+                };
+                await allocationMiddleware(req, res, next);
+                expect(caseworkService.put).toHaveBeenCalledWith(
+                    '/case/CASE_ID/stage/STAGE_ID/team?saveLast=false&saveLastFieldName=XOutOfContactPreviousTeam',
+                    { teamUUID: 'TEAM_UUID' },
+                    { headers: { 'X-Correlation-Id': 'REQUEST_ID', 'X-Auth-Groups': '', 'X-Auth-Roles': '', 'X-Auth-UserId': 'TEST_UUID' } });
+                expect(res.json).toHaveBeenCalledWith({ redirect: '/case/CASE_ID/stage/STAGE_ID?tab=OUT_OF_CONTACT' });
+            });
+
+        it('should set the teamUUID to XOutOfContactPreviousTeam and saveLast to false if both team variables are present',
+            async () => {
+                req.body = {
+                    'XOutOfContactPreviousTeam': 'OLD_TEAM_UUID',
+                    'OutOfContactTeam': 'TEAM_UUID'
+                };
+                await allocationMiddleware(req, res, next);
+                expect(caseworkService.put).toHaveBeenCalledWith(
+                    '/case/CASE_ID/stage/STAGE_ID/team?saveLast=false&saveLastFieldName=XOutOfContactPreviousTeam',
+                    { teamUUID: 'TEAM_UUID' },
+                    { headers: { 'X-Correlation-Id': 'REQUEST_ID', 'X-Auth-Groups': '', 'X-Auth-Roles': '', 'X-Auth-UserId': 'TEST_UUID' } });
+                expect(res.json).toHaveBeenCalledWith({ redirect: '/case/CASE_ID/stage/STAGE_ID?tab=OUT_OF_CONTACT' });
+            });
+
+    });
+});

--- a/server/middleware/allocate.js
+++ b/server/middleware/allocate.js
@@ -1,0 +1,38 @@
+const User = require('../models/user');
+const { caseworkService } = require('../clients');
+
+const allocationMiddleware = async (req, res, next) => {
+    if (!req.query || !req.query.type) {
+        return next(new Error(`Type not specified for case ${req.params.caseId} allocation`));
+    }
+
+    let redirectUrl;
+    switch (req.query.type) {
+        case 'OUT_OF_CONTACT':
+            redirectUrl = await updateOutOfContact(req.body, req.params.caseId, req.params.stageId, req.requestId, req.user);
+            break;
+        default:
+            return next(new Error(`Invalid type ${req.query.type} for case ${req.params.caseId} allocation`));
+    }
+
+    return res.json({ redirect: redirectUrl });
+};
+
+const updateOutOfContact = async (formBody, caseId, stageId, requestId, user) => {
+    // If the case is out of contact then XOutOfContactPreviousTeam will have been set
+    const previousTeamName = 'XOutOfContactPreviousTeam';
+    const isOutOfContact = Boolean(formBody[previousTeamName]);
+    const payload = {
+        teamUUID: formBody[previousTeamName] ?? formBody['OutOfContactTeam']
+    };
+
+    await caseworkService.put(
+        `/case/${caseId}/stage/${stageId}/team?saveLast=${!isOutOfContact}&saveLastFieldName=${previousTeamName}`,
+        payload, { headers: { ...User.createHeaders(user), 'X-Correlation-Id': requestId } });
+
+    return `/case/${caseId}/stage/${stageId}?tab=OUT_OF_CONTACT`;
+};
+
+module.exports = {
+    allocationMiddleware
+};

--- a/server/middleware/form/process.js
+++ b/server/middleware/form/process.js
@@ -202,9 +202,11 @@ const isFieldVisible = (visibilityConditions, hideConditions, data) => {
     // hide component based on hideConditions
     if (hideConditions) {
         for (const condition of hideConditions) {
-            if (condition.function && Object.prototype.hasOwnProperty.call(hideConditions, condition.function)) {
+            if (condition.function && Object.prototype.hasOwnProperty.call(hideConditionFunctions, condition.function)) {
                 if (condition.conditionPropertyName && condition.conditionPropertyValue) {
                     isVisible = hideConditionFunctions[condition.function](data, condition.conditionPropertyName, condition.conditionPropertyValue);
+                } else if (condition.conditionArgs) {
+                    isVisible = hideConditionFunctions[condition.function](data, condition.conditionArgs);
                 } else {
                     isVisible = hideConditionFunctions[condition.function](data);
                 }

--- a/server/routes/api/case.js
+++ b/server/routes/api/case.js
@@ -21,6 +21,7 @@ const {
 } = require('../../middleware/case');
 const { somuApiResponseMiddleware } = require('../../middleware/somu');
 const { getFormForCase, getFormForStage, getGlobalFormForCase, getSomuType, getFormForSomu } = require('../../services/form');
+const { allocationMiddleware } = require('../../middleware/allocate');
 
 router.get('/:caseId/stage/:stageId/allocate', allocateCase);
 router.post('/:caseId/stage/:stageId/allocate/team',
@@ -84,6 +85,13 @@ router.post('/:caseId/stage/:stageId/form/:formId/data',
             error: res.locals.error
         });
     }
+);
+
+router.post('/:caseId/stage/:stageId/form/:formId/allocate',
+    getGlobalFormForCase,
+    fileMiddleware.any(),
+    processMiddleware,
+    allocationMiddleware
 );
 
 router.put('/:caseId/note/:noteId',

--- a/src/shared/common/components/__tests__/side-bar.spec.jsx
+++ b/src/shared/common/components/__tests__/side-bar.spec.jsx
@@ -5,7 +5,6 @@ import SideBar from '../side-bar';
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 
-
 const page = {
     params: {
         caseId: 'some_case_id',
@@ -16,6 +15,8 @@ const page = {
 const MOCK_CONFIG = {
     page
 };
+
+const history = {};
 
 describe('Side bar component', () => {
     it('should render with default props', () => {
@@ -29,7 +30,7 @@ describe('Side bar component', () => {
         const WRAPPER = render(
             <ApplicationProvider config={{ ...MOCK_CONFIG, ...defaultProps }}>
                 <MemoryRouter>
-                    <SideBar page={page} summary={defaultProps.summary} />
+                    <SideBar page={page} summary={defaultProps.summary} history={history}/>
                 </MemoryRouter>
             </ApplicationProvider>
         );
@@ -57,7 +58,7 @@ describe('Side bar component', () => {
         const WRAPPER = render(
             <ApplicationProvider config={{ ...MOCK_CONFIG, ...props }}>
                 <MemoryRouter>
-                    <SideBar page={page} summary={props.summary} />
+                    <SideBar page={page} summary={props.summary} history={history}/>
                 </MemoryRouter>
             </ApplicationProvider>
         );
@@ -87,7 +88,7 @@ describe('Side bar component', () => {
         const WRAPPER = render(
             <ApplicationProvider config={{ ...MOCK_CONFIG, ...props }}>
                 <MemoryRouter>
-                    <SideBar page={page} summary={props.summary} />
+                    <SideBar page={page} summary={props.summary} history={history}/>
                 </MemoryRouter>
             </ApplicationProvider>
         );
@@ -115,7 +116,7 @@ describe('Side bar component', () => {
         const WRAPPER = render(
             <ApplicationProvider config={{ ...MOCK_CONFIG, ...props }}>
                 <MemoryRouter>
-                    <SideBar page={page} summary={props.summary} />
+                    <SideBar page={page} summary={props.summary} history={history}/>
                 </MemoryRouter>
             </ApplicationProvider>
         );

--- a/src/shared/common/components/__tests__/tab-out-of-contact.spec.jsx
+++ b/src/shared/common/components/__tests__/tab-out-of-contact.spec.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { act, render } from '@testing-library/react';
+import TabOutOfContact from '../tab-out-of-contact';
+import axios from 'axios';
+import { Context } from '../../../contexts/application';
+
+jest.mock('axios', () => ({
+    get: jest.fn((url) => {
+        switch (url) {
+            case '/api/form/TAB_OUT_OF_CONTACT/case/__caseId__':
+                return Promise.resolve({ data: {
+                    schema: {
+                        title: 'title'
+                    },
+                    data: {}
+                } });
+        }
+    })
+}));
+
+
+describe('Out of contact', async () => {
+    const customRender = (Component) => {
+        const providerProps = {
+            dispatch: () => { return Promise.resolve(); },
+            page: {
+                params: {
+                    caseId: '__caseId__',
+                    stageId: '__stageId__'
+                }
+            }
+        };
+
+        return render(
+            <Context.Provider value={ { ...providerProps } }>{Component}</Context.Provider>,
+        );
+    };
+
+    it('can be rendered', async () => {
+        let wrapper;
+        await act(async () => {
+            wrapper = customRender(<TabOutOfContact screen={'TAB_OUT_OF_CONTACT'} history={{}} />);
+        });
+
+        expect(axios.get).toHaveBeenCalled();
+        expect(wrapper.getByText('title')).toBeInTheDocument();
+    });
+});

--- a/src/shared/common/components/side-bar.jsx
+++ b/src/shared/common/components/side-bar.jsx
@@ -8,6 +8,8 @@ import StageSummary from './stage-summary.jsx';
 import People from './people.jsx';
 import CaseActions from './case-actions.jsx';
 import TabExGratia from './tab-ex-gratia.jsx';
+import TabOutOfContact from './tab-out-of-contact';
+
 import updateCaseTabs from '../../helpers/case-tabs-helpers';
 
 class SideBar extends Component {
@@ -83,6 +85,8 @@ class SideBar extends Component {
                 return renderTab(<CaseActions />);
             case 'EX_GRATIA':
                 return renderTab(<TabExGratia screen={tab.screen} />);
+            case 'OUT_OF_CONTACT':
+                return renderTab(<TabOutOfContact screen={tab.screen} history={this.props.history}/>);
             default: return null;
         }
     }
@@ -145,7 +149,7 @@ SideBar.propTypes = {
 const WrappedSideBar = props => (
     <ApplicationConsumer>
         {({ page, activeTab, caseTabs, dispatch, summary }) =>
-            <SideBar {...props} page={page} activeTab={activeTab} caseTabs={caseTabs} dispatch={dispatch} summary={summary}/>}
+            <SideBar {...props} page={page} activeTab={activeTab} caseTabs={caseTabs} dispatch={dispatch} summary={summary}  />}
     </ApplicationConsumer>
 );
 

--- a/src/shared/common/components/side-bar.jsx
+++ b/src/shared/common/components/side-bar.jsx
@@ -137,6 +137,7 @@ SideBar.propTypes = {
     activeTab: PropTypes.string,
     page: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
+    history: PropTypes.object.isRequired,
     summary: PropTypes.object.isRequired,
     caseTabs: PropTypes.array
 };

--- a/src/shared/common/components/tab-out-of-contact.jsx
+++ b/src/shared/common/components/tab-out-of-contact.jsx
@@ -1,0 +1,52 @@
+import React, { useContext, useEffect, Fragment, useState } from 'react';
+import { Context } from '../../contexts/application.jsx';
+import PropTypes from 'prop-types';
+import status from '../../helpers/api-status';
+import {
+    updateApiStatus,
+} from '../../contexts/actions';
+import axios from 'axios';
+import FormEmbeddedWrapped from '../forms/form-embedded-wrapped.jsx';
+
+const TabOutOfContact = (props) => {
+    const { dispatch, page } = useContext(Context);
+    const [form, setForm] = useState(null);
+
+    useEffect(() => {
+        getForm();
+    }, []);
+
+    const getForm = () => {
+        const { screen } = props;
+
+        dispatch(updateApiStatus(status.REQUEST_FORM))
+            .then(() => axios.get(`/api/form/${screen}/case/${page.params.caseId}`))
+            .then(({ data }) => setForm(data))
+            .then(() => dispatch(updateApiStatus(status.REQUEST_FORM_SUCCESS)));
+    };
+
+    return (
+        <Fragment>
+            {form &&
+            <Fragment>
+                <h2 className='govuk-heading-m'>{form.schema.title}</h2>
+                <FormEmbeddedWrapped
+                    schema={ form.schema }
+                    fieldData={ form.data }
+                    action={`/api/case/${page.params.caseId}/stage/${page.params.stageId}/form/${props.screen}/allocate?type=OUT_OF_CONTACT`}
+                    baseUrl={`/case/${page.params.caseId}/stage/${page.params.stageId}`}
+                    history={props.history}
+                />
+            </Fragment>
+            }
+        </Fragment>
+    );
+};
+
+TabOutOfContact.propTypes = {
+    page: PropTypes.object,
+    screen: PropTypes.string.isRequired,
+    history: PropTypes.object.isRequired
+};
+
+export default TabOutOfContact;

--- a/src/shared/common/forms/__tests__/form-embedded-wrapped.spec.js
+++ b/src/shared/common/forms/__tests__/form-embedded-wrapped.spec.js
@@ -38,7 +38,8 @@ describe('Form embedded wrapped component', () => {
         },
         submitHandler = (() => {}),
         action = '',
-        baseUrl = '';
+        baseUrl = '',
+        history = {};
 
 
     it('should render with default props', () => {
@@ -52,6 +53,7 @@ describe('Form embedded wrapped component', () => {
                     submitHandler={submitHandler}
                     action={action}
                     baseUrl={baseUrl}
+                    history={history}
                 />
             </ApplicationProvider>
         );

--- a/src/shared/common/forms/form-embedded-wrapped.jsx
+++ b/src/shared/common/forms/form-embedded-wrapped.jsx
@@ -26,7 +26,7 @@ const FormEmbeddedWrapped = (props) => {
             return;
         }
 
-        const { action } = props;
+        const { action, history } = props;
         setSubmitting({ submittingForm: true });
 
         // eslint-disable-next-line no-undef
@@ -54,6 +54,8 @@ const FormEmbeddedWrapped = (props) => {
                         if (res.data.errors) {
                             dispatch(updateApiStatus(status.SUBMIT_FORM_VALIDATION_ERROR))
                                 .then(() => setError(res.data.errors));
+                        } else if (res.data.redirect) {
+                            history.push(res.data.redirect);
                         } else {
                             dispatch(updateApiStatus(status.UPDATE_CASE_DATA_SUCCESS))
                                 .then(() => setError(null));
@@ -99,7 +101,8 @@ FormEmbeddedWrapped.propTypes = {
     fieldData: PropTypes.object,
     submitHandler: PropTypes.func,
     action: PropTypes.string,
-    baseUrl: PropTypes.string
+    baseUrl: PropTypes.string,
+    history: PropTypes.object.isRequired
 };
 
 const FormEmbeddedWrappedWrapper = props => (

--- a/src/shared/common/forms/form-repository.jsx
+++ b/src/shared/common/forms/form-repository.jsx
@@ -104,8 +104,12 @@ function isComponentVisible(config, data) {
     // hide component based on hideConditions
     if (hideConditions) {
         for (const condition of hideConditions) {
-            if (condition.function && Object.prototype.hasOwnProperty.call(hideConditions, condition.function)) {
-                isVisible = hideConditionFunctions[condition.function](data);
+            if (condition.function && Object.prototype.hasOwnProperty.call(hideConditionFunctions, condition.function)) {
+                if (condition.conditionArgs) {
+                    isVisible = hideConditionFunctions[condition.function](data, condition.conditionArgs);
+                } else {
+                    isVisible = hideConditionFunctions[condition.function](data);
+                }
             } else if (data && data[condition.conditionPropertyName] && data[condition.conditionPropertyName] === condition.conditionPropertyValue) {
                 isVisible = false;
             }
@@ -168,7 +172,7 @@ export function formComponentFactory(field, options) {
         case 'confirmation-with-team-name-and-case-ref':
             return renderFormComponent(ConfirmationWithTeamNameAndCaseRef, { key, data, config, caseRef });
         case 'paragraph':
-            return renderFormComponent(Paragraph, { key, config });
+            return renderFormComponent(Paragraph, { key, data, config });
         case 'entity-manager':
             return renderFormComponent(EntityManager, { key, config: { ...config, baseUrl: options.baseUrl } });
         case 'display':

--- a/src/shared/helpers/__tests__/hide-condition-functions.spec.js
+++ b/src/shared/helpers/__tests__/hide-condition-functions.spec.js
@@ -40,4 +40,78 @@ describe('HideConditionFunctions', () => {
             expect(HideConditionFunctions.hasNoContributionsOrFulfilled(mockData[5])).toBe(false);
         });
     });
+
+    describe('hasAnyValue', () => {
+
+        it('should return true when conditionPropertyName is absent in data',  () => {
+
+            const data =  {};
+            const conditionArgs = {
+                'conditionPropertyName': 'var1'
+            };
+
+            const result = HideConditionFunctions.hasAnyValue(data, conditionArgs);
+
+            expect(result).toBeTruthy();
+        });
+
+        it('should return true when conditionPropertyName has empty string val in data',  () => {
+
+            const data =  {
+                'var1': ''
+            };
+            const conditionArgs = {
+                'conditionPropertyName': 'var1'
+            };
+
+            const result = HideConditionFunctions.hasAnyValue(data, conditionArgs);
+
+            expect(result).toBeTruthy();
+        });
+
+        it('should return true when conditionPropertyName has "null" value in data',  () => {
+
+            const data =  {
+                'var1': null
+            };
+
+            const conditionArgs = {
+                'conditionPropertyName': 'var1'
+            };
+
+            const result = HideConditionFunctions.hasAnyValue(data, conditionArgs);
+
+            expect(result).toBeTruthy();
+        });
+
+        it('should return false when conditionPropertyName has string val in data',  () => {
+
+            const data =  {
+                'var1': 'val1'
+            };
+
+            const conditionArgs = {
+                'conditionPropertyName': 'var1'
+            };
+
+            const result = HideConditionFunctions.hasAnyValue(data, conditionArgs);
+
+            expect(result).toBeFalsy();
+        });
+
+        it('should return false when conditionPropertyName has number val in data',  () => {
+
+            const data =  {
+                'var1': 100
+            };
+
+            const conditionArgs = {
+                'conditionPropertyName': 'var1'
+            };
+
+            const result = HideConditionFunctions.hasAnyValue(data, conditionArgs);
+
+            expect(result).toBeFalsy();
+        });
+    });
 });

--- a/src/shared/helpers/hide-condition-functions.js
+++ b/src/shared/helpers/hide-condition-functions.js
@@ -17,6 +17,14 @@ function hasNoContributionsOrFulfilled(data) {
     }
 }
 
+function hasAnyValue(data, conditionArgs) {
+    if (data && data[conditionArgs.conditionPropertyName]) {
+        return false;
+    }
+    return true;
+}
+
 module.exports = {
+    hasAnyValue,
     hasNoContributionsOrFulfilled
 };

--- a/src/shared/pages/form-enabled.jsx
+++ b/src/shared/pages/form-enabled.jsx
@@ -203,12 +203,12 @@ function withForm(Page) {
         }
 
         renderForm() {
-            const { form, match: { url, params }, hasSidebar } = this.props;
+            const { form, match: { url, params }, hasSidebar, history } = this.props;
             const { form_data, form_meta, form_schema, submittingForm } = this.state;
             const { errors } = form || {};
             return (
                 <Page title={form_schema.title} form={form_meta}
-                    hasSidebar={hasSidebar || (form_schema.props && form_schema.props.hasSidebar)} >
+                    hasSidebar={hasSidebar || (form_schema.props && form_schema.props.hasSidebar)} history={history} >
                     {form_schema && <Form
                         {...{
                             schema: form_schema,

--- a/src/shared/pages/stage.jsx
+++ b/src/shared/pages/stage.jsx
@@ -10,7 +10,8 @@ class Stage extends Component {
             children,
             form,
             title,
-            hasSidebar
+            hasSidebar,
+            history
         } = this.props;
 
         return (
@@ -23,7 +24,7 @@ class Stage extends Component {
                     {children}
                 </div>
                 {this.shouldDisplaySidebar(hasSidebar) && <div className="govuk-grid-column-two-thirds">
-                    <SideBar />
+                    <SideBar history={history}/>
                 </div>}
             </div>
         );
@@ -42,7 +43,8 @@ Stage.propTypes = {
     children: PropTypes.node,
     form: PropTypes.object,
     title: PropTypes.string,
-    hasSidebar: PropTypes.string
+    hasSidebar: PropTypes.string,
+    history: PropTypes.object
 };
 
 export default formEnabled(Stage);


### PR DESCRIPTION
Add the `Out of Contact` behaviour that acts as a case reallocation form within a tab. 

This change consists of:
- Prop drill the react router `history` object down to the individual tab. This allows for a redirection back after the change has been applied.
- Addition of the `hasAnyValue` to the hide condition functions.
- New static list applied for the Out of Contact team selection.

Included within this is a fix to the hide condition that previously was mis-checking the input against itself to run a method. This has now been altered to correctly check if the `hideConditionFunctions` class has the function. 
