### PR TITLE
HOCS:6732: New css to override divider and added div tag radio-group.jsx

### DIFF
--- a/src/shared/common/forms/radio-group.jsx
+++ b/src/shared/common/forms/radio-group.jsx
@@ -139,6 +139,9 @@ class Radio extends Component {
                             .filter((choice) => this.isChoiceVisible(choice))
                             .map((choice, i) => {
                                 const idName = this.getIdName(name, i);
+                                if (choice.type === 'divider') {
+                                    return <div className="govuk-radios__divider">{choice.label}</div>;
+                                }
                                 return (
                                     <Fragment key={i}>
                                         <div className="govuk-radios__item">

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -930,4 +930,11 @@ $border-colour: govuk-colour("mid-grey");
   .govuk-checkboxes__label::before {
     background-color: #ffffff;
   }
+
+}
+
+.govuk-radios__divider, .govuk-radios--small .govuk-radios__divider  {
+  width: 100%;
+  text-align: left;
+  float:left;
 }


### PR DESCRIPTION
HOCS-6732: Introduce type divider which will be used in hocs-frontend 
to display divider. 
Respective changes added to workflow branch https://github.com/UKHomeOffice/hocs-workflow/compare/main...hocs-6732_divider_spike. 
Once dev pulls workfow & frontend for this branch, they should be able to see divider text as below screenshot.
However frontend PR needs to be merged.

![image](https://github.com/UKHomeOffice/hocs-frontend/assets/35428275/fa5a28c0-b8a4-4bc6-a347-6fc55a6fc551)
