### PR TITLE
[HOCS-4967] Use aria label instead of label

### DIFF
--- a/src/shared/common/components/__tests__/__snapshots__/workstack.spec.jsx.snap
+++ b/src/shared/common/components/__tests__/__snapshots__/workstack.spec.jsx.snap
@@ -2528,29 +2528,31 @@ exports[`Workstack component should render the move team options 1`] = `
                         name="selected_team"
                       >
                         <option
-                          label="No option selected"
+                          aria-label="No option selected"
                           value=""
-                        />
+                        >
+                           
+                        </option>
                         <option
-                          label="TEST TEAM 1"
+                          aria-label="TEST TEAM 1"
                           value="VALUE 1"
                         >
                           TEST TEAM 1
                         </option>
                         <option
-                          label="TEST TEAM 2"
+                          aria-label="TEST TEAM 2"
                           value="VALUE 2"
                         >
                           TEST TEAM 2
                         </option>
                         <option
-                          label="TEST TEAM 3"
+                          aria-label="TEST TEAM 3"
                           value="VALUE 3"
                         >
                           TEST TEAM 3
                         </option>
                         <option
-                          label="TEST TEAM 4"
+                          aria-label="TEST TEAM 4"
                           value="VALUE 4"
                         >
                           TEST TEAM 4
@@ -3652,29 +3654,31 @@ exports[`Workstack component should render the move team options 1`] = `
                       name="selected_team"
                     >
                       <option
-                        label="No option selected"
+                        aria-label="No option selected"
                         value=""
-                      />
+                      >
+                         
+                      </option>
                       <option
-                        label="TEST TEAM 1"
+                        aria-label="TEST TEAM 1"
                         value="VALUE 1"
                       >
                         TEST TEAM 1
                       </option>
                       <option
-                        label="TEST TEAM 2"
+                        aria-label="TEST TEAM 2"
                         value="VALUE 2"
                       >
                         TEST TEAM 2
                       </option>
                       <option
-                        label="TEST TEAM 3"
+                        aria-label="TEST TEAM 3"
                         value="VALUE 3"
                       >
                         TEST TEAM 3
                       </option>
                       <option
-                        label="TEST TEAM 4"
+                        aria-label="TEST TEAM 4"
                         value="VALUE 4"
                       >
                         TEST TEAM 4
@@ -3810,29 +3814,31 @@ exports[`Workstack component should render the move team options 1`] = `
                       name="selected_team"
                     >
                       <option
-                        label="No option selected"
+                        aria-label="No option selected"
                         value=""
-                      />
+                      >
+                         
+                      </option>
                       <option
-                        label="TEST TEAM 1"
+                        aria-label="TEST TEAM 1"
                         value="VALUE 1"
                       >
                         TEST TEAM 1
                       </option>
                       <option
-                        label="TEST TEAM 2"
+                        aria-label="TEST TEAM 2"
                         value="VALUE 2"
                       >
                         TEST TEAM 2
                       </option>
                       <option
-                        label="TEST TEAM 3"
+                        aria-label="TEST TEAM 3"
                         value="VALUE 3"
                       >
                         TEST TEAM 3
                       </option>
                       <option
-                        label="TEST TEAM 4"
+                        aria-label="TEST TEAM 4"
                         value="VALUE 4"
                       >
                         TEST TEAM 4
@@ -4934,29 +4940,31 @@ exports[`Workstack component should render the move team options 1`] = `
                     name="selected_team"
                   >
                     <option
-                      label="No option selected"
+                      aria-label="No option selected"
                       value=""
-                    />
+                    >
+                       
+                    </option>
                     <option
-                      label="TEST TEAM 1"
+                      aria-label="TEST TEAM 1"
                       value="VALUE 1"
                     >
                       TEST TEAM 1
                     </option>
                     <option
-                      label="TEST TEAM 2"
+                      aria-label="TEST TEAM 2"
                       value="VALUE 2"
                     >
                       TEST TEAM 2
                     </option>
                     <option
-                      label="TEST TEAM 3"
+                      aria-label="TEST TEAM 3"
                       value="VALUE 3"
                     >
                       TEST TEAM 3
                     </option>
                     <option
-                      label="TEST TEAM 4"
+                      aria-label="TEST TEAM 4"
                       value="VALUE 4"
                     >
                       TEST TEAM 4

--- a/src/shared/common/forms/dropdown.jsx
+++ b/src/shared/common/forms/dropdown.jsx
@@ -128,9 +128,9 @@ class Dropdown extends Component {
                             <option
                                 key={i}
                                 value={choice.value}
-                                label={choice.label || 'No option selected'}
+                                aria-label={choice.label || 'No option selected'}
                             >
-                                {choice.label}
+                                {choice.label || <>&nbsp;</>}
                             </option>
                         );
                     })}


### PR DESCRIPTION
From voice over testing:

- When landing on a dropdown "No option selected" is read out
- When choosing from the dropdown option, it doesn't include the "No option selected" and just says menu item
- When the empty item is chosen, it agan reads out "No option selected"

I think this is an acceptable compromise between keeping the behaviour the same and making it clearer to screen reader users.