### PR TITLE
Workaround security vulns causing build failures.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "hocs-frontend",
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
@@ -86,6 +87,15 @@
                 "node": ">=18.12.1"
             }
         },
+        "node_modules/@aashutoshrathi/word-wrap": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/@adobe/css-tools": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
@@ -115,9 +125,9 @@
             }
         },
         "node_modules/@aws-crypto/crc32/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -126,9 +136,9 @@
             }
         },
         "node_modules/@aws-crypto/crc32/node_modules/@aws-sdk/types/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         },
         "node_modules/@aws-crypto/crc32/node_modules/tslib": {
             "version": "1.14.1",
@@ -146,9 +156,9 @@
             }
         },
         "node_modules/@aws-crypto/crc32c/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -157,9 +167,9 @@
             }
         },
         "node_modules/@aws-crypto/crc32c/node_modules/@aws-sdk/types/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         },
         "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
             "version": "1.14.1",
@@ -230,9 +240,9 @@
             }
         },
         "node_modules/@aws-crypto/sha256-browser/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -241,9 +251,9 @@
             }
         },
         "node_modules/@aws-crypto/sha256-browser/node_modules/@aws-sdk/types/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         },
         "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
             "version": "1.14.1",
@@ -261,9 +271,9 @@
             }
         },
         "node_modules/@aws-crypto/sha256-js/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -272,9 +282,9 @@
             }
         },
         "node_modules/@aws-crypto/sha256-js/node_modules/@aws-sdk/types/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         },
         "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
             "version": "1.14.1",
@@ -357,127 +367,63 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.347.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.347.1.tgz",
-            "integrity": "sha512-s7LPecYBo78uMB4ZrSuSV/cGjc9RLzZ5+SA9Ds0mPWudeRROsogBqxK82qZqoCfjPAUVB24e2MIarV8Hzu6+jw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.363.0.tgz",
+            "integrity": "sha512-LNnfg/t8wG5Fqj6l+PSV/t+IXDq9r3Kj9jEHn84513+p7bewXYSSreSpmLjG8OcKuMfHc9EJGNQ3DkMyFaLoWg==",
             "dependencies": {
                 "@aws-crypto/sha1-browser": "3.0.0",
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.347.1",
-                "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/credential-provider-node": "3.347.0",
-                "@aws-sdk/eventstream-serde-browser": "3.347.0",
-                "@aws-sdk/eventstream-serde-config-resolver": "3.347.0",
-                "@aws-sdk/eventstream-serde-node": "3.347.0",
-                "@aws-sdk/fetch-http-handler": "3.347.0",
-                "@aws-sdk/hash-blob-browser": "3.347.0",
-                "@aws-sdk/hash-node": "3.347.0",
-                "@aws-sdk/hash-stream-node": "3.347.0",
-                "@aws-sdk/invalid-dependency": "3.347.0",
-                "@aws-sdk/md5-js": "3.347.0",
-                "@aws-sdk/middleware-bucket-endpoint": "3.347.0",
-                "@aws-sdk/middleware-content-length": "3.347.0",
-                "@aws-sdk/middleware-endpoint": "3.347.0",
-                "@aws-sdk/middleware-expect-continue": "3.347.0",
-                "@aws-sdk/middleware-flexible-checksums": "3.347.0",
-                "@aws-sdk/middleware-host-header": "3.347.0",
-                "@aws-sdk/middleware-location-constraint": "3.347.0",
-                "@aws-sdk/middleware-logger": "3.347.0",
-                "@aws-sdk/middleware-recursion-detection": "3.347.0",
-                "@aws-sdk/middleware-retry": "3.347.0",
-                "@aws-sdk/middleware-sdk-s3": "3.347.0",
-                "@aws-sdk/middleware-serde": "3.347.0",
-                "@aws-sdk/middleware-signing": "3.347.0",
-                "@aws-sdk/middleware-ssec": "3.347.0",
-                "@aws-sdk/middleware-stack": "3.347.0",
-                "@aws-sdk/middleware-user-agent": "3.347.0",
-                "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.347.0",
-                "@aws-sdk/signature-v4-multi-region": "3.347.0",
-                "@aws-sdk/smithy-client": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/url-parser": "3.347.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
-                "@aws-sdk/util-defaults-mode-node": "3.347.0",
-                "@aws-sdk/util-endpoints": "3.347.0",
-                "@aws-sdk/util-retry": "3.347.0",
-                "@aws-sdk/util-stream-browser": "3.347.0",
-                "@aws-sdk/util-stream-node": "3.347.0",
-                "@aws-sdk/util-user-agent-browser": "3.347.0",
-                "@aws-sdk/util-user-agent-node": "3.347.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@aws-sdk/util-waiter": "3.347.0",
+                "@aws-sdk/client-sts": "3.363.0",
+                "@aws-sdk/credential-provider-node": "3.363.0",
+                "@aws-sdk/hash-blob-browser": "3.357.0",
+                "@aws-sdk/hash-stream-node": "3.357.0",
+                "@aws-sdk/md5-js": "3.357.0",
+                "@aws-sdk/middleware-bucket-endpoint": "3.363.0",
+                "@aws-sdk/middleware-expect-continue": "3.363.0",
+                "@aws-sdk/middleware-flexible-checksums": "3.363.0",
+                "@aws-sdk/middleware-host-header": "3.363.0",
+                "@aws-sdk/middleware-location-constraint": "3.363.0",
+                "@aws-sdk/middleware-logger": "3.363.0",
+                "@aws-sdk/middleware-recursion-detection": "3.363.0",
+                "@aws-sdk/middleware-sdk-s3": "3.363.0",
+                "@aws-sdk/middleware-signing": "3.363.0",
+                "@aws-sdk/middleware-ssec": "3.363.0",
+                "@aws-sdk/middleware-user-agent": "3.363.0",
+                "@aws-sdk/signature-v4-multi-region": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/util-user-agent-browser": "3.363.0",
+                "@aws-sdk/util-user-agent-node": "3.363.0",
                 "@aws-sdk/xml-builder": "3.310.0",
+                "@smithy/config-resolver": "^1.0.1",
+                "@smithy/eventstream-serde-browser": "^1.0.1",
+                "@smithy/eventstream-serde-config-resolver": "^1.0.1",
+                "@smithy/eventstream-serde-node": "^1.0.1",
+                "@smithy/fetch-http-handler": "^1.0.1",
+                "@smithy/hash-node": "^1.0.1",
+                "@smithy/invalid-dependency": "^1.0.1",
+                "@smithy/middleware-content-length": "^1.0.1",
+                "@smithy/middleware-endpoint": "^1.0.1",
+                "@smithy/middleware-retry": "^1.0.2",
+                "@smithy/middleware-serde": "^1.0.1",
+                "@smithy/middleware-stack": "^1.0.1",
+                "@smithy/node-config-provider": "^1.0.1",
+                "@smithy/node-http-handler": "^1.0.2",
                 "@smithy/protocol-http": "^1.0.1",
+                "@smithy/smithy-client": "^1.0.3",
                 "@smithy/types": "^1.0.0",
-                "fast-xml-parser": "4.2.4",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-endpoint": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-            "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-            "dependencies": {
-                "@aws-sdk/middleware-serde": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/url-parser": "3.347.0",
-                "@aws-sdk/util-middleware": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-serde": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-            "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-stack": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-            "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/querystring-parser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-            "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/smithy-client": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-            "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-            "dependencies": {
-                "@aws-sdk/middleware-stack": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@smithy/url-parser": "^1.0.1",
+                "@smithy/util-base64": "^1.0.1",
+                "@smithy/util-body-length-browser": "^1.0.1",
+                "@smithy/util-body-length-node": "^1.0.1",
+                "@smithy/util-defaults-mode-browser": "^1.0.1",
+                "@smithy/util-defaults-mode-node": "^1.0.1",
+                "@smithy/util-retry": "^1.0.2",
+                "@smithy/util-stream": "^1.0.1",
+                "@smithy/util-utf8": "^1.0.1",
+                "@smithy/util-waiter": "^1.0.1",
+                "fast-xml-parser": "4.2.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -485,30 +431,9 @@
             }
         },
         "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/url-parser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-            "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-            "dependencies": {
-                "@aws-sdk/querystring-parser": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-middleware": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-            "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -517,42 +442,42 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.347.0.tgz",
-            "integrity": "sha512-AZehWCNLUXTrDavsZYRi7d84Uef20ppYJ2FY0KxqrKB3lx89mO29SfSJSC4woeW5+6ooBokq8HtKxw5ImPfRhA==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.363.0.tgz",
+            "integrity": "sha512-PZ+HfKSgS4hlMnJzG+Ev8/mgHd/b/ETlJWPSWjC/f2NwVoBQkBnqHjdyEx7QjF6nksJozcVh5Q+kkYLKc/QwBQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/fetch-http-handler": "3.347.0",
-                "@aws-sdk/hash-node": "3.347.0",
-                "@aws-sdk/invalid-dependency": "3.347.0",
-                "@aws-sdk/middleware-content-length": "3.347.0",
-                "@aws-sdk/middleware-endpoint": "3.347.0",
-                "@aws-sdk/middleware-host-header": "3.347.0",
-                "@aws-sdk/middleware-logger": "3.347.0",
-                "@aws-sdk/middleware-recursion-detection": "3.347.0",
-                "@aws-sdk/middleware-retry": "3.347.0",
-                "@aws-sdk/middleware-serde": "3.347.0",
-                "@aws-sdk/middleware-stack": "3.347.0",
-                "@aws-sdk/middleware-user-agent": "3.347.0",
-                "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.347.0",
-                "@aws-sdk/smithy-client": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/url-parser": "3.347.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
-                "@aws-sdk/util-defaults-mode-node": "3.347.0",
-                "@aws-sdk/util-endpoints": "3.347.0",
-                "@aws-sdk/util-retry": "3.347.0",
-                "@aws-sdk/util-user-agent-browser": "3.347.0",
-                "@aws-sdk/util-user-agent-node": "3.347.0",
-                "@aws-sdk/util-utf8": "3.310.0",
+                "@aws-sdk/middleware-host-header": "3.363.0",
+                "@aws-sdk/middleware-logger": "3.363.0",
+                "@aws-sdk/middleware-recursion-detection": "3.363.0",
+                "@aws-sdk/middleware-user-agent": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/util-user-agent-browser": "3.363.0",
+                "@aws-sdk/util-user-agent-node": "3.363.0",
+                "@smithy/config-resolver": "^1.0.1",
+                "@smithy/fetch-http-handler": "^1.0.1",
+                "@smithy/hash-node": "^1.0.1",
+                "@smithy/invalid-dependency": "^1.0.1",
+                "@smithy/middleware-content-length": "^1.0.1",
+                "@smithy/middleware-endpoint": "^1.0.1",
+                "@smithy/middleware-retry": "^1.0.2",
+                "@smithy/middleware-serde": "^1.0.1",
+                "@smithy/middleware-stack": "^1.0.1",
+                "@smithy/node-config-provider": "^1.0.1",
+                "@smithy/node-http-handler": "^1.0.2",
                 "@smithy/protocol-http": "^1.0.1",
+                "@smithy/smithy-client": "^1.0.3",
                 "@smithy/types": "^1.0.0",
+                "@smithy/url-parser": "^1.0.1",
+                "@smithy/util-base64": "^1.0.1",
+                "@smithy/util-body-length-browser": "^1.0.1",
+                "@smithy/util-body-length-node": "^1.0.1",
+                "@smithy/util-defaults-mode-browser": "^1.0.1",
+                "@smithy/util-defaults-mode-node": "^1.0.1",
+                "@smithy/util-retry": "^1.0.2",
+                "@smithy/util-utf8": "^1.0.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -560,105 +485,42 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.347.0.tgz",
-            "integrity": "sha512-IBxRfPqb8f9FqpmDbzcRDfoiasj/Y47C4Gj+j3kA5T1XWyGwbDI9QnPW/rnkZTWxLUUG1LSbBNwbPD6TLoff8A==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.363.0.tgz",
+            "integrity": "sha512-V3Ebiq/zNtDS/O92HUWGBa7MY59RYSsqWd+E0XrXv6VYTA00RlMTbNcseivNgp2UghOgB9a20Nkz6EqAeIN+RQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/fetch-http-handler": "3.347.0",
-                "@aws-sdk/hash-node": "3.347.0",
-                "@aws-sdk/invalid-dependency": "3.347.0",
-                "@aws-sdk/middleware-content-length": "3.347.0",
-                "@aws-sdk/middleware-endpoint": "3.347.0",
-                "@aws-sdk/middleware-host-header": "3.347.0",
-                "@aws-sdk/middleware-logger": "3.347.0",
-                "@aws-sdk/middleware-recursion-detection": "3.347.0",
-                "@aws-sdk/middleware-retry": "3.347.0",
-                "@aws-sdk/middleware-serde": "3.347.0",
-                "@aws-sdk/middleware-stack": "3.347.0",
-                "@aws-sdk/middleware-user-agent": "3.347.0",
-                "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.347.0",
-                "@aws-sdk/smithy-client": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/url-parser": "3.347.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
-                "@aws-sdk/util-defaults-mode-node": "3.347.0",
-                "@aws-sdk/util-endpoints": "3.347.0",
-                "@aws-sdk/util-retry": "3.347.0",
-                "@aws-sdk/util-user-agent-browser": "3.347.0",
-                "@aws-sdk/util-user-agent-node": "3.347.0",
-                "@aws-sdk/util-utf8": "3.310.0",
+                "@aws-sdk/middleware-host-header": "3.363.0",
+                "@aws-sdk/middleware-logger": "3.363.0",
+                "@aws-sdk/middleware-recursion-detection": "3.363.0",
+                "@aws-sdk/middleware-user-agent": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/util-user-agent-browser": "3.363.0",
+                "@aws-sdk/util-user-agent-node": "3.363.0",
+                "@smithy/config-resolver": "^1.0.1",
+                "@smithy/fetch-http-handler": "^1.0.1",
+                "@smithy/hash-node": "^1.0.1",
+                "@smithy/invalid-dependency": "^1.0.1",
+                "@smithy/middleware-content-length": "^1.0.1",
+                "@smithy/middleware-endpoint": "^1.0.1",
+                "@smithy/middleware-retry": "^1.0.2",
+                "@smithy/middleware-serde": "^1.0.1",
+                "@smithy/middleware-stack": "^1.0.1",
+                "@smithy/node-config-provider": "^1.0.1",
+                "@smithy/node-http-handler": "^1.0.2",
                 "@smithy/protocol-http": "^1.0.1",
+                "@smithy/smithy-client": "^1.0.3",
                 "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-endpoint": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-            "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-            "dependencies": {
-                "@aws-sdk/middleware-serde": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/url-parser": "3.347.0",
-                "@aws-sdk/util-middleware": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-serde": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-            "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-stack": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-            "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/querystring-parser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-            "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/smithy-client": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-            "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-            "dependencies": {
-                "@aws-sdk/middleware-stack": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@smithy/url-parser": "^1.0.1",
+                "@smithy/util-base64": "^1.0.1",
+                "@smithy/util-body-length-browser": "^1.0.1",
+                "@smithy/util-body-length-node": "^1.0.1",
+                "@smithy/util-defaults-mode-browser": "^1.0.1",
+                "@smithy/util-defaults-mode-node": "^1.0.1",
+                "@smithy/util-retry": "^1.0.2",
+                "@smithy/util-utf8": "^1.0.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -666,94 +528,10 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/url-parser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-            "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-            "dependencies": {
-                "@aws-sdk/querystring-parser": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-middleware": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-            "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-endpoint": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-            "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-            "dependencies": {
-                "@aws-sdk/middleware-serde": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/url-parser": "3.347.0",
-                "@aws-sdk/util-middleware": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-serde": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-            "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-stack": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-            "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/querystring-parser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-            "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/smithy-client": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-            "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-            "dependencies": {
-                "@aws-sdk/middleware-stack": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -761,30 +539,9 @@
             }
         },
         "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/url-parser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-            "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-            "dependencies": {
-                "@aws-sdk/querystring-parser": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-middleware": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-            "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -793,109 +550,46 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.347.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.347.1.tgz",
-            "integrity": "sha512-i7vomVsbZcGD2pzOuEl0RS7yCtFcT6CVfSP1wZLwgcjAssUKTLHi65I/uSAUF0KituChw31aXlxh7EGq1uDqaA==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.363.0.tgz",
+            "integrity": "sha512-0jj14WvBPJQ8xr72cL0mhlmQ90tF0O0wqXwSbtog6PsC8+KDE6Yf+WsxsumyI8E5O8u3eYijBL+KdqG07F/y/w==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/credential-provider-node": "3.347.0",
-                "@aws-sdk/fetch-http-handler": "3.347.0",
-                "@aws-sdk/hash-node": "3.347.0",
-                "@aws-sdk/invalid-dependency": "3.347.0",
-                "@aws-sdk/middleware-content-length": "3.347.0",
-                "@aws-sdk/middleware-endpoint": "3.347.0",
-                "@aws-sdk/middleware-host-header": "3.347.0",
-                "@aws-sdk/middleware-logger": "3.347.0",
-                "@aws-sdk/middleware-recursion-detection": "3.347.0",
-                "@aws-sdk/middleware-retry": "3.347.0",
-                "@aws-sdk/middleware-sdk-sts": "3.347.0",
-                "@aws-sdk/middleware-serde": "3.347.0",
-                "@aws-sdk/middleware-signing": "3.347.0",
-                "@aws-sdk/middleware-stack": "3.347.0",
-                "@aws-sdk/middleware-user-agent": "3.347.0",
-                "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.347.0",
-                "@aws-sdk/smithy-client": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/url-parser": "3.347.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
-                "@aws-sdk/util-defaults-mode-node": "3.347.0",
-                "@aws-sdk/util-endpoints": "3.347.0",
-                "@aws-sdk/util-retry": "3.347.0",
-                "@aws-sdk/util-user-agent-browser": "3.347.0",
-                "@aws-sdk/util-user-agent-node": "3.347.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "fast-xml-parser": "4.2.4",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-endpoint": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-            "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-            "dependencies": {
-                "@aws-sdk/middleware-serde": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/url-parser": "3.347.0",
-                "@aws-sdk/util-middleware": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-serde": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-            "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-stack": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-            "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/querystring-parser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-            "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/smithy-client": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-            "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-            "dependencies": {
-                "@aws-sdk/middleware-stack": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.363.0",
+                "@aws-sdk/middleware-host-header": "3.363.0",
+                "@aws-sdk/middleware-logger": "3.363.0",
+                "@aws-sdk/middleware-recursion-detection": "3.363.0",
+                "@aws-sdk/middleware-sdk-sts": "3.363.0",
+                "@aws-sdk/middleware-signing": "3.363.0",
+                "@aws-sdk/middleware-user-agent": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/util-user-agent-browser": "3.363.0",
+                "@aws-sdk/util-user-agent-node": "3.363.0",
+                "@smithy/config-resolver": "^1.0.1",
+                "@smithy/fetch-http-handler": "^1.0.1",
+                "@smithy/hash-node": "^1.0.1",
+                "@smithy/invalid-dependency": "^1.0.1",
+                "@smithy/middleware-content-length": "^1.0.1",
+                "@smithy/middleware-endpoint": "^1.0.1",
+                "@smithy/middleware-retry": "^1.0.1",
+                "@smithy/middleware-serde": "^1.0.1",
+                "@smithy/middleware-stack": "^1.0.1",
+                "@smithy/node-config-provider": "^1.0.1",
+                "@smithy/node-http-handler": "^1.0.1",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/smithy-client": "^1.0.2",
+                "@smithy/types": "^1.1.0",
+                "@smithy/url-parser": "^1.0.1",
+                "@smithy/util-base64": "^1.0.1",
+                "@smithy/util-body-length-browser": "^1.0.1",
+                "@smithy/util-body-length-node": "^1.0.1",
+                "@smithy/util-defaults-mode-browser": "^1.0.1",
+                "@smithy/util-defaults-mode-node": "^1.0.1",
+                "@smithy/util-retry": "^1.0.1",
+                "@smithy/util-utf8": "^1.0.1",
+                "fast-xml-parser": "4.2.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -903,77 +597,9 @@
             }
         },
         "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/url-parser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-            "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-            "dependencies": {
-                "@aws-sdk/querystring-parser": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-middleware": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-            "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/config-resolver": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
-            "integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-config-provider": "3.310.0",
-                "@aws-sdk/util-middleware": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/util-config-provider": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-            "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/util-middleware": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-            "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -982,12 +608,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
-            "integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.363.0.tgz",
+            "integrity": "sha512-VAQ3zITT2Q0acht0HezouYnMFKZ2vIOa20X4zQA3WI0HfaP4D6ga6KaenbDcb/4VFiqfqiRHfdyXHP0ThcDRMA==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -995,77 +622,30 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-imds": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
-            "integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
-            "dependencies": {
-                "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/url-parser": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-imds/node_modules/@aws-sdk/querystring-parser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-            "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-imds/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-imds/node_modules/@aws-sdk/url-parser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-            "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-            "dependencies": {
-                "@aws-sdk/querystring-parser": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.347.0.tgz",
-            "integrity": "sha512-84TNF34ryabmVbILOq7f+/Jy8tJaskvHdax3X90qxFtXRU11kX0bf5NYL616KT0epR0VGpy50ThfIqvBwxeJfQ==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.363.0.tgz",
+            "integrity": "sha512-ZYN+INoqyX5FVC3rqUxB6O8nOWkr0gHRRBm1suoOlmuFJ/WSlW/uUGthRBY5x1AQQnBF8cpdlxZzGHd41lFVNw==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.347.0",
-                "@aws-sdk/credential-provider-imds": "3.347.0",
-                "@aws-sdk/credential-provider-process": "3.347.0",
-                "@aws-sdk/credential-provider-sso": "3.347.0",
-                "@aws-sdk/credential-provider-web-identity": "3.347.0",
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/shared-ini-file-loader": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/credential-provider-env": "3.363.0",
+                "@aws-sdk/credential-provider-process": "3.363.0",
+                "@aws-sdk/credential-provider-sso": "3.363.0",
+                "@aws-sdk/credential-provider-web-identity": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/credential-provider-imds": "^1.0.1",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/shared-ini-file-loader": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1073,9 +653,9 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1084,19 +664,20 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.347.0.tgz",
-            "integrity": "sha512-ds2uxE0krl94RdQ7bstwafUXdlMeEOPgedhaheVVlj8kH+XqlZdwUUaUv1uoEI9iBzuSjKftUkIHo0xsTiwtaw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.363.0.tgz",
+            "integrity": "sha512-C1qXFIN2yMxD6pGgug0vR1UhScOki6VqdzuBHzXZAGu7MOjvgHNdscEcb3CpWnITHaPL2ztkiw75T1sZ7oIgQg==",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.347.0",
-                "@aws-sdk/credential-provider-imds": "3.347.0",
-                "@aws-sdk/credential-provider-ini": "3.347.0",
-                "@aws-sdk/credential-provider-process": "3.347.0",
-                "@aws-sdk/credential-provider-sso": "3.347.0",
-                "@aws-sdk/credential-provider-web-identity": "3.347.0",
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/shared-ini-file-loader": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/credential-provider-env": "3.363.0",
+                "@aws-sdk/credential-provider-ini": "3.363.0",
+                "@aws-sdk/credential-provider-process": "3.363.0",
+                "@aws-sdk/credential-provider-sso": "3.363.0",
+                "@aws-sdk/credential-provider-web-identity": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/credential-provider-imds": "^1.0.1",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/shared-ini-file-loader": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1104,9 +685,9 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1115,13 +696,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
-            "integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.363.0.tgz",
+            "integrity": "sha512-fOKAINU7Rtj2T8pP13GdCt+u0Ml3gYynp8ki+1jMZIQ+Ju/MdDOqZpKMFKicMn3Z1ttUOgqr+grUdus6z8ceBQ==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/shared-ini-file-loader": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/shared-ini-file-loader": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1129,9 +711,9 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1140,15 +722,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.347.0.tgz",
-            "integrity": "sha512-M1d7EnUaJbSNCmNalEbINmtFkc9wJufx7UhKtEeFwSq9KEzOMroH1MEOeiqIw9f/zE8NI/iPkVeEhw123vmBrQ==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.363.0.tgz",
+            "integrity": "sha512-5RUZ5oM0lwZSo3EehT0dXggOjgtxFogpT3cZvoLGtIwrPBvm8jOQPXQUlaqCj10ThF1sYltEyukz/ovtDwYGew==",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.347.0",
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/shared-ini-file-loader": "3.347.0",
-                "@aws-sdk/token-providers": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/client-sso": "3.363.0",
+                "@aws-sdk/token-providers": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/shared-ini-file-loader": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1156,9 +739,9 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1167,12 +750,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
-            "integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.363.0.tgz",
+            "integrity": "sha512-Z6w7fjgy79pAax580wdixbStQw10xfyZ+hOYLcPudoYFKjoNx0NQBejg5SwBzCF/HQL23Ksm9kDfbXDX9fkPhA==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1180,172 +764,9 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/eventstream-codec": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
-            "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
-            "dependencies": {
-                "@aws-crypto/crc32": "3.0.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/eventstream-codec/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/eventstream-codec/node_modules/@aws-sdk/util-hex-encoding": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-            "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/eventstream-serde-browser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.347.0.tgz",
-            "integrity": "sha512-9BLVTHWgpiTo/hl+k7qt7E9iYu43zVwJN+4TEwA9ZZB3p12068t1Hay6HgCcgJC3+LWMtw/OhvypV6vQAG4UBg==",
-            "dependencies": {
-                "@aws-sdk/eventstream-serde-universal": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/eventstream-serde-browser/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.347.0.tgz",
-            "integrity": "sha512-RcXQbNVq0PFmDqfn6+MnjCUWbbobcYVxpimaF6pMDav04o6Mcle+G2Hrefp5NlFr/lZbHW2eUKYsp1sXPaxVlQ==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/eventstream-serde-node": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.347.0.tgz",
-            "integrity": "sha512-pgQCWH0PkHjcHs04JE7FoGAD3Ww45ffV8Op0MSLUhg9OpGa6EDoO3EOpWi9l/TALtH4f0KRV35PVyUyHJ/wEkA==",
-            "dependencies": {
-                "@aws-sdk/eventstream-serde-universal": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/eventstream-serde-node/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/eventstream-serde-universal": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.347.0.tgz",
-            "integrity": "sha512-4wWj6bz6lOyDIO/dCCjwaLwRz648xzQQnf89R29sLoEqvAPP5XOB7HL+uFaQ/f5tPNh49gL6huNFSVwDm62n4Q==",
-            "dependencies": {
-                "@aws-sdk/eventstream-codec": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/eventstream-serde-universal/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/fetch-http-handler": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
-            "integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/querystring-builder": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/protocol-http": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1354,44 +775,19 @@
             }
         },
         "node_modules/@aws-sdk/hash-blob-browser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.347.0.tgz",
-            "integrity": "sha512-RxgstIldLsdJKN5UHUwSI9PMiatr0xKmKxS4+tnWZ1/OOg6wuWqqpDpWdNOVSJSpxpUaP6kRrvG5Yo5ZevoTXw==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.357.0.tgz",
+            "integrity": "sha512-RDd6UgrGHDmleTnXM9LRSSVa69euSAG2mlNhZMEDWk3OFseXVYqBDaqroVbQ01rM2UAe8MeBFchlV9OmxuVgvw==",
             "dependencies": {
                 "@aws-sdk/chunked-blob-reader": "3.310.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/hash-blob-browser/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/hash-node": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
-            "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/hash-node/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1400,11 +796,11 @@
             }
         },
         "node_modules/@aws-sdk/hash-stream-node": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.347.0.tgz",
-            "integrity": "sha512-tOBfcvELyt1GVuAlQ4d0mvm3QxoSSmvhH15SWIubM9RP4JWytBVzaFAn/aC02DBAWyvp0acMZ5J+47mxrWJElg==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.357.0.tgz",
+            "integrity": "sha512-KZjN1VAw1KHNp+xKVOWBGS+MpaYQTjZFD5f+7QQqW4TfbAkFFwIAEYIHq5Q8Gw+jVh0h61OrV/LyW3J2PVzc+w==",
             "dependencies": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
             },
@@ -1413,29 +809,9 @@
             }
         },
         "node_modules/@aws-sdk/hash-stream-node/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/invalid-dependency": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
-            "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/invalid-dependency/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1475,19 +851,19 @@
             }
         },
         "node_modules/@aws-sdk/md5-js": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.347.0.tgz",
