### PR TITLE
Hocs 6656 invalid date fix

### DIFF
--- a/server/middleware/form/__tests__/process.spec.js
+++ b/server/middleware/form/__tests__/process.spec.js
@@ -432,7 +432,7 @@ describe('Process middleware', () => {
     it('should return sanitised year on change', () => {
         const req = {
             body: {
-                ['test-field-1']: '0000-01-01',
+                ['test-field-1']: '2000-01-01',
                 ['test-field-2']: '00002021-01-01',
                 ['test-field-3']: '002000-01-01',
             },
@@ -475,7 +475,10 @@ describe('Process middleware', () => {
 
         processMiddleware(req, res, next);
         expect(req.form).toBeDefined();
-        expect(req.form.data).toBeUndefined();
+        expect(req.form.data).toBeDefined();
+        expect(req.form.data['test-field-1']).toEqual('2000-01-01');
+        expect(req.form.data['test-field-2']).toEqual('2021-01-01');
+        expect(req.form.data['test-field-3']).toEqual('2000-01-01');
         expect(next).toHaveBeenCalled();
         expect(next).toHaveBeenCalledTimes(1);
     });

--- a/server/middleware/form/__tests__/process.spec.js
+++ b/server/middleware/form/__tests__/process.spec.js
@@ -475,10 +475,7 @@ describe('Process middleware', () => {
 
         processMiddleware(req, res, next);
         expect(req.form).toBeDefined();
-        expect(req.form.data).toBeDefined();
-        expect(req.form.data['test-field-1']).toEqual('-01-01');
-        expect(req.form.data['test-field-2']).toEqual('2021-01-01');
-        expect(req.form.data['test-field-3']).toEqual('2000-01-01');
+        expect(req.form.data).toBeUndefined();
         expect(next).toHaveBeenCalled();
         expect(next).toHaveBeenCalledTimes(1);
     });
@@ -529,10 +526,7 @@ describe('Process middleware', () => {
 
         processMiddleware(req, res, next);
         expect(req.form).toBeDefined();
-        expect(req.form.data).toBeDefined();
-        expect(req.form.data['test-field-1']).toEqual('-01-01');
-        expect(req.form.data['test-field-2']).toEqual('2021--01');
-        expect(req.form.data['test-field-3']).toEqual('2000-01-');
+        expect(req.form.data).toBeUndefined();
         expect(next).toHaveBeenCalled();
         expect(next).toHaveBeenCalledTimes(1);
     });

--- a/server/middleware/form/__tests__/process.spec.js
+++ b/server/middleware/form/__tests__/process.spec.js
@@ -483,57 +483,6 @@ describe('Process middleware', () => {
         expect(next).toHaveBeenCalledTimes(1);
     });
 
-    it('should reject date fields if contains non-numerical characters', () => {
-        const req = {
-            body: {
-                ['test-field-1']: 'da2021-01-01',
-                ['test-field-2']: '2021-01/-01',
-                ['test-field-3']: '2000-01-/01',
-            },
-            query: {},
-            form: {
-                schema: {
-                    fields: [
-                        {
-                            component: 'date',
-                            validation: [
-                                'required'
-                            ],
-                            props: {
-                                name: 'test-field-1',
-                            }
-                        },
-                        {
-                            component: 'date',
-                            validation: [
-                                'required'
-                            ],
-                            props: {
-                                name: 'test-field-2',
-                            }
-                        },
-                        {
-                            component: 'date',
-                            validation: [
-                                'required'
-                            ],
-                            props: {
-                                name: 'test-field-3',
-                            }
-                        }
-                    ]
-                }
-            }
-        };
-        const res = {};
-
-        processMiddleware(req, res, next);
-        expect(req.form).toBeDefined();
-        expect(req.form.data).toBeUndefined();
-        expect(next).toHaveBeenCalled();
-        expect(next).toHaveBeenCalledTimes(1);
-    });
-
     it('should process checkbox data passed as an array', () => {
         const req = {
             body: {

--- a/server/middleware/form/process.js
+++ b/server/middleware/form/process.js
@@ -23,7 +23,15 @@ const customAdapters = {
         const [year = '', month = '', day = ''] = value.split('-');
 
         if (year && month && day) {
-            reducer[name] = `${sanitiseValueString(year, YEAR_REGEX)}-${sanitiseValueString(month, MONTH_REGEX, 2)}-${sanitiseValueString(day, DAY_REGEX, 2)}`;
+            const sanitisedYear = `${sanitiseValueString(year, YEAR_REGEX)}`;
+            const sanitisedMonth = `${sanitiseValueString(month, MONTH_REGEX, 2)}`;
+            const sanitisedDay = `${sanitiseValueString(day, DAY_REGEX, 2)}`;
+
+            if(sanitisedYear === '' || sanitisedMonth === '' ||  sanitisedDay === '') {
+                reducer[name] = '';
+            } else {
+                reducer[name] = `${sanitisedYear}-${sanitisedMonth}-${sanitisedDay}`;
+            }
         } else {
             reducer[name] = '';
         }
@@ -236,6 +244,7 @@ function sanitiseValueString(value, pattern, padLength = 0) {
     const regexMatch = regexMatcher.exec(value);
 
     if (regexMatch) {
+
         return regexMatch[0]
             .replace(/^0+/, '')
             .padStart(padLength, '0');


### PR DESCRIPTION
HOCS-6656: Currently there is an issue when the user enters special or invalid numeric
values in date, month or year field - validation happens in javascript but it replaces 
invalid entry as blank to save it to backend DB. 

For example - if the data field entered as 2023/-05-25 
then while saving payload date is saved as -05-25 rather throwing an error in the UI. 
Also when its parsed in work stack it fails with below error:
**Cannot deserialize value of type `java.time.LocalDate` from String \"2023/-05-25\": Failed to deserialize java.time.LocalDate: (java.time.format.DateTimeParseException) Text '2023/-05-25'**

Applied fix would contain if any of the date field is incorrect, the function would return an 
empty string and this will make sure the user will get an error requesting user to enter 
valid date. Also below scenarios being handled.

**Mandatory date field**
1. If there is a special character entered in any of date field - throw error message
2. If the entered numeric is not valid then error message - for example in month fields if 13 is entered then an error is thrown
3. Only save legitimate date if entered

**Non-mandatory date field (like Complainant DOB)**
1. If a date entered just have only date field whereas month and year is blank then the field will not be saved to backend. Looks like this is the current behaviour.
