### PR TITLE
HOCS-6562: change document handling

### DIFF
--- a/server/middleware/__tests__/document.spec.js
+++ b/server/middleware/__tests__/document.spec.js
@@ -2,17 +2,75 @@ const {
     getOriginalDocument,
     getPdfDocument,
     getDocumentList,
-    apiGetDocumentList
+    apiGetDocumentList, getDocumentInfo
 } = require('../document');
 
 jest.mock('../../clients', () => ({
     caseworkService: {
         get: jest.fn()
+    },
+    documentService: {
+        get: jest.fn()
     }
 }));
-const { caseworkService } = require('../../clients');
+const { caseworkService, documentService } = require('../../clients');
+const { AuthenticationError } = require('../../models/error');
 
 describe('Document middleware', () => {
+
+    describe('Get document info middleware', () => {
+        let req = {};
+        let res = {};
+        const mockResponse = { data: {}, headers: { 'content-disposition': 'TEST' } };
+        const next = jest.fn();
+        const mockUser = { username: 'TEST_USER', uuid: 'TEST', roles: [], groups: [] };
+
+        beforeEach(() => {
+            next.mockReset();
+            req = { params: { documentId: '1234', caseId: '5522' }, user: mockUser,
+                requestId: '00000000-0000-0000-0000-000000000000' };
+            res = { setHeader: jest.fn() };
+            mockResponse.status = 200;
+        });
+
+        const expectedOptions = {
+            headers: {
+                'X-Auth-Groups': '',
+                'X-Auth-Roles': '',
+                'X-Auth-UserId': 'TEST',
+                'X-Correlation-Id': '00000000-0000-0000-0000-000000000000'
+            },
+            responseType: 'stream'
+        };
+
+        it('should call casework service with correct options', async () => {
+            caseworkService.get.mockImplementation(() => Promise.resolve(mockResponse));
+            await getDocumentInfo(req, res, next);
+            expect(caseworkService.get).toHaveBeenCalled();
+            expect(caseworkService.get).toHaveBeenCalledWith('/case/5522/document/1234', expectedOptions);
+        });
+
+        it('should call next with an error if request fails', async () => {
+            const mockError = new Error('Unable to retrieve document information');
+            caseworkService.get.mockImplementation(() => Promise.reject(mockError));
+            await getDocumentInfo(req, res, next);
+            expect(next).toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith(mockError);
+        });
+
+        it('should call next with an error if response status is 401', async () => {
+            const err = {
+                response: {
+                    status: 401
+                }
+            };
+
+            caseworkService.get.mockImplementation(() => Promise.reject(err));
+            await getDocumentInfo(req, res, next);
+            expect(next).toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith(new AuthenticationError('You are not authorised to work on this case'));
+        });
+    });
 
     describe('Get original document middleware', () => {
 
@@ -43,10 +101,10 @@ describe('Document middleware', () => {
         };
 
         it('should pipe the response on success', async () => {
-            caseworkService.get.mockImplementation(() => Promise.resolve(mockResponse));
+            documentService.get.mockImplementation(() => Promise.resolve(mockResponse));
             await getOriginalDocument(req, res, next);
-            expect(caseworkService.get).toHaveBeenCalled();
-            expect(caseworkService.get).toHaveBeenCalledWith('/case/5522/document/1234/file', expectedOptions);
+            expect(documentService.get).toHaveBeenCalled();
+            expect(documentService.get).toHaveBeenCalledWith('/document/1234/file', expectedOptions);
             expect(res.setHeader).toHaveBeenCalled();
             expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'max-age=86400');
             expect(mockResponse.data.pipe).toHaveBeenCalled();
@@ -55,7 +113,7 @@ describe('Document middleware', () => {
 
         it('should call next with an error if request fails', async () => {
             const mockError = new Error('Unable to retrieve original document');
-            caseworkService.get.mockImplementation(() => Promise.reject(mockError));
+            documentService.get.mockImplementation(() => Promise.reject(mockError));
             await getOriginalDocument(req, res, next);
             expect(next).toHaveBeenCalled();
             expect(next).toHaveBeenCalledWith(mockError);
@@ -93,10 +151,10 @@ describe('Document middleware', () => {
         };
 
         it('should pipe the response on success', async () => {
-            caseworkService.get.mockImplementation(() => Promise.resolve(mockResponse));
+            documentService.get.mockImplementation(() => Promise.resolve(mockResponse));
             await getPdfDocument(req, res, next);
-            expect(caseworkService.get).toHaveBeenCalled();
-            expect(caseworkService.get).toHaveBeenCalledWith('/case/5522/document/1234/pdf', expectedOptions);
+            expect(documentService.get).toHaveBeenCalled();
+            expect(documentService.get).toHaveBeenCalledWith('/document/1234/pdf', expectedOptions);
             expect(res.setHeader).toHaveBeenCalled();
             expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'max-age=86400');
             expect(mockResponse.data.pipe).toHaveBeenCalled();
@@ -105,7 +163,7 @@ describe('Document middleware', () => {
 
         it('should call next with an error if request fails', async () => {
             const mockError = new Error('Unable to retrieve PDF document');
-            caseworkService.get.mockImplementation(() => Promise.reject(mockError));
+            documentService.get.mockImplementation(() => Promise.reject(mockError));
             await getPdfDocument(req, res, next);
             expect(next).toHaveBeenCalled();
             expect(next).toHaveBeenCalledWith(mockError);

--- a/server/middleware/document.js
+++ b/server/middleware/document.js
@@ -1,34 +1,56 @@
-const { caseworkService } = require('../clients');
+const { caseworkService, documentService } = require('../clients');
 const getLogger = require('../libs/logger');
 const { DocumentError, AuthenticationError } = require('../models/error');
 const User = require('../models/user');
 
-async function getOriginalDocument(req, res, next) {
+/*
+ * This method is used to retrieve the document information from the casework service.
+ * This is effectively acting as a permission check, to validate the user has access to the document.
+ */
+async function getDocumentInfo(req, res, next) {
     const logger = getLogger(req.requestId);
     const { caseId, documentId } = req.params;
     let options = {
         headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId },
         responseType: 'stream'
     };
+
+    logger.info('REQUEST_DOCUMENT_INFORMATION', { ...req.params });
+    try {
+        await caseworkService.get(`/case/${caseId}/document/${documentId}`, options);
+        return next();
+    } catch (error) {
+        logger.error('REQUEST_DOCUMENT_ORIGINAL_FAILURE', { ...req.params });
+        if (error.response !== undefined && error.response.status === 401) {
+            return next(new AuthenticationError('You are not authorised to work on this case'));
+        }
+        return next(new DocumentError('Unable to retrieve document information'));
+    }
+}
+
+async function getOriginalDocument(req, res, next) {
+    const logger = getLogger(req.requestId);
+    const { documentId } = req.params;
+    let options = {
+        headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId },
+        responseType: 'stream'
+    };
     logger.info('REQUEST_DOCUMENT_ORIGINAL', { ...req.params });
     try {
-        const response = await caseworkService.get(`/case/${caseId}/document/${documentId}/file`, options);
+        const response = await documentService.get(`/document/${documentId}/file`, options);
         res.setHeader('Cache-Control', 'max-age=86400');
         res.setHeader('Content-Disposition', response.headers['content-disposition']);
         response.data.on('finish', () => logger.debug('REQUEST_DOCUMENT_ORIGINAL_SUCCESS', { ...req.params }));
         response.data.pipe(res);
     } catch (error) {
         logger.error('REQUEST_DOCUMENT_ORIGINAL_FAILURE', { ...req.params });
-        if (error.response !== undefined && error.response.status === 401) {
-            return next(new AuthenticationError('You are not authorised to work on this case'));
-        }
         return next(new DocumentError('Unable to retrieve original document'));
     }
 }
 
 async function getPdfDocument(req, res, next) {
     const logger = getLogger(req.requestId);
-    const { caseId, documentId } = req.params;
+    const { documentId } = req.params;
     logger.info('REQUEST_DOCUMENT_PDF', { ...req.params });
 
     let options = {
@@ -37,23 +59,20 @@ async function getPdfDocument(req, res, next) {
     };
 
     try {
-        const response = await caseworkService.get(`/case/${caseId}/document/${documentId}/pdf`, options);
+        const response = await documentService.get(`/document/${documentId}/pdf`, options);
         res.setHeader('Cache-Control', 'max-age=86400');
         res.setHeader('Content-Disposition', response.headers['content-disposition']);
         response.data.on('finish', () => logger.debug('REQUEST_DOCUMENT_PDF_SUCCESS', { ...req.params }));
         response.data.pipe(res);
     } catch (error) {
         logger.error('REQUEST_DOCUMENT_PDF_FAILURE', { ...req.params });
-        if (error.response !== undefined && error.response.status === 401) {
-            return next(new AuthenticationError('You are not authorised to work on this case'));
-        }
         return next(new DocumentError('Unable to retrieve PDF document'));
     }
 }
 
 async function getPdfDocumentPreview(req, res, next) {
     const logger = getLogger(req.requestId);
-    const { caseId, documentId } = req.params;
+    const { documentId } = req.params;
 
     let options = {
         headers: { ...User.createHeaders(req.user), 'X-Correlation-Id': req.requestId } ,
@@ -62,15 +81,12 @@ async function getPdfDocumentPreview(req, res, next) {
 
     logger.info('REQUEST_DOCUMENT_PREVIEW', { ...req.params });
     try {
-        const response = await caseworkService.get(`/case/${caseId}/document/${documentId}/pdf`, options);
+        const response = await documentService.get(`/document/${documentId}/pdf`, options);
         res.setHeader('Cache-Control', 'max-age=86400');
         response.data.on('finish', () => logger.debug('REQUEST_DOCUMENT_PREVIEW_SUCCESS', { ...req.params }));
         response.data.pipe(res);
     } catch (error) {
         logger.error('REQUEST_DOCUMENT_PREVIEW_FAILURE', { ...req.params });
-        if (error.response !== undefined && error.response.status === 401) {
-            return next(new AuthenticationError('You are not authorised to work on this case'));
-        }
         return next(new DocumentError('Unable to retrieve document for PDF preview'));
     }
 }
@@ -95,6 +111,7 @@ function apiGetDocumentList(req, res) {
 }
 
 module.exports = {
+    getDocumentInfo,
     getOriginalDocument,
     getPdfDocument,
     getPdfDocumentPreview,

--- a/server/routes/document.js
+++ b/server/routes/document.js
@@ -1,11 +1,11 @@
 const router = require('express').Router();
-const { getOriginalDocument, getPdfDocument, getPdfDocumentPreview } = require('../middleware/document');
+const { getDocumentInfo, getOriginalDocument, getPdfDocument, getPdfDocumentPreview } = require('../middleware/document');
 
-router.get('/:caseId/document/:documentId/preview', getPdfDocumentPreview);
+router.get('/:caseId/document/:documentId/preview', getDocumentInfo, getPdfDocumentPreview);
 
-router.get('/:caseId/stage/:stageId/download/document/:documentId/pdf', getPdfDocument);
+router.get('/:caseId/stage/:stageId/download/document/:documentId/pdf', getDocumentInfo, getPdfDocument);
 
-router.get('/:caseId/stage/:stageId/download/document/:documentId/original', getOriginalDocument);
+router.get('/:caseId/stage/:stageId/download/document/:documentId/original', getDocumentInfo, getOriginalDocument);
 
 router.get('/:caseId/stage/:stageId/download/standard_line/:documentId', getOriginalDocument);
 


### PR DESCRIPTION
Previously we're using the casework service as a permission middleware and sending the entire document through this service. This results in high memory usage and utilisation through this service, exaggerating existing performance issues.

This change adds a permission specific check that doesn't passthrough the entire file. After this permission check passes, the document is then requested from the document service directly.