-            "integrity": "sha512-mChE+7DByTY9H4cQ6fnWp2x5jf8e6OZN+AdLp6WQ+W99z35zBeqBxVmgm8ziJwkMIrkSTv9j3Y7T9Ve3RIcSfg==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.357.0.tgz",
+            "integrity": "sha512-to42sFAL7KgV/X9X40LLfEaNMHMGQL6/7mPMVCL/W2BZf3zw5OTl3lAaNyjXA+gO5Uo4lFEiQKAQVKNbr8b8Nw==",
             "dependencies": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1496,26 +872,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.347.0.tgz",
-            "integrity": "sha512-i9n4ylkGmGvizVcTfN4L+oN10OCL2DKvyMa4cCAVE1TJrsnaE0g7IOOyJGUS8p5KJYQrKVR7kcsa2L1S0VeEcA==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.363.0.tgz",
+            "integrity": "sha512-kR8+0X50zslpzRW29q4JbpPMadE1z39ZfGwPaBLKpoWvSGt4x+75FaoK71TH7urPPoFyD2Y+XKGA6YRYTUNHSQ==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
                 "@aws-sdk/util-arn-parser": "3.310.0",
-                "@aws-sdk/util-config-provider": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/protocol-http": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-config-provider": "^1.0.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1523,56 +888,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/util-config-provider": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-            "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-content-length": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
-            "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-content-length/node_modules/@aws-sdk/protocol-http": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-content-length/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1599,24 +917,13 @@
             }
         },
         "node_modules/@aws-sdk/middleware-expect-continue": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.347.0.tgz",
-            "integrity": "sha512-95M1unD1ENL0tx35dfyenSfx0QuXBSKtOi/qJja6LfX5771C5fm5ZTOrsrzPFJvRg/wj8pCOVWRZk+d5+jvfOQ==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.363.0.tgz",
+            "integrity": "sha512-I88xneZp6jRwySmIl9uI7eZCcTsqRVnTDfUr1JiXt7zonqNNm80PVYMs6pwaw7t97ec1AQJcsONjuXZyCMnu5g==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/protocol-http": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1624,9 +931,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1635,39 +942,17 @@
             }
         },
         "node_modules/@aws-sdk/middleware-flexible-checksums": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.347.0.tgz",
-            "integrity": "sha512-Pda7VMAIyeHw9nMp29rxdFft3EF4KP/tz/vLB6bqVoBNbLujo5rxn3SGOgStgIz7fuMLQQfoWIsmvxUm+Fp+Dw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.363.0.tgz",
+            "integrity": "sha512-FBYmrMRX01uNximNN0WLgpf97GN4xNTLaKsDlkjYRWKJ+J97ICkvLG0FcSu7+SNCpCdJJBeQ5tRVOPVpUu6nmA==",
             "dependencies": {
                 "@aws-crypto/crc32": "3.0.0",
                 "@aws-crypto/crc32c": "3.0.0",
-                "@aws-sdk/is-array-buffer": "3.310.0",
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/is-array-buffer": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-            "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/protocol-http": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/is-array-buffer": "^1.0.1",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-utf8": "^1.0.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1675,9 +960,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1686,24 +971,13 @@
             }
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
-            "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.363.0.tgz",
+            "integrity": "sha512-FobpclDCf5Y1ueyJDmb9MqguAdPssNMlnqWQpujhYVABq69KHu73fSCWSauFPUrw7YOpV8kG1uagDF0POSxHzA==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/protocol-http": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1711,9 +985,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1722,11 +996,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-location-constraint": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.347.0.tgz",
-            "integrity": "sha512-x5fcEV7q8fQ0OmUO+cLhN5iPqGoLWtC3+aKHIfRRb2BpOO1khyc1FKzsIAdeQz2hfktq4j+WsrmcPvFKv51pSg==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.363.0.tgz",
+            "integrity": "sha512-piNzpNNI/fChSGOZxcq/2msN2qFUSEAbhqs91zbcpv8CEPekVLc4W9laXCG764BEMyfG97ZU8MtzwHeMhELhBA==",
             "dependencies": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1734,9 +1009,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1745,11 +1020,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
-            "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.363.0.tgz",
+            "integrity": "sha512-SSGgthScYnFGTOw8EzbkvquqweFmvn7uJihkpFekbtBNGC/jGOGO+8ziHjTQ8t/iI/YKubEwv+LMi0f77HKSEg==",
             "dependencies": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1757,9 +1033,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1768,24 +1044,13 @@
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
-            "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.363.0.tgz",
+            "integrity": "sha512-MWD/57QgI/N7fG8rtzDTUdSqNpYohQfgj9XCFAoVeI/bU4usrkOrew43L4smJG4XrDxlNT8lSJlDtd64tuiUZA==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/protocol-http": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1793,95 +1058,25 @@
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-retry": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
-            "integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/service-error-classification": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-middleware": "3.347.0",
-                "@aws-sdk/util-retry": "3.347.0",
-                "tslib": "^2.5.0",
-                "uuid": "^8.3.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-retry/node_modules/@aws-sdk/protocol-http": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-retry/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-retry/node_modules/@aws-sdk/util-middleware": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-            "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.347.0.tgz",
-            "integrity": "sha512-TLr92+HMvamrhJJ0VDhA/PiUh4rTNQz38B9dB9ikohTaRgm+duP+mRiIv16tNPZPGl8v82Thn7Ogk2qPByNDtg==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.363.0.tgz",
+            "integrity": "sha512-npC8vLCero+vULizrK0QPjNanWbgH4A/2Llc1nO8N005uvUe7co6WglILF2W3guZrFk/0uGEdX67OnLxUD97pw==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
                 "@aws-sdk/util-arn-parser": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/protocol-http": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1889,9 +1084,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1900,12 +1095,13 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-sts": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
-            "integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.363.0.tgz",
+            "integrity": "sha512-1yy2Ac50FO8BrODaw5bPWvVrRhaVLqXTFH6iHB+dJLPUkwtY5zLM3Mp+9Ilm7kME+r7oIB1wuO6ZB1Lf4ZszIw==",
             "dependencies": {
-                "@aws-sdk/middleware-signing": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1913,9 +1109,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1936,56 +1132,16 @@
             }
         },
         "node_modules/@aws-sdk/middleware-signing": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
-            "integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.363.0.tgz",
+            "integrity": "sha512-/7qia715pt9JKYIPDGu22WmdZxD8cfF/5xB+1kmILg7ZtjO0pPuTaCNJ7xiIuFd7Dn7JXp5lop08anX/GOhNRQ==",
             "dependencies": {
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/signature-v4": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-middleware": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/is-array-buffer": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-            "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/protocol-http": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/signature-v4": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
-            "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
-            "dependencies": {
-                "@aws-sdk/eventstream-codec": "3.347.0",
-                "@aws-sdk/is-array-buffer": "3.310.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-middleware": "3.347.0",
-                "@aws-sdk/util-uri-escape": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/signature-v4": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-middleware": "^1.0.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -1993,42 +1149,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/util-hex-encoding": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-            "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/util-middleware": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-            "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/util-uri-escape": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-            "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -2037,11 +1160,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-ssec": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.347.0.tgz",
-            "integrity": "sha512-467VEi2elPmUGcHAgTmzhguZ3lwTpwK+3s+pk312uZtVsS9rP1MAknYhpS3ZvssiqBUVPx8m29cLcC6Tx5nOJg==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.363.0.tgz",
+            "integrity": "sha512-pN+QN1rMShYpJnTJSCIYnNRhD0S8xSZsTn6ThgcO559Xiwz5LMHFOfOXUCEyxtbVW5kMHLUh3w101AMUKae99A==",
             "dependencies": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -2049,9 +1173,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -2071,25 +1195,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.347.0.tgz",
-            "integrity": "sha512-wJbGN3OE1/daVCrwk49whhIr9E0j1N4gWwN/wi4WuyYIA+5lMUfVp0aGIOvZR+878DxuFz2hQ4XcZVT4K2WvQw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.363.0.tgz",
+            "integrity": "sha512-ri8YaQvXP6odteVTMfxPqFR26Q0h9ejtqhUDv47P34FaKXedEM4nC6ix6o+5FEYj6l8syGyktftZ5O70NoEhug==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-endpoints": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/protocol-http": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -2097,34 +1210,9 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/node-config-provider": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
-            "integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/shared-ini-file-loader": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/node-config-provider/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -2160,29 +1248,6 @@
             }
         },
         "node_modules/@aws-sdk/node-http-handler/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/property-provider": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
-            "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/property-provider/node_modules/@aws-sdk/types": {
             "version": "3.347.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
             "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
@@ -2252,37 +1317,6 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/@aws-sdk/service-error-classification": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
-            "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/shared-ini-file-loader": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
-            "integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/shared-ini-file-loader/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@aws-sdk/signature-v4": {
             "version": "3.197.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.197.0.tgz",
@@ -2300,13 +1334,14 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.347.0.tgz",
-            "integrity": "sha512-838h7pbRCVYWlTl8W+r5+Z5ld7uoBObgAn7/RB1MQ4JjlkfLdN7emiITG6ueVL+7gWZNZc/4dXR/FJSzCgrkxQ==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.363.0.tgz",
+            "integrity": "sha512-iWamQSpaBKg88LKuiUq8xO/7iyxJ+ORkA3qDhAwUqyTJOg87ma47yFf4ycCKqINnflc3AIGLGzBHnkBc4cMF5g==",
             "dependencies": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/signature-v4": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/signature-v4": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -2321,84 +1356,10 @@
                 }
             }
         },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/is-array-buffer": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-            "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/protocol-http": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-            "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-            "dependencies": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/signature-v4": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
-            "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
-            "dependencies": {
-                "@aws-sdk/eventstream-codec": "3.347.0",
-                "@aws-sdk/is-array-buffer": "3.310.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-middleware": "3.347.0",
-                "@aws-sdk/util-uri-escape": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-hex-encoding": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-            "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-middleware": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-            "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-uri-escape": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-            "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -2420,14 +1381,15 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.347.0.tgz",
-            "integrity": "sha512-DZS9UWEy105zsaBJTgcvv1U+0jl7j1OzfMpnLf/lEYjEvx/4FqY2Ue/OZUACJorZgm/dWNqrhY17tZXtS/S3ew==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.363.0.tgz",
+            "integrity": "sha512-6+0aJ1zugNgsMmhTtW2LBWxOVSaXCUk2q3xyTchSXkNzallYaRiZMRkieW+pKNntnu0g5H1T0zyfCO0tbXwxEA==",
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.347.0",
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/shared-ini-file-loader": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/client-sso-oidc": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/shared-ini-file-loader": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -2435,9 +1397,9 @@
             }
         },
         "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -2467,37 +1429,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
             "integrity": "sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-base64": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-            "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-            "dependencies": {
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-body-length-browser": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-            "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-body-length-node": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-            "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -2539,64 +1470,12 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/@aws-sdk/util-defaults-mode-browser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
-            "integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-defaults-mode-node": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
-            "integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
-            "dependencies": {
-                "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/credential-provider-imds": "3.347.0",
-                "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.347.0.tgz",
-            "integrity": "sha512-/WUkirizeNAqwVj0zkcrqdQ9pUm1HY5kU+qy7xTR0OebkuJauglkmSTMD+56L1JPunWqHhlwCMVRaz5eaJdSEQ==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
+            "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
             "dependencies": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -2604,9 +1483,9 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -2647,78 +1526,6 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/@aws-sdk/util-retry": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
-            "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
-            "dependencies": {
-                "@aws-sdk/service-error-classification": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-stream-browser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.347.0.tgz",
-            "integrity": "sha512-pIbmzIJfyX26qG622uIESOmJSMGuBkhmNU7I98bzhYCet5ctC0ow9L5FZw9ljOE46P/HkEcsOhh+qTHyCXlCEQ==",
-            "dependencies": {
-                "@aws-sdk/fetch-http-handler": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-hex-encoding": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-            "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-stream-node": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.347.0.tgz",
-            "integrity": "sha512-E46zm0eMthmeh7hYfztzdInpKX3hZX+M5vmNhfYbhPuxavJ0cBzpwI0Xwb9wpSHPKQ1yzpTviIu1eRplCU5VXQ==",
-            "dependencies": {
-                "@aws-sdk/node-http-handler": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@aws-sdk/util-uri-escape": {
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
@@ -2731,19 +1538,20 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
-            "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.363.0.tgz",
+            "integrity": "sha512-fk9ymBUIYbxiGm99Cn+kAAXmvMCWTf/cHAcB79oCXV4ELXdPa9lN5xQhZRFNxLUeXG4OAMEuCAUUuZEj8Fnc1Q==",
             "dependencies": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/types": "^1.1.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -2752,12 +1560,13 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
-            "integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.363.0.tgz",
+            "integrity": "sha512-Fli/dvgGA9hdnQUrYb1//wNSFlK2jAfdJcfNXA6SeBYzSeH5pVGYF4kXF0FCdnMA3Fef+Zn1zAP/hw9v8VJHWQ==",
             "dependencies": {
-                "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/node-config-provider": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -2773,9 +1582,9 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -2801,30 +1610,6 @@
             "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
             "dependencies": {
                 "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-sdk/util-waiter": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.347.0.tgz",
-            "integrity": "sha512-3ze/0PkwkzUzLncukx93tZgGL0JX9NaP8DxTi6WzflnL/TEul5Z63PCruRNK0om17iZYAWKrf8q2mFoHYb4grA==",
-            "dependencies": {
-                "@aws-sdk/abort-controller": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-waiter/node_modules/@aws-sdk/types": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-            "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
@@ -6810,12 +5595,355 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
-        "node_modules/@smithy/protocol-http": {
+        "node_modules/@smithy/abort-controller": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
-            "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.1.tgz",
+            "integrity": "sha512-An6irzp9NCji2JtJHhrEFlDbxLwHd6c6Y9fq3ZeomyUR8BIXlGXVTxsemUSZVVgOq3166iYbYs/CrPAmgRSFLw==",
             "dependencies": {
-                "@smithy/types": "^1.0.0",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/config-resolver": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.1.tgz",
+            "integrity": "sha512-quj0xUiEVG/UHfY82EtthR/+S5/17p3IxXArC3NFSNqryMobWbG9oWgJy2s2cgUSVZLzxevjKKvxrilK7JEDaA==",
+            "dependencies": {
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-config-provider": "^1.0.1",
+                "@smithy/util-middleware": "^1.0.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/credential-provider-imds": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.1.tgz",
+            "integrity": "sha512-hkRJoxVCh4CEt1zYOBElE+G/MV6lyx3g68hSJpesM4pwMT/bzEVo5E5XzXY+6dVq8yszeatWKbFuqCCBQte8tg==",
+            "dependencies": {
+                "@smithy/node-config-provider": "^1.0.1",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "@smithy/url-parser": "^1.0.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/eventstream-codec": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.1.tgz",
+            "integrity": "sha512-cpcTXQEOEs2wEvIyxW/iTHJ2m0RVqoEOTjjWEXD6SY8Gcs3FCFP6E8MXadC098tdH5ctMIUXc8POXyMpxzGnjw==",
+            "dependencies": {
+                "@aws-crypto/crc32": "3.0.0",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-hex-encoding": "^1.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@smithy/eventstream-serde-browser": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-1.0.1.tgz",
+            "integrity": "sha512-oc8vxe+AU2RzvXH/Ehh0TzM/Nsw3I3ywu7V3qaCzqdkBIntAwK9JGZqcSDsqTK0WxZKBRgFIEwopcuZ2slVnFQ==",
+            "dependencies": {
+                "@smithy/eventstream-serde-universal": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/eventstream-serde-config-resolver": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-1.0.1.tgz",
+            "integrity": "sha512-TJwaXima0djnNY819utO1j93qZHaheFH1bhHxBkMrImtEOuXY48Tjma/L2m8swkIq8dy8jFC9hrYOkD0eYHkFA==",
+            "dependencies": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/eventstream-serde-node": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-1.0.1.tgz",
+            "integrity": "sha512-JEj8w7IRs4l+kcwKxbv3pNuu8n7ORC4pMFrIOrM4rERzrRnI7vMNTRzvAPGYA53rqm/Y9tBA9dw4C+H6hLXcsA==",
+            "dependencies": {
+                "@smithy/eventstream-serde-universal": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/eventstream-serde-universal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-1.0.1.tgz",
+            "integrity": "sha512-c6m9DH7m6D2S93dof4wSxysaGSQdauO20TNcSePzrgHd4rkTnz5pqZ1a7Pt22q2SKf09SvTugq5cV2Sy4r8zHw==",
+            "dependencies": {
+                "@smithy/eventstream-codec": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.1.tgz",
+            "integrity": "sha512-/e2A8eOMk4FVZBQ0o6uF/ttLtFZcmsK5MIwDu1UE3crM4pCAIP19Ul8U9rdLlHhIu81X4AcJmSw55RDSpVRL/w==",
+            "dependencies": {
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/querystring-builder": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-base64": "^1.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@smithy/hash-node": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.1.tgz",
+            "integrity": "sha512-eCz08BySBcOjVObjbRAS/XMKUGY4ujnuS+GoWeEpzpCSKDnO8/YQ0rStRt4C0llRmhApizYc1tK9DiJwfvXcBg==",
+            "dependencies": {
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-buffer-from": "^1.0.1",
+                "@smithy/util-utf8": "^1.0.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/invalid-dependency": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.1.tgz",
+            "integrity": "sha512-kib63GFlAzRn/wf8M0cRWrZA1cyOy5IvpTkLavCY782DPFMP0EaEeD6VrlNIOvD6ncf7uCJ68HqckhwK1qLT3g==",
+            "dependencies": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@smithy/is-array-buffer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.1.tgz",
+            "integrity": "sha512-fHSTW70gANnzPYWNDcWkPXpp+QMbHhKozbQm/+Denkhp4gwSiPuAovWZRpJa9sXO+Q4dOnNzYN2max1vTCEroA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-content-length": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.1.tgz",
+            "integrity": "sha512-vWWigayk5i2cFp9xPX5vdzHyK+P0t/xZ3Ovp4Ss+c8JQ1Hlq2kpJZVWtTKsmdfND5rVo5lu0kD5wgAMUCcmuhw==",
+            "dependencies": {
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-endpoint": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.2.tgz",
+            "integrity": "sha512-F3CyXgjtDI4quGFkDmVNytt6KMwlzzeMxtopk6Edue4uKdKcMC1vUmoRS5xTbFzKDDp4XwpnEV7FshPaL3eCPw==",
+            "dependencies": {
+                "@smithy/middleware-serde": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "@smithy/url-parser": "^1.0.1",
+                "@smithy/util-middleware": "^1.0.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.3.tgz",
+            "integrity": "sha512-ZRsjG8adtxQ456FULPqPFmWtrW44Fq8IgdQvQB+rC2RSho3OUzS+TiEIwb5Zs6rf2IoewITKtfdtsUZcxXO0ng==",
+            "dependencies": {
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/service-error-classification": "^1.0.2",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-middleware": "^1.0.1",
+                "@smithy/util-retry": "^1.0.3",
+                "tslib": "^2.5.0",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@smithy/middleware-serde": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.1.tgz",
+            "integrity": "sha512-bn5lWk8UUeXFCQfkrNErz5SbeNd+2hgYegHMLsOLPt4URDIsyREar6wMsdsR+8UCdgR5s8udG3Zalgc7puizIQ==",
+            "dependencies": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-stack": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.1.tgz",
+            "integrity": "sha512-T6+gsAO1JYamOJqmORCrByDeQ/NB+ggjHb33UDOgdX4xIjXz/FB/3UqHgQu6PL1cSFrK+i4oteDIwqARDs/Szw==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/node-config-provider": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.1.tgz",
+            "integrity": "sha512-FRxifH/J2SgOaVLihIqBFuGhiHR/NfzbZYp5nYO7BGgT/gc/f9nAuuRJcEy/hwO3aI6ThyG5apH4tGec6A2sCw==",
+            "dependencies": {
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/shared-ini-file-loader": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/node-http-handler": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.2.tgz",
+            "integrity": "sha512-PzPrGRSt3kNuruLCeR4ffJp57ZLVnIukMXVL3Ppr65ZoxiE+HBsOVAa/Z/T+4HzjCM6RaXnnmB8YKfsDjlb0iA==",
+            "dependencies": {
+                "@smithy/abort-controller": "^1.0.1",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/querystring-builder": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/property-provider": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.1.tgz",
+            "integrity": "sha512-3EG/61Ls1MrgEaafpltXBJHSqFPqmTzEX7QKO7lOEHuYGmGYzZ08t1SsTgd1vM74z0IihoZyGPynZ7WmXKvTeg==",
+            "dependencies": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/protocol-http": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
+            "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+            "dependencies": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-builder": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.1.tgz",
+            "integrity": "sha512-J5Tzkw1PMtu01h6wl+tlN5vsyROmS6/z5lEfNlLo/L4ELHeVkQ4Q0PEIjDddPLfjVLCm8biQTESE5GCMixSRNQ==",
+            "dependencies": {
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-uri-escape": "^1.0.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-parser": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.1.tgz",
+            "integrity": "sha512-zauxdMc3cwxoLitI5DZqH7xN6Fk0mwRxrUMAETbav2j6Se2U0UGak/55rZcDg2yGzOURaLYi5iOm1gHr98P+Bw==",
+            "dependencies": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/service-error-classification": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.2.tgz",
+            "integrity": "sha512-Q5CCuzYL5FGo6Rr/O+lZxXHm2hrRgbmMn8MgyjqZUWZg20COg20DuNtIbho2iht6CoB7jOpmpBqhWizLlzUZgg==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/shared-ini-file-loader": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.1.tgz",
+            "integrity": "sha512-EztziuIPoNronENGqh+MWVKJErA4rJpaPzJCPukzBeEoG2USka0/q4B5Mr/1zszOnrb49fPNh4u3u5LfiH7QzA==",
+            "dependencies": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/signature-v4": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.1.tgz",
+            "integrity": "sha512-2D69je14ou1vBTnAQeysSK4QVMm0j3WHS3MDg/DnHnFFcXRCzVl/xAARO7POD8+fpi4tMFPs8Z4hzo1Zw40L0Q==",
+            "dependencies": {
+                "@smithy/eventstream-codec": "^1.0.1",
+                "@smithy/is-array-buffer": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-hex-encoding": "^1.0.1",
+                "@smithy/util-middleware": "^1.0.1",
+                "@smithy/util-uri-escape": "^1.0.1",
+                "@smithy/util-utf8": "^1.0.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/smithy-client": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.3.tgz",
+            "integrity": "sha512-Wh1mNP/1yUZK0uYkgCQ6NMxpBT3Fmc45TMdUfOlH1xD2zGYL7U4yDHFOhEZdi/suyjaelFobXB2p9pPIw6LjRQ==",
+            "dependencies": {
+                "@smithy/middleware-stack": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-stream": "^1.0.1",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -6823,10 +5951,192 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
-            "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
+            "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
             "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/url-parser": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.1.tgz",
+            "integrity": "sha512-33vWEtE6HzmwjEcEb4I58XMLRAchwPS93YhfDyXAXr1jwDCzfXmMayQwwpyW847rpWj0XJimxqia8q0z+k/ybw==",
+            "dependencies": {
+                "@smithy/querystring-parser": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@smithy/util-base64": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.1.tgz",
+            "integrity": "sha512-rJcpRi/yUi6TyCEkjdTH86/ExBuKlfctEXhG9/4gMJ3/cnPcHJJnr0mQ9evSEO+3DbpT/Nxq90bcTBdTIAmCig==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^1.0.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-browser": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.1.tgz",
+            "integrity": "sha512-Pdp744fmF7E1NWoSb7256Anhm8eYoCubvosdMwXzOnHuPRVbDa15pKUz2027K3+jrfGpXo1r+MnDerajME1Osw==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-node": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.1.tgz",
+            "integrity": "sha512-4PIHjDFwG07SNensAiVq/CJmubEVuwclWSYOTNtzBNTvxOeGLznvygkGYgPzS3erByT8C4S9JvnLYgtrsVV3nQ==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-buffer-from": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.1.tgz",
+            "integrity": "sha512-363N7Wq0ceUgE5lLe6kaR6GlJs2/m4r9V6bRMfIszb6P1FZbbRRM2FQYUWWPFSsRymm9mJL18b3fjiVsIvhDGg==",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^1.0.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-config-provider": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.1.tgz",
+            "integrity": "sha512-4Qy38Oy5/q43MpTwCLV1P+7NeaOp4W2etQDxMjgEeRlOyGGNlgttn0syi4g2rVSukFVqQ6FbeRs5xbnFmS6kaQ==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.1.tgz",
+            "integrity": "sha512-/9ObwNch4Z/NJYfkO4AvqBWku60Ju+c2Ck32toPOLmWe/V6eI9FLn8C1abri+GxDRCkLIqvkaWU1lgZ3nWZIIw==",
+            "dependencies": {
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-node": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.1.tgz",
+            "integrity": "sha512-XQM3KvqRLgv7bwAzVkXTITkOmcOINoG9icJiGT8FA0zV35lY5UvyIsg5kHw01xigQS8ufa/33AwG3ZoXip+V5g==",
+            "dependencies": {
+                "@smithy/config-resolver": "^1.0.1",
+                "@smithy/credential-provider-imds": "^1.0.1",
+                "@smithy/node-config-provider": "^1.0.1",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@smithy/util-hex-encoding": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.1.tgz",
+            "integrity": "sha512-FPTtMz/t02/rbfq5Pdll/TWUYP+GVFLCQNr+DgifrLzVRU0g8rdRjyFpDh8nPTdkDDusTTo9P1bepAYj68s0eA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-middleware": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.1.tgz",
+            "integrity": "sha512-u9akN3Zmbr0vZH4F+2iehG7cFg+3fvDfnvS/hhsXH4UHuhqiQ+ADefibnLzPoz1pooY7rvwaQ/TVHyJmZHdLdQ==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-retry": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.3.tgz",
+            "integrity": "sha512-gYQnZDD8I2XJFspVwUISyukjPWVikTzKR0IdG8hCWYPTpeULFl1o6yzXlT5SL63TBkuEYl0R1/93cdNtMiNnoA==",
+            "dependencies": {
+                "@smithy/service-error-classification": "^1.0.2",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-stream": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.1.tgz",
+            "integrity": "sha512-4aBCIz35aZAnt2Rbq341KrnUzGhWv2/Zu8HouJqYLvSWCzlrvsNCGlXP4e70Kjzcw8hSuuCNtdUICwQ5qUWLxg==",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^1.0.1",
+                "@smithy/node-http-handler": "^1.0.2",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-base64": "^1.0.1",
+                "@smithy/util-buffer-from": "^1.0.1",
+                "@smithy/util-hex-encoding": "^1.0.1",
+                "@smithy/util-utf8": "^1.0.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-uri-escape": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.1.tgz",
+            "integrity": "sha512-IJUrRnXKEIc+PKnU1XzTsIENVR+60jUDPBP3iWX/EvuuT3Xfob47x1FGUe2c3yMXNuU6ax8VDk27hL5LKNoehQ==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.1.tgz",
+            "integrity": "sha512-iX6XHpjh4DFEUIBSKp2tjy3pYnLQMsJ62zYi1BVAC0kobE6p8AVpiZnxsU3ZkgQatAsUaEspFHUZ7CL7oSqaPQ==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^1.0.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-waiter": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-1.0.1.tgz",
+            "integrity": "sha512-dsn8O0s3pFIgxFzySLe1dv0w4tEQizEP6UqbgZ4r/Kar4n8pSdrPi6DJg8BzXwkwEIZpMtV4/nhSeGZ7HksDXA==",
+            "dependencies": {
+                "@smithy/abort-controller": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -7492,21 +6802,6 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@typescript-eslint/parser": {
             "version": "5.59.11",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.11.tgz",
@@ -7618,21 +6913,6 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-            "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@typescript-eslint/utils": {
             "version": "5.59.11",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.11.tgz",
@@ -7679,21 +6959,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4.0"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/semver": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-            "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
@@ -9534,21 +8799,6 @@
                 "webpack": "^5.0.0"
             }
         },
-        "node_modules/css-loader/node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/css.escape": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -11185,9 +10435,9 @@
             "dev": true
         },
         "node_modules/fast-xml-parser": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
-            "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
             "funding": [
                 {
                     "type": "paypal",
@@ -15800,21 +15050,6 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/jest-snapshot/node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/jest-snapshot/node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -16386,20 +15621,6 @@
             "engines": {
                 "node": ">=12",
                 "npm": ">=6"
-            }
-        },
-        "node_modules/jsonwebtoken/node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/jsx-ast-utils": {
@@ -17000,15 +16221,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/make-dir/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
         "node_modules/make-error": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -17374,22 +16586,6 @@
                 "which": "^2.0.2"
             }
         },
-        "node_modules/node-notifier/node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/node-notifier/node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -17442,15 +16638,6 @@
                 "ms": "^2.1.1"
             }
         },
-        "node_modules/nodemon/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
         "node_modules/nopt": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
@@ -17476,15 +16663,6 @@
                 "resolve": "^1.10.0",
                 "semver": "2 || 3 || 4 || 5",
                 "validate-npm-package-license": "^3.0.1"
-            }
-        },
-        "node_modules/normalize-package-data/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver"
             }
         },
         "node_modules/normalize-path": {
@@ -17790,17 +16968,17 @@
             }
         },
         "node_modules/optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
             "dev": true,
             "dependencies": {
+                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
+                "type-check": "^0.4.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -18095,21 +17273,6 @@
             "peerDependencies": {
                 "postcss": "^7.0.0 || ^8.0.1",
                 "webpack": "^5.0.0"
-            }
-        },
-        "node_modules/postcss-loader/node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/postcss-modules-extract-imports": {
@@ -19374,15 +18537,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/sane/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
         "node_modules/sane/node_modules/shebang-command": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -19562,11 +18716,17 @@
             "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg=="
         },
         "node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+            "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
             "bin": {
                 "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/send": {
@@ -19753,15 +18913,6 @@
             },
             "engines": {
                 "node": ">=8.10.0"
-            }
-        },
-        "node_modules/simple-update-notifier/node_modules/semver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-            "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/sisteransi": {
@@ -22123,6 +21274,12 @@
         }
     },
     "dependencies": {
+        "@aashutoshrathi/word-wrap": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+            "dev": true
+        },
         "@adobe/css-tools": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
@@ -22149,17 +21306,17 @@
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     },
                     "dependencies": {
                         "tslib": {
-                            "version": "2.5.3",
-                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+                            "version": "2.6.0",
+                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+                            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
                         }
                     }
                 },
@@ -22181,17 +21338,17 @@
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     },
                     "dependencies": {
                         "tslib": {
-                            "version": "2.5.3",
-                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+                            "version": "2.6.0",
+                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+                            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
                         }
                     }
                 },
@@ -22269,17 +21426,17 @@
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     },
                     "dependencies": {
                         "tslib": {
-                            "version": "2.5.3",
-                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+                            "version": "2.6.0",
+                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+                            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
                         }
                     }
                 },
@@ -22301,17 +21458,17 @@
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     },
                     "dependencies": {
                         "tslib": {
-                            "version": "2.5.3",
-                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+                            "version": "2.6.0",
+                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+                            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
                         }
                     }
                 },
@@ -22397,137 +21554,70 @@
             }
         },
         "@aws-sdk/client-s3": {
-            "version": "3.347.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.347.1.tgz",
-            "integrity": "sha512-s7LPecYBo78uMB4ZrSuSV/cGjc9RLzZ5+SA9Ds0mPWudeRROsogBqxK82qZqoCfjPAUVB24e2MIarV8Hzu6+jw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.363.0.tgz",
+            "integrity": "sha512-LNnfg/t8wG5Fqj6l+PSV/t+IXDq9r3Kj9jEHn84513+p7bewXYSSreSpmLjG8OcKuMfHc9EJGNQ3DkMyFaLoWg==",
             "requires": {
                 "@aws-crypto/sha1-browser": "3.0.0",
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.347.1",
-                "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/credential-provider-node": "3.347.0",
-                "@aws-sdk/eventstream-serde-browser": "3.347.0",
-                "@aws-sdk/eventstream-serde-config-resolver": "3.347.0",
-                "@aws-sdk/eventstream-serde-node": "3.347.0",
-                "@aws-sdk/fetch-http-handler": "3.347.0",
-                "@aws-sdk/hash-blob-browser": "3.347.0",
-                "@aws-sdk/hash-node": "3.347.0",
-                "@aws-sdk/hash-stream-node": "3.347.0",
-                "@aws-sdk/invalid-dependency": "3.347.0",
-                "@aws-sdk/md5-js": "3.347.0",
-                "@aws-sdk/middleware-bucket-endpoint": "3.347.0",
-                "@aws-sdk/middleware-content-length": "3.347.0",
-                "@aws-sdk/middleware-endpoint": "3.347.0",
-                "@aws-sdk/middleware-expect-continue": "3.347.0",
-                "@aws-sdk/middleware-flexible-checksums": "3.347.0",
-                "@aws-sdk/middleware-host-header": "3.347.0",
-                "@aws-sdk/middleware-location-constraint": "3.347.0",
-                "@aws-sdk/middleware-logger": "3.347.0",
-                "@aws-sdk/middleware-recursion-detection": "3.347.0",
-                "@aws-sdk/middleware-retry": "3.347.0",
-                "@aws-sdk/middleware-sdk-s3": "3.347.0",
-                "@aws-sdk/middleware-serde": "3.347.0",
-                "@aws-sdk/middleware-signing": "3.347.0",
-                "@aws-sdk/middleware-ssec": "3.347.0",
-                "@aws-sdk/middleware-stack": "3.347.0",
-                "@aws-sdk/middleware-user-agent": "3.347.0",
-                "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.347.0",
-                "@aws-sdk/signature-v4-multi-region": "3.347.0",
-                "@aws-sdk/smithy-client": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/url-parser": "3.347.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
-                "@aws-sdk/util-defaults-mode-node": "3.347.0",
-                "@aws-sdk/util-endpoints": "3.347.0",
-                "@aws-sdk/util-retry": "3.347.0",
-                "@aws-sdk/util-stream-browser": "3.347.0",
-                "@aws-sdk/util-stream-node": "3.347.0",
-                "@aws-sdk/util-user-agent-browser": "3.347.0",
-                "@aws-sdk/util-user-agent-node": "3.347.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@aws-sdk/util-waiter": "3.347.0",
+                "@aws-sdk/client-sts": "3.363.0",
+                "@aws-sdk/credential-provider-node": "3.363.0",
+                "@aws-sdk/hash-blob-browser": "3.357.0",
+                "@aws-sdk/hash-stream-node": "3.357.0",
+                "@aws-sdk/md5-js": "3.357.0",
+                "@aws-sdk/middleware-bucket-endpoint": "3.363.0",
+                "@aws-sdk/middleware-expect-continue": "3.363.0",
+                "@aws-sdk/middleware-flexible-checksums": "3.363.0",
+                "@aws-sdk/middleware-host-header": "3.363.0",
+                "@aws-sdk/middleware-location-constraint": "3.363.0",
+                "@aws-sdk/middleware-logger": "3.363.0",
+                "@aws-sdk/middleware-recursion-detection": "3.363.0",
+                "@aws-sdk/middleware-sdk-s3": "3.363.0",
+                "@aws-sdk/middleware-signing": "3.363.0",
+                "@aws-sdk/middleware-ssec": "3.363.0",
+                "@aws-sdk/middleware-user-agent": "3.363.0",
+                "@aws-sdk/signature-v4-multi-region": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/util-user-agent-browser": "3.363.0",
+                "@aws-sdk/util-user-agent-node": "3.363.0",
                 "@aws-sdk/xml-builder": "3.310.0",
+                "@smithy/config-resolver": "^1.0.1",
+                "@smithy/eventstream-serde-browser": "^1.0.1",
+                "@smithy/eventstream-serde-config-resolver": "^1.0.1",
+                "@smithy/eventstream-serde-node": "^1.0.1",
+                "@smithy/fetch-http-handler": "^1.0.1",
+                "@smithy/hash-node": "^1.0.1",
+                "@smithy/invalid-dependency": "^1.0.1",
+                "@smithy/middleware-content-length": "^1.0.1",
+                "@smithy/middleware-endpoint": "^1.0.1",
+                "@smithy/middleware-retry": "^1.0.2",
+                "@smithy/middleware-serde": "^1.0.1",
+                "@smithy/middleware-stack": "^1.0.1",
+                "@smithy/node-config-provider": "^1.0.1",
+                "@smithy/node-http-handler": "^1.0.2",
                 "@smithy/protocol-http": "^1.0.1",
+                "@smithy/smithy-client": "^1.0.3",
                 "@smithy/types": "^1.0.0",
-                "fast-xml-parser": "4.2.4",
+                "@smithy/url-parser": "^1.0.1",
+                "@smithy/util-base64": "^1.0.1",
+                "@smithy/util-body-length-browser": "^1.0.1",
+                "@smithy/util-body-length-node": "^1.0.1",
+                "@smithy/util-defaults-mode-browser": "^1.0.1",
+                "@smithy/util-defaults-mode-node": "^1.0.1",
+                "@smithy/util-retry": "^1.0.2",
+                "@smithy/util-stream": "^1.0.1",
+                "@smithy/util-utf8": "^1.0.1",
+                "@smithy/util-waiter": "^1.0.1",
+                "fast-xml-parser": "4.2.5",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
-                "@aws-sdk/middleware-endpoint": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-                    "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-                    "requires": {
-                        "@aws-sdk/middleware-serde": "3.347.0",
-                        "@aws-sdk/types": "3.347.0",
-                        "@aws-sdk/url-parser": "3.347.0",
-                        "@aws-sdk/util-middleware": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/middleware-serde": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-                    "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/middleware-stack": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-                    "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/querystring-parser": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-                    "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/smithy-client": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-                    "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-                    "requires": {
-                        "@aws-sdk/middleware-stack": "3.347.0",
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/url-parser": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-                    "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-                    "requires": {
-                        "@aws-sdk/querystring-parser": "3.347.0",
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-middleware": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-                    "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -22535,115 +21625,49 @@
             }
         },
         "@aws-sdk/client-sso": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.347.0.tgz",
-            "integrity": "sha512-AZehWCNLUXTrDavsZYRi7d84Uef20ppYJ2FY0KxqrKB3lx89mO29SfSJSC4woeW5+6ooBokq8HtKxw5ImPfRhA==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.363.0.tgz",
+            "integrity": "sha512-PZ+HfKSgS4hlMnJzG+Ev8/mgHd/b/ETlJWPSWjC/f2NwVoBQkBnqHjdyEx7QjF6nksJozcVh5Q+kkYLKc/QwBQ==",
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/fetch-http-handler": "3.347.0",
-                "@aws-sdk/hash-node": "3.347.0",
-                "@aws-sdk/invalid-dependency": "3.347.0",
-                "@aws-sdk/middleware-content-length": "3.347.0",
-                "@aws-sdk/middleware-endpoint": "3.347.0",
-                "@aws-sdk/middleware-host-header": "3.347.0",
-                "@aws-sdk/middleware-logger": "3.347.0",
-                "@aws-sdk/middleware-recursion-detection": "3.347.0",
-                "@aws-sdk/middleware-retry": "3.347.0",
-                "@aws-sdk/middleware-serde": "3.347.0",
-                "@aws-sdk/middleware-stack": "3.347.0",
-                "@aws-sdk/middleware-user-agent": "3.347.0",
-                "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.347.0",
-                "@aws-sdk/smithy-client": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/url-parser": "3.347.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
-                "@aws-sdk/util-defaults-mode-node": "3.347.0",
-                "@aws-sdk/util-endpoints": "3.347.0",
-                "@aws-sdk/util-retry": "3.347.0",
-                "@aws-sdk/util-user-agent-browser": "3.347.0",
-                "@aws-sdk/util-user-agent-node": "3.347.0",
-                "@aws-sdk/util-utf8": "3.310.0",
+                "@aws-sdk/middleware-host-header": "3.363.0",
+                "@aws-sdk/middleware-logger": "3.363.0",
+                "@aws-sdk/middleware-recursion-detection": "3.363.0",
+                "@aws-sdk/middleware-user-agent": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/util-user-agent-browser": "3.363.0",
+                "@aws-sdk/util-user-agent-node": "3.363.0",
+                "@smithy/config-resolver": "^1.0.1",
+                "@smithy/fetch-http-handler": "^1.0.1",
+                "@smithy/hash-node": "^1.0.1",
+                "@smithy/invalid-dependency": "^1.0.1",
+                "@smithy/middleware-content-length": "^1.0.1",
+                "@smithy/middleware-endpoint": "^1.0.1",
+                "@smithy/middleware-retry": "^1.0.2",
+                "@smithy/middleware-serde": "^1.0.1",
+                "@smithy/middleware-stack": "^1.0.1",
+                "@smithy/node-config-provider": "^1.0.1",
+                "@smithy/node-http-handler": "^1.0.2",
                 "@smithy/protocol-http": "^1.0.1",
+                "@smithy/smithy-client": "^1.0.3",
                 "@smithy/types": "^1.0.0",
+                "@smithy/url-parser": "^1.0.1",
+                "@smithy/util-base64": "^1.0.1",
+                "@smithy/util-body-length-browser": "^1.0.1",
+                "@smithy/util-body-length-node": "^1.0.1",
+                "@smithy/util-defaults-mode-browser": "^1.0.1",
+                "@smithy/util-defaults-mode-node": "^1.0.1",
+                "@smithy/util-retry": "^1.0.2",
+                "@smithy/util-utf8": "^1.0.1",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
-                "@aws-sdk/middleware-endpoint": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-                    "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-                    "requires": {
-                        "@aws-sdk/middleware-serde": "3.347.0",
-                        "@aws-sdk/types": "3.347.0",
-                        "@aws-sdk/url-parser": "3.347.0",
-                        "@aws-sdk/util-middleware": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/middleware-serde": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-                    "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/middleware-stack": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-                    "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/querystring-parser": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-                    "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/smithy-client": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-                    "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-                    "requires": {
-                        "@aws-sdk/middleware-stack": "3.347.0",
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/url-parser": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-                    "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-                    "requires": {
-                        "@aws-sdk/querystring-parser": "3.347.0",
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-middleware": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-                    "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -22651,115 +21675,49 @@
             }
         },
         "@aws-sdk/client-sso-oidc": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.347.0.tgz",
-            "integrity": "sha512-IBxRfPqb8f9FqpmDbzcRDfoiasj/Y47C4Gj+j3kA5T1XWyGwbDI9QnPW/rnkZTWxLUUG1LSbBNwbPD6TLoff8A==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.363.0.tgz",
+            "integrity": "sha512-V3Ebiq/zNtDS/O92HUWGBa7MY59RYSsqWd+E0XrXv6VYTA00RlMTbNcseivNgp2UghOgB9a20Nkz6EqAeIN+RQ==",
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/fetch-http-handler": "3.347.0",
-                "@aws-sdk/hash-node": "3.347.0",
-                "@aws-sdk/invalid-dependency": "3.347.0",
-                "@aws-sdk/middleware-content-length": "3.347.0",
-                "@aws-sdk/middleware-endpoint": "3.347.0",
-                "@aws-sdk/middleware-host-header": "3.347.0",
-                "@aws-sdk/middleware-logger": "3.347.0",
-                "@aws-sdk/middleware-recursion-detection": "3.347.0",
-                "@aws-sdk/middleware-retry": "3.347.0",
-                "@aws-sdk/middleware-serde": "3.347.0",
-                "@aws-sdk/middleware-stack": "3.347.0",
-                "@aws-sdk/middleware-user-agent": "3.347.0",
-                "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.347.0",
-                "@aws-sdk/smithy-client": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/url-parser": "3.347.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
-                "@aws-sdk/util-defaults-mode-node": "3.347.0",
-                "@aws-sdk/util-endpoints": "3.347.0",
-                "@aws-sdk/util-retry": "3.347.0",
-                "@aws-sdk/util-user-agent-browser": "3.347.0",
-                "@aws-sdk/util-user-agent-node": "3.347.0",
-                "@aws-sdk/util-utf8": "3.310.0",
+                "@aws-sdk/middleware-host-header": "3.363.0",
+                "@aws-sdk/middleware-logger": "3.363.0",
+                "@aws-sdk/middleware-recursion-detection": "3.363.0",
+                "@aws-sdk/middleware-user-agent": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/util-user-agent-browser": "3.363.0",
+                "@aws-sdk/util-user-agent-node": "3.363.0",
+                "@smithy/config-resolver": "^1.0.1",
+                "@smithy/fetch-http-handler": "^1.0.1",
+                "@smithy/hash-node": "^1.0.1",
+                "@smithy/invalid-dependency": "^1.0.1",
+                "@smithy/middleware-content-length": "^1.0.1",
+                "@smithy/middleware-endpoint": "^1.0.1",
+                "@smithy/middleware-retry": "^1.0.2",
+                "@smithy/middleware-serde": "^1.0.1",
+                "@smithy/middleware-stack": "^1.0.1",
+                "@smithy/node-config-provider": "^1.0.1",
+                "@smithy/node-http-handler": "^1.0.2",
                 "@smithy/protocol-http": "^1.0.1",
+                "@smithy/smithy-client": "^1.0.3",
                 "@smithy/types": "^1.0.0",
+                "@smithy/url-parser": "^1.0.1",
+                "@smithy/util-base64": "^1.0.1",
+                "@smithy/util-body-length-browser": "^1.0.1",
+                "@smithy/util-body-length-node": "^1.0.1",
+                "@smithy/util-defaults-mode-browser": "^1.0.1",
+                "@smithy/util-defaults-mode-node": "^1.0.1",
+                "@smithy/util-retry": "^1.0.2",
+                "@smithy/util-utf8": "^1.0.1",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
-                "@aws-sdk/middleware-endpoint": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-                    "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-                    "requires": {
-                        "@aws-sdk/middleware-serde": "3.347.0",
-                        "@aws-sdk/types": "3.347.0",
-                        "@aws-sdk/url-parser": "3.347.0",
-                        "@aws-sdk/util-middleware": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/middleware-serde": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-                    "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/middleware-stack": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-                    "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/querystring-parser": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-                    "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/smithy-client": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-                    "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-                    "requires": {
-                        "@aws-sdk/middleware-stack": "3.347.0",
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/url-parser": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-                    "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-                    "requires": {
-                        "@aws-sdk/querystring-parser": "3.347.0",
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-middleware": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-                    "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -22767,156 +21725,53 @@
             }
         },
         "@aws-sdk/client-sts": {
-            "version": "3.347.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.347.1.tgz",
-            "integrity": "sha512-i7vomVsbZcGD2pzOuEl0RS7yCtFcT6CVfSP1wZLwgcjAssUKTLHi65I/uSAUF0KituChw31aXlxh7EGq1uDqaA==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.363.0.tgz",
+            "integrity": "sha512-0jj14WvBPJQ8xr72cL0mhlmQ90tF0O0wqXwSbtog6PsC8+KDE6Yf+WsxsumyI8E5O8u3eYijBL+KdqG07F/y/w==",
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/credential-provider-node": "3.347.0",
-                "@aws-sdk/fetch-http-handler": "3.347.0",
-                "@aws-sdk/hash-node": "3.347.0",
-                "@aws-sdk/invalid-dependency": "3.347.0",
-                "@aws-sdk/middleware-content-length": "3.347.0",
-                "@aws-sdk/middleware-endpoint": "3.347.0",
-                "@aws-sdk/middleware-host-header": "3.347.0",
-                "@aws-sdk/middleware-logger": "3.347.0",
-                "@aws-sdk/middleware-recursion-detection": "3.347.0",
-                "@aws-sdk/middleware-retry": "3.347.0",
-                "@aws-sdk/middleware-sdk-sts": "3.347.0",
-                "@aws-sdk/middleware-serde": "3.347.0",
-                "@aws-sdk/middleware-signing": "3.347.0",
-                "@aws-sdk/middleware-stack": "3.347.0",
-                "@aws-sdk/middleware-user-agent": "3.347.0",
-                "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/node-http-handler": "3.347.0",
-                "@aws-sdk/smithy-client": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/url-parser": "3.347.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.347.0",
-                "@aws-sdk/util-defaults-mode-node": "3.347.0",
-                "@aws-sdk/util-endpoints": "3.347.0",
-                "@aws-sdk/util-retry": "3.347.0",
-                "@aws-sdk/util-user-agent-browser": "3.347.0",
-                "@aws-sdk/util-user-agent-node": "3.347.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "fast-xml-parser": "4.2.4",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/middleware-endpoint": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-                    "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-                    "requires": {
-                        "@aws-sdk/middleware-serde": "3.347.0",
-                        "@aws-sdk/types": "3.347.0",
-                        "@aws-sdk/url-parser": "3.347.0",
-                        "@aws-sdk/util-middleware": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/middleware-serde": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-                    "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/middleware-stack": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-                    "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/querystring-parser": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-                    "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/smithy-client": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-                    "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-                    "requires": {
-                        "@aws-sdk/middleware-stack": "3.347.0",
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/url-parser": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-                    "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-                    "requires": {
-                        "@aws-sdk/querystring-parser": "3.347.0",
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-middleware": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-                    "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/config-resolver": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
-            "integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
-            "requires": {
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-config-provider": "3.310.0",
-                "@aws-sdk/util-middleware": "3.347.0",
+                "@aws-sdk/credential-provider-node": "3.363.0",
+                "@aws-sdk/middleware-host-header": "3.363.0",
+                "@aws-sdk/middleware-logger": "3.363.0",
+                "@aws-sdk/middleware-recursion-detection": "3.363.0",
+                "@aws-sdk/middleware-sdk-sts": "3.363.0",
+                "@aws-sdk/middleware-signing": "3.363.0",
+                "@aws-sdk/middleware-user-agent": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/util-user-agent-browser": "3.363.0",
+                "@aws-sdk/util-user-agent-node": "3.363.0",
+                "@smithy/config-resolver": "^1.0.1",
+                "@smithy/fetch-http-handler": "^1.0.1",
+                "@smithy/hash-node": "^1.0.1",
+                "@smithy/invalid-dependency": "^1.0.1",
+                "@smithy/middleware-content-length": "^1.0.1",
+                "@smithy/middleware-endpoint": "^1.0.1",
+                "@smithy/middleware-retry": "^1.0.1",
+                "@smithy/middleware-serde": "^1.0.1",
+                "@smithy/middleware-stack": "^1.0.1",
+                "@smithy/node-config-provider": "^1.0.1",
+                "@smithy/node-http-handler": "^1.0.1",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/smithy-client": "^1.0.2",
+                "@smithy/types": "^1.1.0",
+                "@smithy/url-parser": "^1.0.1",
+                "@smithy/util-base64": "^1.0.1",
+                "@smithy/util-body-length-browser": "^1.0.1",
+                "@smithy/util-body-length-node": "^1.0.1",
+                "@smithy/util-defaults-mode-browser": "^1.0.1",
+                "@smithy/util-defaults-mode-node": "^1.0.1",
+                "@smithy/util-retry": "^1.0.1",
+                "@smithy/util-utf8": "^1.0.1",
+                "fast-xml-parser": "4.2.5",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-config-provider": {
-                    "version": "3.310.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-                    "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-middleware": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-                    "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -22924,86 +21779,47 @@
             }
         },
         "@aws-sdk/credential-provider-env": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
-            "integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.363.0.tgz",
+            "integrity": "sha512-VAQ3zITT2Q0acht0HezouYnMFKZ2vIOa20X4zQA3WI0HfaP4D6ga6KaenbDcb/4VFiqfqiRHfdyXHP0ThcDRMA==",
             "requires": {
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/credential-provider-imds": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
-            "integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
-            "requires": {
-                "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/url-parser": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/querystring-parser": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-                    "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/url-parser": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-                    "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-                    "requires": {
-                        "@aws-sdk/querystring-parser": "3.347.0",
-                        "@aws-sdk/types": "3.347.0",
                         "tslib": "^2.5.0"
                     }
                 }
             }
         },
         "@aws-sdk/credential-provider-ini": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.347.0.tgz",
-            "integrity": "sha512-84TNF34ryabmVbILOq7f+/Jy8tJaskvHdax3X90qxFtXRU11kX0bf5NYL616KT0epR0VGpy50ThfIqvBwxeJfQ==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.363.0.tgz",
+            "integrity": "sha512-ZYN+INoqyX5FVC3rqUxB6O8nOWkr0gHRRBm1suoOlmuFJ/WSlW/uUGthRBY5x1AQQnBF8cpdlxZzGHd41lFVNw==",
             "requires": {
-                "@aws-sdk/credential-provider-env": "3.347.0",
-                "@aws-sdk/credential-provider-imds": "3.347.0",
-                "@aws-sdk/credential-provider-process": "3.347.0",
-                "@aws-sdk/credential-provider-sso": "3.347.0",
-                "@aws-sdk/credential-provider-web-identity": "3.347.0",
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/shared-ini-file-loader": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/credential-provider-env": "3.363.0",
+                "@aws-sdk/credential-provider-process": "3.363.0",
+                "@aws-sdk/credential-provider-sso": "3.363.0",
+                "@aws-sdk/credential-provider-web-identity": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/credential-provider-imds": "^1.0.1",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/shared-ini-file-loader": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23011,26 +21827,27 @@
             }
         },
         "@aws-sdk/credential-provider-node": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.347.0.tgz",
-            "integrity": "sha512-ds2uxE0krl94RdQ7bstwafUXdlMeEOPgedhaheVVlj8kH+XqlZdwUUaUv1uoEI9iBzuSjKftUkIHo0xsTiwtaw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.363.0.tgz",
+            "integrity": "sha512-C1qXFIN2yMxD6pGgug0vR1UhScOki6VqdzuBHzXZAGu7MOjvgHNdscEcb3CpWnITHaPL2ztkiw75T1sZ7oIgQg==",
             "requires": {
-                "@aws-sdk/credential-provider-env": "3.347.0",
-                "@aws-sdk/credential-provider-imds": "3.347.0",
-                "@aws-sdk/credential-provider-ini": "3.347.0",
-                "@aws-sdk/credential-provider-process": "3.347.0",
-                "@aws-sdk/credential-provider-sso": "3.347.0",
-                "@aws-sdk/credential-provider-web-identity": "3.347.0",
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/shared-ini-file-loader": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/credential-provider-env": "3.363.0",
+                "@aws-sdk/credential-provider-ini": "3.363.0",
+                "@aws-sdk/credential-provider-process": "3.363.0",
+                "@aws-sdk/credential-provider-sso": "3.363.0",
+                "@aws-sdk/credential-provider-web-identity": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/credential-provider-imds": "^1.0.1",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/shared-ini-file-loader": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23038,20 +21855,21 @@
             }
         },
         "@aws-sdk/credential-provider-process": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
-            "integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.363.0.tgz",
+            "integrity": "sha512-fOKAINU7Rtj2T8pP13GdCt+u0Ml3gYynp8ki+1jMZIQ+Ju/MdDOqZpKMFKicMn3Z1ttUOgqr+grUdus6z8ceBQ==",
             "requires": {
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/shared-ini-file-loader": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/shared-ini-file-loader": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23059,22 +21877,23 @@
             }
         },
         "@aws-sdk/credential-provider-sso": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.347.0.tgz",
-            "integrity": "sha512-M1d7EnUaJbSNCmNalEbINmtFkc9wJufx7UhKtEeFwSq9KEzOMroH1MEOeiqIw9f/zE8NI/iPkVeEhw123vmBrQ==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.363.0.tgz",
+            "integrity": "sha512-5RUZ5oM0lwZSo3EehT0dXggOjgtxFogpT3cZvoLGtIwrPBvm8jOQPXQUlaqCj10ThF1sYltEyukz/ovtDwYGew==",
             "requires": {
-                "@aws-sdk/client-sso": "3.347.0",
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/shared-ini-file-loader": "3.347.0",
-                "@aws-sdk/token-providers": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/client-sso": "3.363.0",
+                "@aws-sdk/token-providers": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/shared-ini-file-loader": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23082,158 +21901,20 @@
             }
         },
         "@aws-sdk/credential-provider-web-identity": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
-            "integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.363.0.tgz",
+            "integrity": "sha512-Z6w7fjgy79pAax580wdixbStQw10xfyZ+hOYLcPudoYFKjoNx0NQBejg5SwBzCF/HQL23Ksm9kDfbXDX9fkPhA==",
             "requires": {
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/eventstream-codec": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
-            "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
-            "requires": {
-                "@aws-crypto/crc32": "3.0.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-hex-encoding": {
-                    "version": "3.310.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-                    "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/eventstream-serde-browser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.347.0.tgz",
-            "integrity": "sha512-9BLVTHWgpiTo/hl+k7qt7E9iYu43zVwJN+4TEwA9ZZB3p12068t1Hay6HgCcgJC3+LWMtw/OhvypV6vQAG4UBg==",
-            "requires": {
-                "@aws-sdk/eventstream-serde-universal": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/eventstream-serde-config-resolver": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.347.0.tgz",
-            "integrity": "sha512-RcXQbNVq0PFmDqfn6+MnjCUWbbobcYVxpimaF6pMDav04o6Mcle+G2Hrefp5NlFr/lZbHW2eUKYsp1sXPaxVlQ==",
-            "requires": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/eventstream-serde-node": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.347.0.tgz",
-            "integrity": "sha512-pgQCWH0PkHjcHs04JE7FoGAD3Ww45ffV8Op0MSLUhg9OpGa6EDoO3EOpWi9l/TALtH4f0KRV35PVyUyHJ/wEkA==",
-            "requires": {
-                "@aws-sdk/eventstream-serde-universal": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/eventstream-serde-universal": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.347.0.tgz",
-            "integrity": "sha512-4wWj6bz6lOyDIO/dCCjwaLwRz648xzQQnf89R29sLoEqvAPP5XOB7HL+uFaQ/f5tPNh49gL6huNFSVwDm62n4Q==",
-            "requires": {
-                "@aws-sdk/eventstream-codec": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/fetch-http-handler": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
-            "integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
-            "requires": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/querystring-builder": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/protocol-http": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-                    "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23241,40 +21922,19 @@
             }
         },
         "@aws-sdk/hash-blob-browser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.347.0.tgz",
-            "integrity": "sha512-RxgstIldLsdJKN5UHUwSI9PMiatr0xKmKxS4+tnWZ1/OOg6wuWqqpDpWdNOVSJSpxpUaP6kRrvG5Yo5ZevoTXw==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.357.0.tgz",
+            "integrity": "sha512-RDd6UgrGHDmleTnXM9LRSSVa69euSAG2mlNhZMEDWk3OFseXVYqBDaqroVbQ01rM2UAe8MeBFchlV9OmxuVgvw==",
             "requires": {
                 "@aws-sdk/chunked-blob-reader": "3.310.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/hash-node": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
-            "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
-            "requires": {
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23282,38 +21942,19 @@
             }
         },
         "@aws-sdk/hash-stream-node": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.347.0.tgz",
-            "integrity": "sha512-tOBfcvELyt1GVuAlQ4d0mvm3QxoSSmvhH15SWIubM9RP4JWytBVzaFAn/aC02DBAWyvp0acMZ5J+47mxrWJElg==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.357.0.tgz",
+            "integrity": "sha512-KZjN1VAw1KHNp+xKVOWBGS+MpaYQTjZFD5f+7QQqW4TfbAkFFwIAEYIHq5Q8Gw+jVh0h61OrV/LyW3J2PVzc+w==",
             "requires": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/invalid-dependency": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
-            "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
-            "requires": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23342,19 +21983,19 @@
             }
         },
         "@aws-sdk/md5-js": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.347.0.tgz",
-            "integrity": "sha512-mChE+7DByTY9H4cQ6fnWp2x5jf8e6OZN+AdLp6WQ+W99z35zBeqBxVmgm8ziJwkMIrkSTv9j3Y7T9Ve3RIcSfg==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.357.0.tgz",
+            "integrity": "sha512-to42sFAL7KgV/X9X40LLfEaNMHMGQL6/7mPMVCL/W2BZf3zw5OTl3lAaNyjXA+gO5Uo4lFEiQKAQVKNbr8b8Nw==",
             "requires": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
                 "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23362,67 +22003,22 @@
             }
         },
         "@aws-sdk/middleware-bucket-endpoint": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.347.0.tgz",
-            "integrity": "sha512-i9n4ylkGmGvizVcTfN4L+oN10OCL2DKvyMa4cCAVE1TJrsnaE0g7IOOyJGUS8p5KJYQrKVR7kcsa2L1S0VeEcA==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.363.0.tgz",
+            "integrity": "sha512-kR8+0X50zslpzRW29q4JbpPMadE1z39ZfGwPaBLKpoWvSGt4x+75FaoK71TH7urPPoFyD2Y+XKGA6YRYTUNHSQ==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
                 "@aws-sdk/util-arn-parser": "3.310.0",
-                "@aws-sdk/util-config-provider": "3.310.0",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-config-provider": "^1.0.1",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
-                "@aws-sdk/protocol-http": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-                    "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-config-provider": {
-                    "version": "3.310.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-                    "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/middleware-content-length": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
-            "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
-            "requires": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/protocol-http": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-                    "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23445,28 +22041,20 @@
             }
         },
         "@aws-sdk/middleware-expect-continue": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.347.0.tgz",
-            "integrity": "sha512-95M1unD1ENL0tx35dfyenSfx0QuXBSKtOi/qJja6LfX5771C5fm5ZTOrsrzPFJvRg/wj8pCOVWRZk+d5+jvfOQ==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.363.0.tgz",
+            "integrity": "sha512-I88xneZp6jRwySmIl9uI7eZCcTsqRVnTDfUr1JiXt7zonqNNm80PVYMs6pwaw7t97ec1AQJcsONjuXZyCMnu5g==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
-                "@aws-sdk/protocol-http": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-                    "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23474,40 +22062,24 @@
             }
         },
         "@aws-sdk/middleware-flexible-checksums": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.347.0.tgz",
-            "integrity": "sha512-Pda7VMAIyeHw9nMp29rxdFft3EF4KP/tz/vLB6bqVoBNbLujo5rxn3SGOgStgIz7fuMLQQfoWIsmvxUm+Fp+Dw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.363.0.tgz",
+            "integrity": "sha512-FBYmrMRX01uNximNN0WLgpf97GN4xNTLaKsDlkjYRWKJ+J97ICkvLG0FcSu7+SNCpCdJJBeQ5tRVOPVpUu6nmA==",
             "requires": {
                 "@aws-crypto/crc32": "3.0.0",
                 "@aws-crypto/crc32c": "3.0.0",
-                "@aws-sdk/is-array-buffer": "3.310.0",
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-utf8": "3.310.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/is-array-buffer": "^1.0.1",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-utf8": "^1.0.1",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
-                "@aws-sdk/is-array-buffer": {
-                    "version": "3.310.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-                    "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/protocol-http": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-                    "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23515,28 +22087,20 @@
             }
         },
         "@aws-sdk/middleware-host-header": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
-            "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.363.0.tgz",
+            "integrity": "sha512-FobpclDCf5Y1ueyJDmb9MqguAdPssNMlnqWQpujhYVABq69KHu73fSCWSauFPUrw7YOpV8kG1uagDF0POSxHzA==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
-                "@aws-sdk/protocol-http": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-                    "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23544,18 +22108,19 @@
             }
         },
         "@aws-sdk/middleware-location-constraint": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.347.0.tgz",
-            "integrity": "sha512-x5fcEV7q8fQ0OmUO+cLhN5iPqGoLWtC3+aKHIfRRb2BpOO1khyc1FKzsIAdeQz2hfktq4j+WsrmcPvFKv51pSg==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.363.0.tgz",
+            "integrity": "sha512-piNzpNNI/fChSGOZxcq/2msN2qFUSEAbhqs91zbcpv8CEPekVLc4W9laXCG764BEMyfG97ZU8MtzwHeMhELhBA==",
             "requires": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23563,18 +22128,19 @@
             }
         },
         "@aws-sdk/middleware-logger": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
-            "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.363.0.tgz",
+            "integrity": "sha512-SSGgthScYnFGTOw8EzbkvquqweFmvn7uJihkpFekbtBNGC/jGOGO+8ziHjTQ8t/iI/YKubEwv+LMi0f77HKSEg==",
             "requires": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23582,104 +22148,42 @@
             }
         },
         "@aws-sdk/middleware-recursion-detection": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
-            "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.363.0.tgz",
+            "integrity": "sha512-MWD/57QgI/N7fG8rtzDTUdSqNpYohQfgj9XCFAoVeI/bU4usrkOrew43L4smJG4XrDxlNT8lSJlDtd64tuiUZA==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
-                "@aws-sdk/protocol-http": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-                    "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
-                }
-            }
-        },
-        "@aws-sdk/middleware-retry": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
-            "integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
-            "requires": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/service-error-classification": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-middleware": "3.347.0",
-                "@aws-sdk/util-retry": "3.347.0",
-                "tslib": "^2.5.0",
-                "uuid": "^8.3.2"
-            },
-            "dependencies": {
-                "@aws-sdk/protocol-http": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-                    "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-middleware": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-                    "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "uuid": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
                 }
             }
         },
         "@aws-sdk/middleware-sdk-s3": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.347.0.tgz",
-            "integrity": "sha512-TLr92+HMvamrhJJ0VDhA/PiUh4rTNQz38B9dB9ikohTaRgm+duP+mRiIv16tNPZPGl8v82Thn7Ogk2qPByNDtg==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.363.0.tgz",
+            "integrity": "sha512-npC8vLCero+vULizrK0QPjNanWbgH4A/2Llc1nO8N005uvUe7co6WglILF2W3guZrFk/0uGEdX67OnLxUD97pw==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
                 "@aws-sdk/util-arn-parser": "3.310.0",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
-                "@aws-sdk/protocol-http": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-                    "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23687,19 +22191,20 @@
             }
         },
         "@aws-sdk/middleware-sdk-sts": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
-            "integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.363.0.tgz",
+            "integrity": "sha512-1yy2Ac50FO8BrODaw5bPWvVrRhaVLqXTFH6iHB+dJLPUkwtY5zLM3Mp+9Ilm7kME+r7oIB1wuO6ZB1Lf4ZszIw==",
             "requires": {
-                "@aws-sdk/middleware-signing": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/middleware-signing": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23716,78 +22221,23 @@
             }
         },
         "@aws-sdk/middleware-signing": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
-            "integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.363.0.tgz",
+            "integrity": "sha512-/7qia715pt9JKYIPDGu22WmdZxD8cfF/5xB+1kmILg7ZtjO0pPuTaCNJ7xiIuFd7Dn7JXp5lop08anX/GOhNRQ==",
             "requires": {
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/signature-v4": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-middleware": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/signature-v4": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-middleware": "^1.0.1",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
-                "@aws-sdk/is-array-buffer": {
-                    "version": "3.310.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-                    "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/protocol-http": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-                    "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/signature-v4": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
-                    "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
-                    "requires": {
-                        "@aws-sdk/eventstream-codec": "3.347.0",
-                        "@aws-sdk/is-array-buffer": "3.310.0",
-                        "@aws-sdk/types": "3.347.0",
-                        "@aws-sdk/util-hex-encoding": "3.310.0",
-                        "@aws-sdk/util-middleware": "3.347.0",
-                        "@aws-sdk/util-uri-escape": "3.310.0",
-                        "@aws-sdk/util-utf8": "3.310.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-hex-encoding": {
-                    "version": "3.310.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-                    "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-middleware": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-                    "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-uri-escape": {
-                    "version": "3.310.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-                    "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23795,18 +22245,19 @@
             }
         },
         "@aws-sdk/middleware-ssec": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.347.0.tgz",
-            "integrity": "sha512-467VEi2elPmUGcHAgTmzhguZ3lwTpwK+3s+pk312uZtVsS9rP1MAknYhpS3ZvssiqBUVPx8m29cLcC6Tx5nOJg==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.363.0.tgz",
+            "integrity": "sha512-pN+QN1rMShYpJnTJSCIYnNRhD0S8xSZsTn6ThgcO559Xiwz5LMHFOfOXUCEyxtbVW5kMHLUh3w101AMUKae99A==",
             "requires": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23822,50 +22273,21 @@
             }
         },
         "@aws-sdk/middleware-user-agent": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.347.0.tgz",
-            "integrity": "sha512-wJbGN3OE1/daVCrwk49whhIr9E0j1N4gWwN/wi4WuyYIA+5lMUfVp0aGIOvZR+878DxuFz2hQ4XcZVT4K2WvQw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.363.0.tgz",
+            "integrity": "sha512-ri8YaQvXP6odteVTMfxPqFR26Q0h9ejtqhUDv47P34FaKXedEM4nC6ix6o+5FEYj6l8syGyktftZ5O70NoEhug==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-endpoints": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/protocol-http": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-                    "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/node-config-provider": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
-            "integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
-            "requires": {
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/shared-ini-file-loader": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -23893,25 +22315,6 @@
                         "tslib": "^2.5.0"
                     }
                 },
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/property-provider": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
-            "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
-            "requires": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
                 "@aws-sdk/types": {
                     "version": "3.347.0",
                     "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
@@ -23968,30 +22371,6 @@
                 "tslib": "^2.3.1"
             }
         },
-        "@aws-sdk/service-error-classification": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
-            "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg=="
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
-            "integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
-            "requires": {
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
         "@aws-sdk/signature-v4": {
             "version": "3.197.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.197.0.tgz",
@@ -24006,76 +22385,21 @@
             }
         },
         "@aws-sdk/signature-v4-multi-region": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.347.0.tgz",
-            "integrity": "sha512-838h7pbRCVYWlTl8W+r5+Z5ld7uoBObgAn7/RB1MQ4JjlkfLdN7emiITG6ueVL+7gWZNZc/4dXR/FJSzCgrkxQ==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.363.0.tgz",
+            "integrity": "sha512-iWamQSpaBKg88LKuiUq8xO/7iyxJ+ORkA3qDhAwUqyTJOg87ma47yFf4ycCKqINnflc3AIGLGzBHnkBc4cMF5g==",
             "requires": {
-                "@aws-sdk/protocol-http": "3.347.0",
-                "@aws-sdk/signature-v4": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/signature-v4": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
-                "@aws-sdk/is-array-buffer": {
-                    "version": "3.310.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-                    "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/protocol-http": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-                    "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-                    "requires": {
-                        "@aws-sdk/types": "3.347.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/signature-v4": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
-                    "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
-                    "requires": {
-                        "@aws-sdk/eventstream-codec": "3.347.0",
-                        "@aws-sdk/is-array-buffer": "3.310.0",
-                        "@aws-sdk/types": "3.347.0",
-                        "@aws-sdk/util-hex-encoding": "3.310.0",
-                        "@aws-sdk/util-middleware": "3.347.0",
-                        "@aws-sdk/util-uri-escape": "3.310.0",
-                        "@aws-sdk/util-utf8": "3.310.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-hex-encoding": {
-                    "version": "3.310.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-                    "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-middleware": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-                    "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-uri-escape": {
-                    "version": "3.310.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-                    "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -24093,21 +22417,22 @@
             }
         },
         "@aws-sdk/token-providers": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.347.0.tgz",
-            "integrity": "sha512-DZS9UWEy105zsaBJTgcvv1U+0jl7j1OzfMpnLf/lEYjEvx/4FqY2Ue/OZUACJorZgm/dWNqrhY17tZXtS/S3ew==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.363.0.tgz",
+            "integrity": "sha512-6+0aJ1zugNgsMmhTtW2LBWxOVSaXCUk2q3xyTchSXkNzallYaRiZMRkieW+pKNntnu0g5H1T0zyfCO0tbXwxEA==",
             "requires": {
-                "@aws-sdk/client-sso-oidc": "3.347.0",
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/shared-ini-file-loader": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/client-sso-oidc": "3.363.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/shared-ini-file-loader": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -24133,31 +22458,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
             "integrity": "sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==",
-            "requires": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-base64": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-            "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-            "requires": {
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-body-length-browser": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-            "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-            "requires": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-body-length-node": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-            "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
             "requires": {
                 "tslib": "^2.5.0"
             }
@@ -24189,63 +22489,19 @@
                 "tslib": "^2.3.1"
             }
         },
-        "@aws-sdk/util-defaults-mode-browser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
-            "integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
-            "requires": {
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/util-defaults-mode-node": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
-            "integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
-            "requires": {
-                "@aws-sdk/config-resolver": "3.347.0",
-                "@aws-sdk/credential-provider-imds": "3.347.0",
-                "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/property-provider": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
         "@aws-sdk/util-endpoints": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.347.0.tgz",
-            "integrity": "sha512-/WUkirizeNAqwVj0zkcrqdQ9pUm1HY5kU+qy7xTR0OebkuJauglkmSTMD+56L1JPunWqHhlwCMVRaz5eaJdSEQ==",
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
+            "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
             "requires": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -24276,67 +22532,6 @@
                 "tslib": "^2.3.1"
             }
         },
-        "@aws-sdk/util-retry": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
-            "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
-            "requires": {
-                "@aws-sdk/service-error-classification": "3.347.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-stream-browser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.347.0.tgz",
-            "integrity": "sha512-pIbmzIJfyX26qG622uIESOmJSMGuBkhmNU7I98bzhYCet5ctC0ow9L5FZw9ljOE46P/HkEcsOhh+qTHyCXlCEQ==",
-            "requires": {
-                "@aws-sdk/fetch-http-handler": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-hex-encoding": {
-                    "version": "3.310.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-                    "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
-        "@aws-sdk/util-stream-node": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.347.0.tgz",
-            "integrity": "sha512-E46zm0eMthmeh7hYfztzdInpKX3hZX+M5vmNhfYbhPuxavJ0cBzpwI0Xwb9wpSHPKQ1yzpTviIu1eRplCU5VXQ==",
-            "requires": {
-                "@aws-sdk/node-http-handler": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
-            }
-        },
         "@aws-sdk/util-uri-escape": {
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
@@ -24346,19 +22541,20 @@
             }
         },
         "@aws-sdk/util-user-agent-browser": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
-            "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.363.0.tgz",
+            "integrity": "sha512-fk9ymBUIYbxiGm99Cn+kAAXmvMCWTf/cHAcB79oCXV4ELXdPa9lN5xQhZRFNxLUeXG4OAMEuCAUUuZEj8Fnc1Q==",
             "requires": {
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/types": "^1.1.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -24366,19 +22562,20 @@
             }
         },
         "@aws-sdk/util-user-agent-node": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
-            "integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
+            "version": "3.363.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.363.0.tgz",
+            "integrity": "sha512-Fli/dvgGA9hdnQUrYb1//wNSFlK2jAfdJcfNXA6SeBYzSeH5pVGYF4kXF0FCdnMA3Fef+Zn1zAP/hw9v8VJHWQ==",
             "requires": {
-                "@aws-sdk/node-config-provider": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
+                "@aws-sdk/types": "3.357.0",
+                "@smithy/node-config-provider": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             },
             "dependencies": {
                 "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
                     "requires": {
                         "tslib": "^2.5.0"
                     }
@@ -24400,26 +22597,6 @@
             "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
             "requires": {
                 "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-waiter": {
-            "version": "3.347.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.347.0.tgz",
-            "integrity": "sha512-3ze/0PkwkzUzLncukx93tZgGL0JX9NaP8DxTi6WzflnL/TEul5Z63PCruRNK0om17iZYAWKrf8q2mFoHYb4grA==",
-            "requires": {
-                "@aws-sdk/abort-controller": "3.347.0",
-                "@aws-sdk/types": "3.347.0",
-                "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/types": {
-                    "version": "3.347.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
-                    "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-                    "requires": {
-                        "tslib": "^2.5.0"
-                    }
-                }
             }
         },
         "@aws-sdk/xml-builder": {
@@ -24479,7 +22656,7 @@
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
                 "json5": "^2.2.2",
-                "semver": "^6.3.0"
+                "semver": "^7.5.3"
             }
         },
         "@babel/generator": {
@@ -24533,7 +22710,7 @@
                 "@babel/helper-validator-option": "^7.18.6",
                 "browserslist": "^4.21.3",
                 "lru-cache": "^5.1.1",
-                "semver": "^6.3.0"
+                "semver": "^7.5.3"
             },
             "dependencies": {
                 "lru-cache": {
@@ -24565,7 +22742,7 @@
                 "@babel/helper-replace-supers": "^7.22.5",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.5",
-                "semver": "^6.3.0"
+                "semver": "^7.5.3"
             }
         },
         "@babel/helper-create-regexp-features-plugin": {
@@ -24589,7 +22766,7 @@
                 "debug": "^4.1.1",
                 "lodash.debounce": "^4.0.8",
                 "resolve": "^1.14.2",
-                "semver": "^6.1.2"
+                "semver": "^7.5.3"
             }
         },
         "@babel/helper-environment-visitor": {
@@ -25568,7 +23745,7 @@
                 "babel-plugin-polyfill-corejs3": "^0.6.0",
                 "babel-plugin-polyfill-regenerator": "^0.4.1",
                 "core-js-compat": "^3.25.1",
-                "semver": "^6.3.0"
+                "semver": "^7.5.3"
             }
         },
         "@babel/preset-modules": {
@@ -26817,7 +24994,7 @@
                         "@babel/core": "^7.7.5",
                         "@istanbuljs/schema": "^0.1.2",
                         "istanbul-lib-coverage": "^3.0.0",
-                        "semver": "^6.3.0"
+                        "semver": "^7.5.3"
                     }
                 },
                 "jest-haste-map": {
@@ -27387,20 +25564,436 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
-        "@smithy/protocol-http": {
+        "@smithy/abort-controller": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
-            "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.1.tgz",
+            "integrity": "sha512-An6irzp9NCji2JtJHhrEFlDbxLwHd6c6Y9fq3ZeomyUR8BIXlGXVTxsemUSZVVgOq3166iYbYs/CrPAmgRSFLw==",
             "requires": {
-                "@smithy/types": "^1.0.0",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/config-resolver": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.1.tgz",
+            "integrity": "sha512-quj0xUiEVG/UHfY82EtthR/+S5/17p3IxXArC3NFSNqryMobWbG9oWgJy2s2cgUSVZLzxevjKKvxrilK7JEDaA==",
+            "requires": {
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-config-provider": "^1.0.1",
+                "@smithy/util-middleware": "^1.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/credential-provider-imds": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.1.tgz",
+            "integrity": "sha512-hkRJoxVCh4CEt1zYOBElE+G/MV6lyx3g68hSJpesM4pwMT/bzEVo5E5XzXY+6dVq8yszeatWKbFuqCCBQte8tg==",
+            "requires": {
+                "@smithy/node-config-provider": "^1.0.1",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "@smithy/url-parser": "^1.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/eventstream-codec": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.1.tgz",
+            "integrity": "sha512-cpcTXQEOEs2wEvIyxW/iTHJ2m0RVqoEOTjjWEXD6SY8Gcs3FCFP6E8MXadC098tdH5ctMIUXc8POXyMpxzGnjw==",
+            "requires": {
+                "@aws-crypto/crc32": "3.0.0",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-hex-encoding": "^1.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/eventstream-serde-browser": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-1.0.1.tgz",
+            "integrity": "sha512-oc8vxe+AU2RzvXH/Ehh0TzM/Nsw3I3ywu7V3qaCzqdkBIntAwK9JGZqcSDsqTK0WxZKBRgFIEwopcuZ2slVnFQ==",
+            "requires": {
+                "@smithy/eventstream-serde-universal": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/eventstream-serde-config-resolver": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-1.0.1.tgz",
+            "integrity": "sha512-TJwaXima0djnNY819utO1j93qZHaheFH1bhHxBkMrImtEOuXY48Tjma/L2m8swkIq8dy8jFC9hrYOkD0eYHkFA==",
+            "requires": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/eventstream-serde-node": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-1.0.1.tgz",
+            "integrity": "sha512-JEj8w7IRs4l+kcwKxbv3pNuu8n7ORC4pMFrIOrM4rERzrRnI7vMNTRzvAPGYA53rqm/Y9tBA9dw4C+H6hLXcsA==",
+            "requires": {
+                "@smithy/eventstream-serde-universal": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/eventstream-serde-universal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-1.0.1.tgz",
+            "integrity": "sha512-c6m9DH7m6D2S93dof4wSxysaGSQdauO20TNcSePzrgHd4rkTnz5pqZ1a7Pt22q2SKf09SvTugq5cV2Sy4r8zHw==",
+            "requires": {
+                "@smithy/eventstream-codec": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/fetch-http-handler": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.1.tgz",
+            "integrity": "sha512-/e2A8eOMk4FVZBQ0o6uF/ttLtFZcmsK5MIwDu1UE3crM4pCAIP19Ul8U9rdLlHhIu81X4AcJmSw55RDSpVRL/w==",
+            "requires": {
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/querystring-builder": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-base64": "^1.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/hash-node": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.1.tgz",
+            "integrity": "sha512-eCz08BySBcOjVObjbRAS/XMKUGY4ujnuS+GoWeEpzpCSKDnO8/YQ0rStRt4C0llRmhApizYc1tK9DiJwfvXcBg==",
+            "requires": {
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-buffer-from": "^1.0.1",
+                "@smithy/util-utf8": "^1.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/invalid-dependency": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.1.tgz",
+            "integrity": "sha512-kib63GFlAzRn/wf8M0cRWrZA1cyOy5IvpTkLavCY782DPFMP0EaEeD6VrlNIOvD6ncf7uCJ68HqckhwK1qLT3g==",
+            "requires": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/is-array-buffer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.1.tgz",
+            "integrity": "sha512-fHSTW70gANnzPYWNDcWkPXpp+QMbHhKozbQm/+Denkhp4gwSiPuAovWZRpJa9sXO+Q4dOnNzYN2max1vTCEroA==",
+            "requires": {
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/middleware-content-length": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.1.tgz",
+            "integrity": "sha512-vWWigayk5i2cFp9xPX5vdzHyK+P0t/xZ3Ovp4Ss+c8JQ1Hlq2kpJZVWtTKsmdfND5rVo5lu0kD5wgAMUCcmuhw==",
+            "requires": {
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/middleware-endpoint": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.2.tgz",
+            "integrity": "sha512-F3CyXgjtDI4quGFkDmVNytt6KMwlzzeMxtopk6Edue4uKdKcMC1vUmoRS5xTbFzKDDp4XwpnEV7FshPaL3eCPw==",
+            "requires": {
+                "@smithy/middleware-serde": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "@smithy/url-parser": "^1.0.1",
+                "@smithy/util-middleware": "^1.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/middleware-retry": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.3.tgz",
+            "integrity": "sha512-ZRsjG8adtxQ456FULPqPFmWtrW44Fq8IgdQvQB+rC2RSho3OUzS+TiEIwb5Zs6rf2IoewITKtfdtsUZcxXO0ng==",
+            "requires": {
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/service-error-classification": "^1.0.2",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-middleware": "^1.0.1",
+                "@smithy/util-retry": "^1.0.3",
+                "tslib": "^2.5.0",
+                "uuid": "^8.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                }
+            }
+        },
+        "@smithy/middleware-serde": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.1.tgz",
+            "integrity": "sha512-bn5lWk8UUeXFCQfkrNErz5SbeNd+2hgYegHMLsOLPt4URDIsyREar6wMsdsR+8UCdgR5s8udG3Zalgc7puizIQ==",
+            "requires": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/middleware-stack": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.1.tgz",
+            "integrity": "sha512-T6+gsAO1JYamOJqmORCrByDeQ/NB+ggjHb33UDOgdX4xIjXz/FB/3UqHgQu6PL1cSFrK+i4oteDIwqARDs/Szw==",
+            "requires": {
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/node-config-provider": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.1.tgz",
+            "integrity": "sha512-FRxifH/J2SgOaVLihIqBFuGhiHR/NfzbZYp5nYO7BGgT/gc/f9nAuuRJcEy/hwO3aI6ThyG5apH4tGec6A2sCw==",
+            "requires": {
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/shared-ini-file-loader": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/node-http-handler": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.2.tgz",
+            "integrity": "sha512-PzPrGRSt3kNuruLCeR4ffJp57ZLVnIukMXVL3Ppr65ZoxiE+HBsOVAa/Z/T+4HzjCM6RaXnnmB8YKfsDjlb0iA==",
+            "requires": {
+                "@smithy/abort-controller": "^1.0.1",
+                "@smithy/protocol-http": "^1.1.0",
+                "@smithy/querystring-builder": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/property-provider": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.1.tgz",
+            "integrity": "sha512-3EG/61Ls1MrgEaafpltXBJHSqFPqmTzEX7QKO7lOEHuYGmGYzZ08t1SsTgd1vM74z0IihoZyGPynZ7WmXKvTeg==",
+            "requires": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/protocol-http": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
+            "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+            "requires": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/querystring-builder": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.1.tgz",
+            "integrity": "sha512-J5Tzkw1PMtu01h6wl+tlN5vsyROmS6/z5lEfNlLo/L4ELHeVkQ4Q0PEIjDddPLfjVLCm8biQTESE5GCMixSRNQ==",
+            "requires": {
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-uri-escape": "^1.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/querystring-parser": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.1.tgz",
+            "integrity": "sha512-zauxdMc3cwxoLitI5DZqH7xN6Fk0mwRxrUMAETbav2j6Se2U0UGak/55rZcDg2yGzOURaLYi5iOm1gHr98P+Bw==",
+            "requires": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/service-error-classification": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.2.tgz",
+            "integrity": "sha512-Q5CCuzYL5FGo6Rr/O+lZxXHm2hrRgbmMn8MgyjqZUWZg20COg20DuNtIbho2iht6CoB7jOpmpBqhWizLlzUZgg=="
+        },
+        "@smithy/shared-ini-file-loader": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.1.tgz",
+            "integrity": "sha512-EztziuIPoNronENGqh+MWVKJErA4rJpaPzJCPukzBeEoG2USka0/q4B5Mr/1zszOnrb49fPNh4u3u5LfiH7QzA==",
+            "requires": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/signature-v4": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.1.tgz",
+            "integrity": "sha512-2D69je14ou1vBTnAQeysSK4QVMm0j3WHS3MDg/DnHnFFcXRCzVl/xAARO7POD8+fpi4tMFPs8Z4hzo1Zw40L0Q==",
+            "requires": {
+                "@smithy/eventstream-codec": "^1.0.1",
+                "@smithy/is-array-buffer": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-hex-encoding": "^1.0.1",
+                "@smithy/util-middleware": "^1.0.1",
+                "@smithy/util-uri-escape": "^1.0.1",
+                "@smithy/util-utf8": "^1.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/smithy-client": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.3.tgz",
+            "integrity": "sha512-Wh1mNP/1yUZK0uYkgCQ6NMxpBT3Fmc45TMdUfOlH1xD2zGYL7U4yDHFOhEZdi/suyjaelFobXB2p9pPIw6LjRQ==",
+            "requires": {
+                "@smithy/middleware-stack": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-stream": "^1.0.1",
                 "tslib": "^2.5.0"
             }
         },
         "@smithy/types": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
-            "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
+            "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
             "requires": {
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/url-parser": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.1.tgz",
+            "integrity": "sha512-33vWEtE6HzmwjEcEb4I58XMLRAchwPS93YhfDyXAXr1jwDCzfXmMayQwwpyW847rpWj0XJimxqia8q0z+k/ybw==",
+            "requires": {
+                "@smithy/querystring-parser": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/util-base64": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.1.tgz",
+            "integrity": "sha512-rJcpRi/yUi6TyCEkjdTH86/ExBuKlfctEXhG9/4gMJ3/cnPcHJJnr0mQ9evSEO+3DbpT/Nxq90bcTBdTIAmCig==",
+            "requires": {
+                "@smithy/util-buffer-from": "^1.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/util-body-length-browser": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.1.tgz",
+            "integrity": "sha512-Pdp744fmF7E1NWoSb7256Anhm8eYoCubvosdMwXzOnHuPRVbDa15pKUz2027K3+jrfGpXo1r+MnDerajME1Osw==",
+            "requires": {
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/util-body-length-node": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.1.tgz",
+            "integrity": "sha512-4PIHjDFwG07SNensAiVq/CJmubEVuwclWSYOTNtzBNTvxOeGLznvygkGYgPzS3erByT8C4S9JvnLYgtrsVV3nQ==",
+            "requires": {
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/util-buffer-from": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.1.tgz",
+            "integrity": "sha512-363N7Wq0ceUgE5lLe6kaR6GlJs2/m4r9V6bRMfIszb6P1FZbbRRM2FQYUWWPFSsRymm9mJL18b3fjiVsIvhDGg==",
+            "requires": {
+                "@smithy/is-array-buffer": "^1.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/util-config-provider": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.1.tgz",
+            "integrity": "sha512-4Qy38Oy5/q43MpTwCLV1P+7NeaOp4W2etQDxMjgEeRlOyGGNlgttn0syi4g2rVSukFVqQ6FbeRs5xbnFmS6kaQ==",
+            "requires": {
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/util-defaults-mode-browser": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.1.tgz",
+            "integrity": "sha512-/9ObwNch4Z/NJYfkO4AvqBWku60Ju+c2Ck32toPOLmWe/V6eI9FLn8C1abri+GxDRCkLIqvkaWU1lgZ3nWZIIw==",
+            "requires": {
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/util-defaults-mode-node": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.1.tgz",
+            "integrity": "sha512-XQM3KvqRLgv7bwAzVkXTITkOmcOINoG9icJiGT8FA0zV35lY5UvyIsg5kHw01xigQS8ufa/33AwG3ZoXip+V5g==",
+            "requires": {
+                "@smithy/config-resolver": "^1.0.1",
+                "@smithy/credential-provider-imds": "^1.0.1",
+                "@smithy/node-config-provider": "^1.0.1",
+                "@smithy/property-provider": "^1.0.1",
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/util-hex-encoding": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.1.tgz",
+            "integrity": "sha512-FPTtMz/t02/rbfq5Pdll/TWUYP+GVFLCQNr+DgifrLzVRU0g8rdRjyFpDh8nPTdkDDusTTo9P1bepAYj68s0eA==",
+            "requires": {
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/util-middleware": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.1.tgz",
+            "integrity": "sha512-u9akN3Zmbr0vZH4F+2iehG7cFg+3fvDfnvS/hhsXH4UHuhqiQ+ADefibnLzPoz1pooY7rvwaQ/TVHyJmZHdLdQ==",
+            "requires": {
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/util-retry": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.3.tgz",
+            "integrity": "sha512-gYQnZDD8I2XJFspVwUISyukjPWVikTzKR0IdG8hCWYPTpeULFl1o6yzXlT5SL63TBkuEYl0R1/93cdNtMiNnoA==",
+            "requires": {
+                "@smithy/service-error-classification": "^1.0.2",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/util-stream": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.1.tgz",
+            "integrity": "sha512-4aBCIz35aZAnt2Rbq341KrnUzGhWv2/Zu8HouJqYLvSWCzlrvsNCGlXP4e70Kjzcw8hSuuCNtdUICwQ5qUWLxg==",
+            "requires": {
+                "@smithy/fetch-http-handler": "^1.0.1",
+                "@smithy/node-http-handler": "^1.0.2",
+                "@smithy/types": "^1.1.0",
+                "@smithy/util-base64": "^1.0.1",
+                "@smithy/util-buffer-from": "^1.0.1",
+                "@smithy/util-hex-encoding": "^1.0.1",
+                "@smithy/util-utf8": "^1.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/util-uri-escape": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.1.tgz",
+            "integrity": "sha512-IJUrRnXKEIc+PKnU1XzTsIENVR+60jUDPBP3iWX/EvuuT3Xfob47x1FGUe2c3yMXNuU6ax8VDk27hL5LKNoehQ==",
+            "requires": {
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/util-utf8": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.1.tgz",
+            "integrity": "sha512-iX6XHpjh4DFEUIBSKp2tjy3pYnLQMsJ62zYi1BVAC0kobE6p8AVpiZnxsU3ZkgQatAsUaEspFHUZ7CL7oSqaPQ==",
+            "requires": {
+                "@smithy/util-buffer-from": "^1.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@smithy/util-waiter": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-1.0.1.tgz",
+            "integrity": "sha512-dsn8O0s3pFIgxFzySLe1dv0w4tEQizEP6UqbgZ4r/Kar4n8pSdrPi6DJg8BzXwkwEIZpMtV4/nhSeGZ7HksDXA==",
+            "requires": {
+                "@smithy/abort-controller": "^1.0.1",
+                "@smithy/types": "^1.1.0",
                 "tslib": "^2.5.0"
             }
         },
@@ -27974,19 +26567,8 @@
                 "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "natural-compare-lite": "^1.4.0",
-                "semver": "^7.3.7",
+                "semver": "^7.5.3",
                 "tsutils": "^3.21.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
             }
         },
         "@typescript-eslint/parser": {
@@ -28040,19 +26622,8 @@
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
-                "semver": "^7.3.7",
+                "semver": "^7.5.3",
                 "tsutils": "^3.21.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.5.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-                    "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
             }
         },
         "@typescript-eslint/utils": {
@@ -28068,7 +26639,7 @@
                 "@typescript-eslint/types": "5.59.11",
                 "@typescript-eslint/typescript-estree": "5.59.11",
                 "eslint-scope": "^5.1.1",
-                "semver": "^7.3.7"
+                "semver": "^7.5.3"
             },
             "dependencies": {
                 "eslint-scope": {
@@ -28086,15 +26657,6 @@
                     "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
                     "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
                     "dev": true
-                },
-                "semver": {
-                    "version": "7.5.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-                    "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
                 }
             }
         },
@@ -28752,7 +27314,7 @@
             "requires": {
                 "@babel/compat-data": "^7.17.7",
                 "@babel/helper-define-polyfill-provider": "^0.3.3",
-                "semver": "^6.1.1"
+                "semver": "^7.5.3"
             }
         },
         "babel-plugin-polyfill-corejs3": {
@@ -29495,18 +28057,7 @@
                 "postcss-modules-scope": "^3.0.0",
                 "postcss-modules-values": "^4.0.0",
                 "postcss-value-parser": "^4.2.0",
-                "semver": "^7.3.8"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
+                "semver": "^7.5.3"
             }
         },
         "css.escape": {
@@ -29990,7 +28541,7 @@
                         "levn": "~0.3.0",
                         "prelude-ls": "~1.1.2",
                         "type-check": "~0.3.2",
-                        "word-wrap": "~1.2.3"
+                        "word-wrap": "^1.2.3"
                     }
                 },
                 "prelude-ls": {
@@ -30208,7 +28759,7 @@
                 "object.values": "^1.1.5",
                 "prop-types": "^15.8.1",
                 "resolve": "^2.0.0-next.3",
-                "semver": "^6.3.0",
+                "semver": "^7.5.3",
                 "string.prototype.matchall": "^4.0.7"
             },
             "dependencies": {
@@ -30763,9 +29314,9 @@
             "dev": true
         },
         "fast-xml-parser": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
-            "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
             "requires": {
                 "strnum": "^1.0.5"
             }
@@ -30863,7 +29414,7 @@
                     "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
                     "dev": true,
                     "requires": {
-                        "semver": "^6.0.0"
+                        "semver": "^7.5.3"
                     }
                 }
             }
@@ -31836,7 +30387,7 @@
                 "@babel/parser": "^7.14.7",
                 "@istanbuljs/schema": "^0.1.2",
                 "istanbul-lib-coverage": "^3.2.0",
-                "semver": "^6.3.0"
+                "semver": "^7.5.3"
             }
         },
         "istanbul-lib-report": {
@@ -31862,7 +30413,7 @@
                     "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
                     "dev": true,
                     "requires": {
-                        "semver": "^6.0.0"
+                        "semver": "^7.5.3"
                     }
                 },
                 "supports-color": {
@@ -34073,7 +32624,7 @@
                 "jest-resolve": "^26.6.2",
                 "natural-compare": "^1.4.0",
                 "pretty-format": "^26.6.2",
-                "semver": "^7.3.2"
+                "semver": "^7.5.3"
             },
             "dependencies": {
                 "@jest/types": {
@@ -34257,15 +32808,6 @@
                         "ansi-regex": "^5.0.0",
                         "ansi-styles": "^4.0.0",
                         "react-is": "^17.0.1"
-                    }
-                },
-                "semver": {
-                    "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
                     }
                 },
                 "slash": {
@@ -34706,17 +33248,7 @@
                 "jws": "^3.2.2",
                 "lodash": "^4.17.21",
                 "ms": "^2.1.1",
-                "semver": "^7.3.8"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
+                "semver": "^7.5.3"
             }
         },
         "jsx-ast-utils": {
@@ -35138,19 +33670,13 @@
             "dev": true,
             "requires": {
                 "pify": "^4.0.1",
-                "semver": "^5.6.0"
+                "semver": "^7.5.3"
             },
             "dependencies": {
                 "pify": {
                     "version": "4.0.1",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
                     "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
                 }
             }
@@ -35423,22 +33949,12 @@
             "requires": {
                 "growly": "^1.3.0",
                 "is-wsl": "^2.2.0",
-                "semver": "^7.3.2",
+                "semver": "^7.5.3",
                 "shellwords": "^0.1.1",
                 "uuid": "^8.3.0",
                 "which": "^2.0.2"
             },
             "dependencies": {
-                "semver": {
-                    "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
                 "uuid": {
                     "version": "8.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -35464,7 +33980,7 @@
                 "ignore-by-default": "^1.0.1",
                 "minimatch": "^3.1.2",
                 "pstree.remy": "^1.1.8",
-                "semver": "^5.7.1",
+                "semver": "^7.5.3",
                 "simple-update-notifier": "^1.0.7",
                 "supports-color": "^5.5.0",
                 "touch": "^3.1.0",
@@ -35479,12 +33995,6 @@
                     "requires": {
                         "ms": "^2.1.1"
                     }
-                },
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "dev": true
                 }
             }
         },
@@ -35505,16 +34015,8 @@
             "requires": {
                 "hosted-git-info": "^2.1.4",
                 "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
+                "semver": "^7.5.3",
                 "validate-npm-package-license": "^3.0.1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "dev": true
-                }
             }
         },
         "normalize-path": {
@@ -35740,17 +34242,17 @@
             }
         },
         "optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
             "dev": true,
             "requires": {
+                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
+                "type-check": "^0.4.0"
             }
         },
         "os-shim": {
@@ -35935,18 +34437,7 @@
             "requires": {
                 "cosmiconfig": "^8.2.0",
                 "jiti": "^1.18.2",
-                "semver": "^7.3.8"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
+                "semver": "^7.5.3"
             }
         },
         "postcss-modules-extract-imports": {
@@ -36803,7 +35294,7 @@
                     "requires": {
                         "nice-try": "^1.0.4",
                         "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
+                        "semver": "^7.5.3",
                         "shebang-command": "^1.2.0",
                         "which": "^1.2.9"
                     }
@@ -36932,12 +35423,6 @@
                     "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
                     "dev": true
                 },
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "dev": true
-                },
                 "shebang-command": {
                     "version": "1.2.0",
                     "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -37058,9 +35543,12 @@
             "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg=="
         },
         "semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+            "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+            "requires": {
+                "lru-cache": "^6.0.0"
+            }
         },
         "send": {
             "version": "0.18.0",
@@ -37221,15 +35709,7 @@
             "integrity": "sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==",
             "dev": true,
             "requires": {
-                "semver": "~7.0.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-                    "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-                    "dev": true
-                }
+                "semver": "^7.5.3"
             }
         },
         "sisteransi": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "test": "jest --coverage",
         "jest": "node_modules/jest/bin/jest.js  .",
         "lint": "eslint ./ --ext js,jsx --ignore-path .gitignore",
-        "audit": "npm audit",
+        "audit": "npm audit --omit dev && npm audit --audit-level high",
         "lint-staged": "node_modules/lint-staged/bin/lint-staged.js"
     },
     "jest": {
@@ -116,5 +116,8 @@
     "lint-staged": {
         "*.js": "node_modules/eslint/bin/eslint.js ./ --ignore-path .gitignore",
         "*.jsx": "node_modules/eslint/bin/eslint.js ./ --ext .jsx --ignore-path .gitignore"
+    },
+    "overrides": {
+        "semver": "^7.5.3"
     }
 }


### PR DESCRIPTION
- Force non-vulnerable semver version
- Only check production dependencies (all levels) and high severity for dev dependencies (to work around un-fixed word-wrap vuln)